### PR TITLE
witness-generator: RPC output renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ target
 zkevm-fixtures
 # zkevm metrics file
 zkevm-metrics
+
+# vscode settings
+.vscode

--- a/crates/witness-generator/src/rpc.rs
+++ b/crates/witness-generator/src/rpc.rs
@@ -147,7 +147,7 @@ impl RPCBlocksAndWitnesses {
                 .ok_or_else(|| anyhow::anyhow!("No block found for hash {}", block_hash))?;
 
             blocks_and_witnesses.push(BlocksAndWitnesses {
-                name: format!("mainnet_block_{}", block_num),
+                name: format!("rpc_block_{}", block_num),
                 blocks_and_witnesses: vec![ClientInput {
                     block: block.into_consensus(),
                     witness,


### PR DESCRIPTION
This PR renames the generated output to avoid `mainnet` naming since the RPC generator can point to any network. 

Use the same name used as in L183.