### PR TITLE
cli: add benchmark filtering flag

### DIFF
--- a/crates/ere-hosts/readme.md
+++ b/crates/ere-hosts/readme.md
@@ -39,6 +39,12 @@ Run all available zkVMs:
 cargo run --features "sp1,risc0,openvm,pico" -- tests
 ```
 
+You can use the `--filter` to only run specific tests. If you use multiple filters, they will be combined 
+with a logical AND, for example:
+```bash
+cargo run --features "sp1,risc0,openvm,pico" -- tests --filter "Prague" --filter "Blockhash"
+```
+
 ### Data Sources
 
 The benchmarker supports two data sources:

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -1,10 +1,7 @@
 //! Binary for benchmarking different Ere compatible zkVMs
 
 use clap::{Parser, Subcommand, ValueEnum};
-use std::{
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{path::PathBuf, process::Command};
 use witness_generator::{
     generate_stateless_witness::ExecSpecTestBlocksAndWitnesses, rpc::RPCBlocksAndWitnessesBuilder,
     witness_generator::WitnessGenerator,
@@ -62,6 +59,8 @@ enum SourceCommand {
     Tests {
         #[arg(short, long, default_value = path_to_zkevm_fixtures())]
         directory_path: PathBuf,
+        #[arg(short, long)]
+        filter: Option<Vec<String>>,
     },
     Rpc {
         /// Number of last blocks to pull
@@ -121,9 +120,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let action: Action = cli.action.into();
 
     let block_witness_gen: Box<dyn WitnessGenerator> = match cli.source {
-        SourceCommand::Tests { directory_path } => {
-            Box::new(ExecSpecTestBlocksAndWitnesses::new(directory_path))
-        }
+        SourceCommand::Tests {
+            directory_path,
+            filter,
+        } => Box::new(ExecSpecTestBlocksAndWitnesses::new(directory_path, filter)),
         SourceCommand::Rpc {
             last_n_blocks,
             block,

--- a/crates/witness-generator/src/generate_stateless_witness.rs
+++ b/crates/witness-generator/src/generate_stateless_witness.rs
@@ -14,6 +14,7 @@ use reth_stateless::ClientInput;
 #[derive(Debug, Clone)]
 pub struct ExecSpecTestBlocksAndWitnesses {
     directory_path: PathBuf,
+    filter: Option<Vec<String>>,
 }
 impl ExecSpecTestBlocksAndWitnesses {
     /// Creates a new instance of `ExecSpecTestBlocksAndWitnesses`.
@@ -21,8 +22,11 @@ impl ExecSpecTestBlocksAndWitnesses {
     /// # Arguments
     ///
     /// * `directory_path` - The path to the directory containing the blockchain test cases.
-    pub fn new(directory_path: PathBuf) -> Self {
-        Self { directory_path }
+    pub fn new(directory_path: PathBuf, filter: Option<Vec<String>>) -> Self {
+        Self {
+            directory_path,
+            filter,
+        }
     }
 }
 
@@ -69,6 +73,11 @@ impl WitnessGenerator for ExecSpecTestBlocksAndWitnesses {
                 // This is why we have `tests`.
                 .tests
                 .iter()
+                .filter(|(name, _)| {
+                    self.filter
+                        .as_ref()
+                        .map_or(true, |filter| filter.iter().all(|f| name.contains(f)))
+                })
                 .map(|(name, case)| BlocksAndWitnesses {
                     name: name.to_string(),
                     blocks_and_witnesses: run_case(case)


### PR DESCRIPTION
This PR adds a new `--filter` flag when running the tool for `tests` benchmarks.

The main motivation here is mainly having an easy way to only run tests for a single fork (since many tests are filled for multiple forks, e.g., Prague and Cancun), and also only running a single tests (e.g., `BLOCKHASH` or whatever opcode/precompile) instead of the whole set available in the downloaded folder.