### PR TITLE
chore: Add powdr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5035,15 +5035,6 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
-name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
@@ -5518,7 +5509,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -6009,7 +6000,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-stateless",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -10052,7 +10043,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12167,17 +12158,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -12201,16 +12181,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
@@ -12225,20 +12195,7 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
  "tracing-core",
- "tracing-log 0.1.4",
- "tracing-serde 0.1.3",
 ]
 
 [[package]]
@@ -12247,7 +12204,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
- "matchers 0.1.0",
+ "matchers",
  "nu-ansi-term",
  "once_cell",
  "regex",
@@ -12258,8 +12215,8 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
- "tracing-serde 0.2.0",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -12453,12 +12410,12 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
- "getrandom 0.3.2",
- "rand 0.9.1",
+ "getrandom 0.2.16",
+ "rand 0.8.5",
  "uuid-macro-internal",
 ]
 
@@ -13606,7 +13563,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-stateless",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.19",
  "zkm-zkvm 1.0.0 (git+https://github.com/zkMIPS/zkMIPS.git)",
 ]
 
@@ -13864,7 +13821,7 @@ dependencies = [
  "tonic-build",
  "tracing",
  "twirp-rs",
- "uuid 1.16.0",
+ "uuid 1.4.1",
  "vergen",
  "zkm-build 1.0.0 (git+https://github.com/kevaundray/zkMIPS.git?branch=kw%2Fpatch-alloy)",
  "zkm-core-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,24 @@ members = [
     # openvm
     "crates/zkevm-openvm/program",
     "crates/zkevm-openvm/host",
+    # powdr
+    # "crates/zkevm-powdr/program",
+    # "crates/zkevm-powdr/host",
+
 ]
+# Powdr compilation won't allow us to have it in the workspace
+# Seems to be a TODO in powder code.
+# thread 'main' panicked at /Users/kev/.cargo/git/checkouts/powdr-fb0e233c2e750fd6/340858e/riscv/src/lib.rs:251:5:
+# assertion `left == right` failed
+#   left: 12
+#  right: 1
+exclude = ["crates/zkevm-powdr/program", "crates/zkevm-powdr/host"]
+
 resolver = "2"
 
 [workspace.package]
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 

--- a/crates/zkevm-powdr/.gitignore
+++ b/crates/zkevm-powdr/.gitignore
@@ -1,0 +1,3 @@
+target
+program/Cargo.lock
+host/Cargo.lock

--- a/crates/zkevm-powdr/host/Cargo.toml
+++ b/crates/zkevm-powdr/host/Cargo.toml
@@ -1,0 +1,27 @@
+cargo-features = ["edition2024"]
+
+[package]
+name = "powdr-host"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+default = []
+simd = ["powdr/plonky3-simd"]
+
+[dependencies]
+powdr = { git = "https://github.com/powdr-labs/powdr", tag = "v0.1.3", features = [
+  "plonky3",
+] }
+
+serde = { version = "1.0", default-features = false, features = [
+  "alloc",
+  "derive",
+  "rc",
+] }
+serde_cbor = { version = "0.11.2", default-features = false, features = [
+  "alloc",
+] }
+
+env_logger = "0.10.2"
+log = "0.4.17"

--- a/crates/zkevm-powdr/host/src/main.rs
+++ b/crates/zkevm-powdr/host/src/main.rs
@@ -1,0 +1,31 @@
+use powdr::Session;
+
+fn main() {
+    env_logger::init();
+
+    let some_data = vec![1, 2, 3, 4, 5];
+
+    // Create a new powdr session to make proofs for the `guest` crate.
+    // Store all temporary and final artifacts in `powdr-target`.
+    let mut session = Session::builder()
+        .guest_path("../program")
+        .out_path("powdr-target")
+        // powdrVM splits long execution traces into chunks
+        // which are proven individually.
+        // The default size of a chunk is 2^20 = 1048576 rows.
+        // For experiments and smaller traces/proofs, it may be beneficial to reduce the chunk size.
+        // Create a new powdr session with a custom chunk size.
+        // 2^18 = 262144 rows per chunk.
+        .chunk_size_log2(18)
+        .build()
+        // Write `some_data` to channel 1 and the sum of `some_data` to channel 2.
+        // Any serde-serializable type can be written to a channel.
+        .write(1, &some_data)
+        .write(2, &some_data.iter().sum::<u32>());
+
+    // Fast dry run to test execution.
+    session.run();
+
+    // Uncomment to compute the proof.
+    //session.prove();
+}

--- a/crates/zkevm-powdr/program/Cargo.toml
+++ b/crates/zkevm-powdr/program/Cargo.toml
@@ -1,0 +1,17 @@
+cargo-features = ["edition2024"]
+
+[package]
+name = "powdr-guest"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+powdr-riscv-syscalls = { git = "https://github.com/powdr-labs/powdr", tag = "v0.1.3" }
+powdr-riscv-runtime = { git = "https://github.com/powdr-labs/powdr", tag = "v0.1.3", features = [
+    "std",
+] }
+
+# Since we cannot put powdr in the workspace because of a TODO, we need to copy paste these here
+reth-ethereum-primitives = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }
+reth-primitives-traits = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }
+reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "96de1f325d8835d589bd505b9f94507904f20963" }

--- a/crates/zkevm-powdr/program/src/main.rs
+++ b/crates/zkevm-powdr/program/src/main.rs
@@ -1,0 +1,13 @@
+use powdr_riscv_runtime;
+use powdr_riscv_runtime::io::read;
+
+fn main() {
+    // Any serde-deserializable type can be read from a channel.
+    // Read some data from channel 1.
+    let data: Vec<u32> = read(1);
+    // Read the claimed sum from channel 2.
+    let sum: u32 = read(2);
+
+    // Check that the claimed sum is correct.
+    assert_eq!(data.iter().sum::<u32>(), sum);
+}


### PR DESCRIPTION
Currently it is not compiling due to:

```bash
     Running `target/release/powdr-host`
Compiling guest program...
error: failed to download `op-alloy-consensus v0.14.1`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/Users/kev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/op-alloy-consensus-0.14.1/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.82.0-nightly (257b72b8a 2024-07-30)).
  Consider trying a more recent nightly release.
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
thread 'main' panicked at /Users/kev/.cargo/git/checkouts/powdr-5ad669c296f4e377/340858e/riscv/src/lib.rs:242:5:
assertion failed: build_status.success()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

We also cannot put it as part of the workspace due to a TODO in powdr, see top level Cargo.toml for the error that we get.