### PR TITLE
cargo: update ere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,12 +109,12 @@ witness-generator = { path = "crates/witness-generator" }
 zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "zkvm-interface" }
-ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "ere-sp1" }
-ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "ere-risczero" }
-ere-pico = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "ere-pico" }
-ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "ere-openvm" }
-ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", rev = "5f4fe5e7a83c969cab160b10644330ab771ee94c", package = "ere-zisk" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.1", package = "zkvm-interface" }
+ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.1", package = "ere-sp1" }
+ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.1", package = "ere-risczero" }
+ere-pico = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.1", package = "ere-pico" }
+ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.1", package = "ere-openvm" }
+ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.1", package = "ere-zisk" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.

--- a/ere-guests/risc0/guest/Cargo.toml
+++ b/ere-guests/risc0/guest/Cargo.toml
@@ -20,7 +20,7 @@ reth-primitives-traits = { workspace = true, features = [
 ] }
 reth-stateless.workspace = true
 revm = { version = "23", features = ["std", "c-kzg", "blst", "bn"] }
-risc0-zkvm = { version = "^2.0.2", default-features = false, features = [
+risc0-zkvm = { version = "^2.1.0", default-features = false, features = [
     "std",
     "unstable",
     "getrandom",


### PR DESCRIPTION
This PR updates `ere` to the latest version. This version contains a important change in SP1 to use [compressed proofs types](https://github.com/eth-act/ere/pull/36).