### PR TITLE
Include host hardware spec, block used gas, proof size and have more uniform crash handling in outputs

### DIFF
--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -68,6 +68,7 @@ where
 
     for ci in blocks_and_witnesses {
         let block_number = ci.block.number;
+        let block_used_gas = ci.block.gas_used;
         let mut stdin = Input::new();
         stdin.write(ci);
         stdin.write(bw.network);
@@ -109,6 +110,7 @@ where
         };
         reports.push(BenchmarkRun {
             name: format!("{}-{}", bw.name, block_number),
+            block_used_gas,
             hardware: hardware.clone(),
             actions_metrics: vec![workload_metrics],
         });

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -193,9 +193,10 @@ where
                 }
             }
             Action::Prove => {
-                let (_, report) = zkvm_ref.prove(&stdin)?;
+                let (proof, report) = zkvm_ref.prove(&stdin)?;
                 WorkloadMetrics::Proving {
                     name: format!("{}-{}", bw.name, block_number),
+                    proof_size: proof.len(),
                     proving_time_ms: report.proving_time.as_millis(),
                 }
             }

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -1,48 +1,8 @@
-use anyhow::*;
 use rayon::prelude::*;
-use std::{fs, panic, sync::Arc};
-use witness_generator::{witness_generator::WitnessGenerator, BlocksAndWitnesses};
-use zkevm_metrics::WorkloadMetrics;
+use std::{any::Any, panic, sync::Arc};
+use witness_generator::BlocksAndWitnesses;
+use zkevm_metrics::{ActionMetrics, BenchmarkRun, CrashInfo, ExecutionMetrics, ProvingMetrics};
 use zkvm_interface::{zkVM, Input};
-
-#[deprecated(note = "this function is being phased out, use run_benchmark_ere")]
-pub async fn run_benchmark<F>(
-    elf_path: &'static [u8],
-    metrics_path_prefix: &str,
-    zkvm_executor: F,
-    wg: &Box<dyn WitnessGenerator>,
-) -> Result<()>
-where
-    F: Fn(&BlocksAndWitnesses, &'static [u8]) -> Vec<WorkloadMetrics> + Send + Sync,
-{
-    let generated_corpuses = wg.generate().await?;
-
-    generated_corpuses.into_par_iter().for_each(|bw| {
-        println!("{} (num_blocks={})", bw.name, bw.blocks_and_witnesses.len());
-
-        let reports = zkvm_executor(&bw, elf_path);
-
-        WorkloadMetrics::to_path(
-            format!(
-                "{}/{}/{}/{}.json",
-                env!("CARGO_WORKSPACE_DIR"),
-                "zkevm-metrics",
-                metrics_path_prefix,
-                bw.name
-            ),
-            &reports,
-        )
-        .unwrap();
-
-        println!(
-            "Finished processing and saved metrics for corpus: {}. Number of reports: {}",
-            bw.name,
-            reports.len()
-        );
-        // dbg!(&reports);
-    });
-    Ok(())
-}
 
 /// Action specifies whether we should prove or execute
 #[derive(Clone, Copy)]
@@ -66,101 +26,101 @@ pub fn run_benchmark_ere<V>(
         Action::Execute => {
             // Use parallel iteration for execution
             corpuses.into_par_iter().for_each(|bw| {
-                process_corpus_with_crash_handling(bw, zkvm_ref.clone(), &action, host_name);
+                process_corpus(bw, zkvm_ref.clone(), &action, host_name);
             });
         }
         Action::Prove => {
             // Use sequential iteration for proving
             corpuses.into_iter().for_each(|bw| {
-                process_corpus_with_crash_handling(bw, Arc::new(&*zkvm_ref), &action, host_name);
+                process_corpus(bw, Arc::new(&*zkvm_ref), &action, host_name);
             });
         }
     }
 }
 
-fn process_corpus_with_crash_handling<V>(
-    bw: &BlocksAndWitnesses,
-    zkvm_ref: Arc<&V>,
-    action: &Action,
-    host_name: &str,
-) where
-    V: zkVM + Sync,
-{
-    let bench_name = bw.name.clone();
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        process_corpus(bw, zkvm_ref, action, host_name)
-    }));
+// fn process_corpus_with_crash_handling<V>(
+//     bw: &BlocksAndWitnesses,
+//     zkvm_ref: Arc<&V>,
+//     action: &Action,
+//     host_name: &str,
+// ) where
+//     V: zkVM + Sync,
+// {
+//     let bench_name = bw.name.clone();
+//     let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+//         process_corpus(bw, zkvm_ref, action, host_name)
+//     }));
 
-    let action_str = match action {
-        Action::Execute => "execute",
-        Action::Prove => "prove",
-    };
+//     let action_str = match action {
+//         Action::Execute => "execute",
+//         Action::Prove => "prove",
+//     };
 
-    use std::result::Result::Ok;
-    let crash_reason = match result {
-        Ok(Ok(())) => {
-            // Success, nothing to do
-            return;
-        }
-        Ok(Err(e)) => {
-            // Regular error - treat as crash
-            format!("Error: {}", e)
-        }
-        Err(panic_info) => {
-            // Panic - treat as crash
-            let panic_msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-                s.to_string()
-            } else if let Some(s) = panic_info.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic occurred".to_string()
-            };
-            format!("Panic: {}", panic_msg)
-        }
-    };
+//     use std::result::Result::Ok;
+//     let crash_reason = match result {
+//         Ok(Ok(())) => {
+//             // Success, nothing to do
+//             return;
+//         }
+//         Ok(Err(e)) => {
+//             // Regular error - treat as crash
+//             format!("Error: {}", e)
+//         }
+//         Err(panic_info) => {
+//             // Panic - treat as crash
+//             let panic_msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+//                 s.to_string()
+//             } else if let Some(s) = panic_info.downcast_ref::<String>() {
+//                 s.clone()
+//             } else {
+//                 "Unknown panic occurred".to_string()
+//             };
+//             format!("Panic: {}", panic_msg)
+//         }
+//     };
 
-    eprintln!(
-        "Benchmark CRASHED for {}: {}",
-        bench_name.clone(),
-        crash_reason
-    );
+//     eprintln!(
+//         "Benchmark CRASHED for {}: {}",
+//         bench_name.clone(),
+//         crash_reason
+//     );
 
-    // Create crash metrics
-    let crash_metrics = WorkloadMetrics::Crashed {
-        name: bench_name.clone(),
-        action: action_str.to_string(),
-        reason: crash_reason.clone(),
-    };
+//     // Create crash metrics
+//     let crash_metrics = WorkloadMetrics::Crashed {
+//         name: bench_name.clone(),
+//         action: action_str.to_string(),
+//         reason: crash_reason.clone(),
+//     };
 
-    // Save crash info to crash directory
-    let crash_dir = format!(
-        "{}/zkevm-metrics/{}/crash",
-        env!("CARGO_WORKSPACE_DIR"),
-        host_name
-    );
+//     // Save crash info to crash directory
+//     let crash_dir = format!(
+//         "{}/zkevm-metrics/{}/crash",
+//         env!("CARGO_WORKSPACE_DIR"),
+//         host_name
+//     );
 
-    if let Err(e) = fs::create_dir_all(&crash_dir) {
-        panic!("Failed to create crash directory: {}", e);
-    }
+//     if let Err(e) = fs::create_dir_all(&crash_dir) {
+//         panic!("Failed to create crash directory: {}", e);
+//     }
 
-    // Save crash metrics as JSON
-    let crash_json_file = format!("{}/{}.json", crash_dir, &bench_name);
-    if let Err(e) = WorkloadMetrics::to_path(&crash_json_file, &[crash_metrics]) {
-        panic!("Failed to save crash metrics JSON: {}", e);
-    } else {
-        println!(
-            "Recorded crash for corpus: {} in {}",
-            bench_name, crash_json_file
-        );
-    }
-}
+//     // Save crash metrics as JSON
+//     let crash_json_file = format!("{}/{}.json", crash_dir, &bench_name);
+//     if let Err(e) = WorkloadMetrics::to_path(&crash_json_file, &[crash_metrics]) {
+//         panic!("Failed to save crash metrics JSON: {}", e);
+//     } else {
+//         println!(
+//             "Recorded crash for corpus: {} in {}",
+//             bench_name, crash_json_file
+//         );
+//     }
+// }
 
 fn process_corpus<V>(
     bw: &BlocksAndWitnesses,
     zkvm_ref: Arc<&V>,
     action: &Action,
     host_name: &str,
-) -> Result<()>
+) -> anyhow::Result<()>
 where
     V: zkVM + Sync,
 {
@@ -184,24 +144,43 @@ where
 
         let workload_metrics = match action {
             Action::Execute => {
-                let report = zkvm_ref.execute(&stdin)?;
-                WorkloadMetrics::Execution {
-                    name: format!("{}-{}", bw.name, block_number),
-                    total_num_cycles: report.total_num_cycles,
-                    region_cycles: report.region_cycles.into_iter().collect(),
-                    execution_duration: report.execution_duration,
+                let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm_ref.execute(&stdin)));
+                match run {
+                    Ok(Ok(report)) => ActionMetrics::Execution(ExecutionMetrics::Success {
+                        total_num_cycles: report.total_num_cycles,
+                        region_cycles: report.region_cycles.into_iter().collect(),
+                        execution_duration: report.execution_duration,
+                    }),
+                    Ok(Err(e)) => ActionMetrics::Execution(ExecutionMetrics::Crashed(CrashInfo {
+                        reason: e.to_string(),
+                    })),
+                    Err(panic_info) => {
+                        ActionMetrics::Execution(ExecutionMetrics::Crashed(CrashInfo {
+                            reason: get_panic_msg(panic_info),
+                        }))
+                    }
                 }
             }
             Action::Prove => {
-                let (proof, report) = zkvm_ref.prove(&stdin)?;
-                WorkloadMetrics::Proving {
-                    name: format!("{}-{}", bw.name, block_number),
-                    proof_size: proof.len(),
-                    proving_time_ms: report.proving_time.as_millis(),
+                let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm_ref.prove(&stdin)));
+                match run {
+                    Ok(Ok((proof, report))) => ActionMetrics::Proving(ProvingMetrics::Success {
+                        proof_size: proof.len(),
+                        proving_time_ms: report.proving_time.as_millis(),
+                    }),
+                    Ok(Err(e)) => ActionMetrics::Proving(ProvingMetrics::Crashed(CrashInfo {
+                        reason: e.to_string(),
+                    })),
+                    Err(panic_info) => ActionMetrics::Proving(ProvingMetrics::Crashed(CrashInfo {
+                        reason: get_panic_msg(panic_info),
+                    })),
                 }
             }
         };
-        reports.push(workload_metrics);
+        reports.push(BenchmarkRun {
+            name: format!("{}-{}", bw.name, block_number),
+            actions_metrics: vec![workload_metrics],
+        });
     }
 
     let out_path = format!(
@@ -210,7 +189,17 @@ where
         host_name,
         bw.name
     );
-    WorkloadMetrics::to_path(out_path, &reports)?;
+    BenchmarkRun::to_path(out_path, &reports)?;
     println!("wrote {} reports", reports.len());
     Ok(())
+}
+
+fn get_panic_msg(panic_info: Box<dyn Any + Send>) -> String {
+    if let Some(s) = panic_info.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = panic_info.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "Unknown panic occurred".to_string()
+    }
 }

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -20,6 +20,11 @@ pub fn run_benchmark_ere<V>(
 where
     V: zkVM + Sync,
 {
+    HardwareInfo::detect().to_path(format!(
+        "{}/zkevm-metrics/hardware.json",
+        env!("CARGO_WORKSPACE_DIR")
+    ))?;
+
     println!("Benchmarking `{}`…", host_name);
     let zkvm_ref = Arc::new(&zkvm_instance);
 
@@ -49,9 +54,6 @@ fn process_corpus<V>(
 where
     V: zkVM + Sync,
 {
-    // Detect hardware information once per corpus
-    let hardware = HardwareInfo::detect();
-
     // Take the last element, because benchmarks are setup in such a way that
     // We only want to benchmark the last block.
     let last_block_with_witness = match bw.blocks_and_witnesses.last() {
@@ -109,7 +111,6 @@ where
         reports.push(BenchmarkRun {
             name: format!("{}-{}", bw.name, block_number),
             block_used_gas,
-            hardware: hardware.clone(),
             execution,
             proving,
         });

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -1,7 +1,9 @@
 use rayon::prelude::*;
 use std::{any::Any, panic, sync::Arc};
 use witness_generator::BlocksAndWitnesses;
-use zkevm_metrics::{ActionMetrics, BenchmarkRun, CrashInfo, ExecutionMetrics, ProvingMetrics};
+use zkevm_metrics::{
+    ActionMetrics, BenchmarkRun, CrashInfo, ExecutionMetrics, HardwareInfo, ProvingMetrics,
+};
 use zkvm_interface::{zkVM, Input};
 
 /// Action specifies whether we should prove or execute
@@ -49,6 +51,9 @@ fn process_corpus<V>(
 where
     V: zkVM + Sync,
 {
+    // Detect hardware information once per corpus
+    let hardware = HardwareInfo::detect();
+
     // Take the last element, because benchmarks are setup in such a way that
     // We only want to benchmark the last block.
     let last_block_with_witness = match bw.blocks_and_witnesses.last() {
@@ -104,6 +109,7 @@ where
         };
         reports.push(BenchmarkRun {
             name: format!("{}-{}", bw.name, block_number),
+            hardware: hardware.clone(),
             actions_metrics: vec![workload_metrics],
         });
     }

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -165,7 +165,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("sp1")?;
         let sp1_zkvm = new_sp1_zkvm(resource.clone())?;
-        run_benchmark_ere("sp1", sp1_zkvm, action, &corpuses);
+        run_benchmark_ere("sp1", sp1_zkvm, action, &corpuses)?;
         ran_any = true;
     }
 
@@ -173,7 +173,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("zisk")?;
         let zisk_zkvm = new_zisk_zkvm(resource)?;
-        run_benchmark_ere("zisk", zisk_zkvm, action, &corpuses);
+        run_benchmark_ere("zisk", zisk_zkvm, action, &corpuses)?;
         ran_any = true;
     }
 
@@ -181,7 +181,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("risc0")?;
         let risc0_zkvm = new_risczero_zkvm(resource.clone())?;
-        run_benchmark_ere("risc0", risc0_zkvm, action, &corpuses);
+        run_benchmark_ere("risc0", risc0_zkvm, action, &corpuses)?;
         ran_any = true;
     }
 
@@ -189,7 +189,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("openvm")?;
         let openvm_zkvm = new_openvm_zkvm(resource.clone())?;
-        run_benchmark_ere("openvm", openvm_zkvm, action, &corpuses);
+        run_benchmark_ere("openvm", openvm_zkvm, action, &corpuses)?;
         ran_any = true;
     }
 
@@ -197,7 +197,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("pico")?;
         let pico_zkvm = new_pico_zkvm(resource.clone())?;
-        run_benchmark_ere("pico", pico_zkvm, action, &corpuses);
+        run_benchmark_ere("pico", pico_zkvm, action, &corpuses)?;
         ran_any = true;
     }
 

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -172,7 +172,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "zisk")]
     {
         run_cargo_patch_command("zisk")?;
-        let zisk_zkvm = new_zisk_zkvm(resource)?;
+        let zisk_zkvm = new_zisk_zkvm(resource.clone())?;
         run_benchmark_ere("zisk", zisk_zkvm, action, &corpuses)?;
         ran_any = true;
     }

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -10,6 +10,7 @@ serde.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true
 serde_derive.workspace = true
+sysinfo = "0.26"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/metrics/README.md
+++ b/crates/metrics/README.md
@@ -7,6 +7,7 @@ This crate provides data structures and utilities for handling workload performa
 The core data structure is `BenchmarkRun`, which stores:
 
 - `name`: The name of the benchmark (e.g., "fft_bench", "aes_bench").
+- `block_used_gas`: The amount of gas used by the block in the benchmark.
 - `hardware`: Hardware information about the system where the benchmark was run, including CPU model, RAM, and GPU details.
 - `actions_metrics`: A list of `ActionMetrics`, which can be either `Execution` or `Proving` metrics.
 
@@ -61,6 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let metrics_data = vec![
         BenchmarkRun {
             name: "workload name".into(),
+            block_used_gas: 12345,
             hardware: HardwareInfo::detect(), // Automatically detect hardware
             actions_metrics: vec![ActionMetrics::Execution(ExecutionMetrics::Success {
                 total_num_cycles: 1_000,

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -22,6 +22,7 @@ pub struct CrashInfo {
 
 /// Metrics for a particular action, either execution or proving.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum ActionMetrics {
     /// Metrics produced when benchmarking in execution mode.
     Execution(ExecutionMetrics),
@@ -31,6 +32,7 @@ pub enum ActionMetrics {
 
 /// Metrics for execution workloads, either successful or crashed.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum ExecutionMetrics {
     /// Metrics for a successful execution workload.
     Success {
@@ -47,6 +49,7 @@ pub enum ExecutionMetrics {
 
 /// Metrics for proving workloads, either successful or crashed.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum ProvingMetrics {
     /// Metrics for a successful proving workload.
     Success {

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -24,6 +24,8 @@ pub enum WorkloadMetrics {
     Proving {
         /// Name of the workload (e.g., "fft", "aes").
         name: String,
+        /// Proof size
+        proof_size: usize,
         /// Proving time in milliseconds
         proving_time_ms: u128,
     },
@@ -153,10 +155,12 @@ mod tests {
             },
             WorkloadMetrics::Proving {
                 name: "rsa".into(),
+                proof_size: 512,
                 proving_time_ms: 5_000,
             },
             WorkloadMetrics::Proving {
                 name: "ecdsa".into(),
+                proof_size: 256,
                 proving_time_ms: 3_500,
             },
             WorkloadMetrics::Crashed {
@@ -209,6 +213,7 @@ mod tests {
 
         let proving_metric = WorkloadMetrics::Proving {
             name: "test_proving".into(),
+            proof_size: 512,
             proving_time_ms: 2000,
         };
 
@@ -234,6 +239,7 @@ mod tests {
             },
             WorkloadMetrics::Proving {
                 name: "mixed_proving".into(),
+                proof_size: 300,
                 proving_time_ms: 1000,
             },
         ];

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -297,6 +297,30 @@ mod tests {
     }
 
     #[test]
+    fn test_name_accessor() {
+        let benchmark_run = BenchmarkRun {
+            name: "test_benchmark".into(),
+            hardware: sample_hardware_info(),
+            actions_metrics: vec![
+                ActionMetrics::Execution(ExecutionMetrics::Success {
+                    total_num_cycles: 1000,
+                    region_cycles: HashMap::new(),
+                    execution_duration: Duration::from_millis(150),
+                }),
+                ActionMetrics::Proving(ProvingMetrics::Success {
+                    proof_size: 256,
+                    proving_time_ms: 2000,
+                }),
+                ActionMetrics::Execution(ExecutionMetrics::Crashed(CrashInfo {
+                    reason: "Test panic".into(),
+                })),
+            ],
+        };
+
+        assert_eq!(benchmark_run.name(), "test_benchmark");
+    }
+
+    #[test]
     fn test_mixed_metrics_serialization() {
         let mixed_workloads = vec![
             ActionMetrics::Execution(ExecutionMetrics::Success {

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -15,8 +15,10 @@ pub struct BenchmarkRun {
     /// Information about the hardware on which the benchmark was run.
     pub hardware: HardwareInfo,
     /// Execution metrics for the benchmark run.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub execution: Option<ExecutionMetrics>,
     /// Proving metrics for the benchmark run.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub proving: Option<ProvingMetrics>,
 }
 

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -4,15 +4,36 @@ use serde_derive::{Deserialize, Serialize};
 use std::{collections::HashMap, fs, io, path::Path, time::Duration};
 use thiserror::Error;
 
-/// Cycle-count metrics for a particular workload.
-///
-/// Stores the total cycle count and a breakdown of cycle count per named region.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum WorkloadMetrics {
-    /// Metrics produced when benchmarking in execution mode
-    Execution {
-        /// Name of the workload (e.g., "fft", "aes").
-        name: String,
+/// Represents a single benchmark run.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct BenchmarkRun {
+    /// Name of the benchmark.
+    pub name: String,
+    /// Metrics collected during run.
+    pub actions_metrics: Vec<ActionMetrics>,
+}
+
+/// Information about a crash that occurred during a workload.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct CrashInfo {
+    /// The reason for the crash (e.g., panic message).
+    pub reason: String,
+}
+
+/// Metrics for a particular action, either execution or proving.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub enum ActionMetrics {
+    /// Metrics produced when benchmarking in execution mode.
+    Execution(ExecutionMetrics),
+    /// Metrics produced when benchmarking in proving mode.
+    Proving(ProvingMetrics),
+}
+
+/// Metrics for execution workloads, either successful or crashed.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub enum ExecutionMetrics {
+    /// Metrics for a successful execution workload.
+    Success {
         /// Total number of cycles for the entire workload execution.
         total_num_cycles: u64,
         /// Region-specific cycles, mapping region names (e.g., "setup", "compute") to their cycle counts.
@@ -20,24 +41,22 @@ pub enum WorkloadMetrics {
         /// Execution duration.
         execution_duration: Duration,
     },
-    /// Metrics produced when benchmarking in proving mode
-    Proving {
-        /// Name of the workload (e.g., "fft", "aes").
-        name: String,
-        /// Proof size
+    /// Metrics for a crashed execution workload.
+    Crashed(CrashInfo),
+}
+
+/// Metrics for proving workloads, either successful or crashed.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub enum ProvingMetrics {
+    /// Metrics for a successful proving workload.
+    Success {
+        /// Proof size in bytes.
         proof_size: usize,
-        /// Proving time in milliseconds
+        /// Proving time in milliseconds.
         proving_time_ms: u128,
     },
-    /// Metrics produced when a benchmark crashes/errors
-    Crashed {
-        /// Name of the workload that crashed
-        name: String,
-        /// Action being performed when crash occurred (e.g., "execute", "prove")
-        action: String,
-        /// Reason for the crash (panic message)
-        reason: String,
-    },
+    /// Metrics for a crashed proving workload.
+    Crashed(CrashInfo),
 }
 
 /// Errors that can occur during metrics processing.
@@ -62,14 +81,10 @@ impl MetricsError {
     }
 }
 
-impl WorkloadMetrics {
-    /// Returns the name of the workload regardless of the variant.
+impl BenchmarkRun {
+    /// Returns the name of the benchmark.
     pub fn name(&self) -> &str {
-        match self {
-            WorkloadMetrics::Execution { name, .. } => name,
-            WorkloadMetrics::Proving { name, .. } => name,
-            WorkloadMetrics::Crashed { name, .. } => name,
-        }
+        self.name.as_str()
     }
 
     /// Serializes a list of `WorkloadMetrics` into a JSON string.
@@ -131,121 +146,103 @@ mod tests {
     use tempfile::NamedTempFile;
 
     // This is just a fixed sample we are using to test serde_roundtrip
-    fn sample() -> Vec<WorkloadMetrics> {
+    fn sample() -> Vec<BenchmarkRun> {
         vec![
-            WorkloadMetrics::Execution {
-                name: "fft".into(),
-                total_num_cycles: 1_000,
-                region_cycles: HashMap::from_iter([
-                    ("setup".to_string(), 100),
-                    ("compute".to_string(), 800),
-                    ("teardown".to_string(), 100),
-                ]),
-                execution_duration: Duration::from_millis(150),
+            BenchmarkRun {
+                name: "fft_bench".into(),
+                actions_metrics: vec![
+                    ActionMetrics::Execution(ExecutionMetrics::Success {
+                        total_num_cycles: 1_000,
+                        region_cycles: HashMap::from_iter([
+                            ("setup".to_string(), 100),
+                            ("compute".to_string(), 800),
+                            ("teardown".to_string(), 100),
+                        ]),
+                        execution_duration: Duration::from_millis(150),
+                    }),
+                    ActionMetrics::Execution(ExecutionMetrics::Crashed(CrashInfo {
+                        reason: "panic in fft".into(),
+                    })),
+                ],
             },
-            WorkloadMetrics::Execution {
-                name: "aes".into(),
-                total_num_cycles: 2_000,
-                region_cycles: HashMap::from_iter([
-                    ("init".to_string(), 200),
-                    ("encrypt".to_string(), 1_600),
-                    ("final".to_string(), 200),
-                ]),
-                execution_duration: Duration::from_millis(300),
+            BenchmarkRun {
+                name: "aes_bench".into(),
+                actions_metrics: vec![ActionMetrics::Execution(ExecutionMetrics::Success {
+                    total_num_cycles: 2_000,
+                    region_cycles: HashMap::from_iter([
+                        ("init".to_string(), 200),
+                        ("encrypt".to_string(), 1_600),
+                        ("final".to_string(), 200),
+                    ]),
+                    execution_duration: Duration::from_millis(300),
+                })],
             },
-            WorkloadMetrics::Proving {
-                name: "rsa".into(),
-                proof_size: 512,
-                proving_time_ms: 5_000,
-            },
-            WorkloadMetrics::Proving {
-                name: "ecdsa".into(),
-                proof_size: 256,
-                proving_time_ms: 3_500,
-            },
-            WorkloadMetrics::Crashed {
-                name: "sha256".into(),
-                action: "execute".into(),
-                reason: "Out of memory panic".into(),
+            BenchmarkRun {
+                name: "proving_bench".into(),
+                actions_metrics: vec![
+                    ActionMetrics::Proving(ProvingMetrics::Success {
+                        proof_size: 512,
+                        proving_time_ms: 5_000,
+                    }),
+                    ActionMetrics::Proving(ProvingMetrics::Crashed(CrashInfo {
+                        reason: "proving failed".into(),
+                    })),
+                ],
             },
         ]
     }
 
     #[test]
     fn round_trip_json() {
-        let workloads = sample();
-        let json = WorkloadMetrics::to_json(&workloads).expect("serialize");
-        let parsed = WorkloadMetrics::from_json(&json).expect("deserialize");
-        assert_eq!(workloads, parsed);
+        let runs = sample();
+        let json = BenchmarkRun::to_json(&runs).expect("serialize");
+        let parsed = BenchmarkRun::from_json(&json).expect("deserialize");
+        assert_eq!(runs, parsed);
     }
 
     #[test]
     fn bad_json_is_error() {
         let bad = "{this is not valid json}";
-        let err = WorkloadMetrics::from_json(bad).unwrap_err();
+        let err = BenchmarkRun::from_json(bad).unwrap_err();
         assert!(err.into_serde_err().is_data());
     }
 
     #[test]
     fn file_round_trip() -> Result<(), MetricsError> {
-        // Create a named temporary file.
         let temp_file = NamedTempFile::new()?;
         let path = temp_file.path();
-
-        let workloads = sample();
-
-        // Write → read → compare using the temp file's path.
-        WorkloadMetrics::to_path(path, &workloads)?;
-        let read_back = WorkloadMetrics::from_path(path)?;
-        assert_eq!(workloads, read_back);
-
+        let runs = sample();
+        BenchmarkRun::to_path(path, &runs)?;
+        let read_back = BenchmarkRun::from_path(path)?;
+        assert_eq!(runs, read_back);
         Ok(())
-    }
-
-    #[test]
-    fn test_name_accessor() {
-        let execution_metric = WorkloadMetrics::Execution {
-            name: "test_execution".into(),
-            total_num_cycles: 1000,
-            region_cycles: HashMap::new(),
-            execution_duration: Duration::from_millis(150),
-        };
-
-        let proving_metric = WorkloadMetrics::Proving {
-            name: "test_proving".into(),
-            proof_size: 512,
-            proving_time_ms: 2000,
-        };
-
-        let crashed_metric = WorkloadMetrics::Crashed {
-            name: "test_crashed".into(),
-            action: "execute".into(),
-            reason: "Test panic".into(),
-        };
-
-        assert_eq!(execution_metric.name(), "test_execution");
-        assert_eq!(proving_metric.name(), "test_proving");
-        assert_eq!(crashed_metric.name(), "test_crashed");
     }
 
     #[test]
     fn test_mixed_metrics_serialization() {
         let mixed_workloads = vec![
-            WorkloadMetrics::Execution {
-                name: "mixed_execution".into(),
+            ActionMetrics::Execution(ExecutionMetrics::Success {
                 total_num_cycles: 500,
                 region_cycles: HashMap::from_iter([("phase1".to_string(), 500)]),
                 execution_duration: Duration::from_millis(200),
-            },
-            WorkloadMetrics::Proving {
-                name: "mixed_proving".into(),
+            }),
+            ActionMetrics::Proving(ProvingMetrics::Success {
                 proof_size: 300,
                 proving_time_ms: 1000,
-            },
+            }),
+            ActionMetrics::Execution(ExecutionMetrics::Crashed(CrashInfo {
+                reason: "fail".into(),
+            })),
+            ActionMetrics::Proving(ProvingMetrics::Crashed(CrashInfo {
+                reason: "fail".into(),
+            })),
         ];
-
-        let json = WorkloadMetrics::to_json(&mixed_workloads).expect("serialize mixed");
-        let parsed = WorkloadMetrics::from_json(&json).expect("deserialize mixed");
-        assert_eq!(mixed_workloads, parsed);
+        let bench = BenchmarkRun {
+            name: "mixed_bench".into(),
+            actions_metrics: mixed_workloads.clone(),
+        };
+        let json = BenchmarkRun::to_json(&[bench.clone()]).expect("serialize mixed");
+        let parsed = BenchmarkRun::from_json(&json).expect("deserialize mixed");
+        assert_eq!(vec![bench], parsed);
     }
 }

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -9,8 +9,28 @@ use thiserror::Error;
 pub struct BenchmarkRun {
     /// Name of the benchmark.
     pub name: String,
+    /// Information about the hardware on which the benchmark was run.
+    pub hardware: HardwareInfo,
     /// Metrics collected during run.
     pub actions_metrics: Vec<ActionMetrics>,
+}
+
+/// Hardware specs of the benchmark runner.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct HardwareInfo {
+    /// CPU model name.
+    pub cpu_model: String,
+    /// Total RAM in bytes.
+    pub total_ram_bytes: u64,
+    /// Available GPUs.
+    pub gpus: Vec<GpuInfo>,
+}
+
+/// Information about a GPU.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct GpuInfo {
+    /// GPU model name.
+    pub model: String,
 }
 
 /// Information about a crash that occurred during a workload.
@@ -148,11 +168,20 @@ mod tests {
     use std::iter::FromIterator;
     use tempfile::NamedTempFile;
 
+    fn sample_hardware_info() -> HardwareInfo {
+        HardwareInfo {
+            cpu_model: "test_cpu".to_string(),
+            total_ram_bytes: 1,
+            gpus: vec![],
+        }
+    }
+
     // This is just a fixed sample we are using to test serde_roundtrip
     fn sample() -> Vec<BenchmarkRun> {
         vec![
             BenchmarkRun {
                 name: "fft_bench".into(),
+                hardware: sample_hardware_info(),
                 actions_metrics: vec![
                     ActionMetrics::Execution(ExecutionMetrics::Success {
                         total_num_cycles: 1_000,
@@ -170,6 +199,7 @@ mod tests {
             },
             BenchmarkRun {
                 name: "aes_bench".into(),
+                hardware: sample_hardware_info(),
                 actions_metrics: vec![ActionMetrics::Execution(ExecutionMetrics::Success {
                     total_num_cycles: 2_000,
                     region_cycles: HashMap::from_iter([
@@ -182,6 +212,7 @@ mod tests {
             },
             BenchmarkRun {
                 name: "proving_bench".into(),
+                hardware: sample_hardware_info(),
                 actions_metrics: vec![
                     ActionMetrics::Proving(ProvingMetrics::Success {
                         proof_size: 512,
@@ -242,6 +273,7 @@ mod tests {
         ];
         let bench = BenchmarkRun {
             name: "mixed_bench".into(),
+            hardware: sample_hardware_info(),
             actions_metrics: mixed_workloads.clone(),
         };
         let json = BenchmarkRun::to_json(&[bench.clone()]).expect("serialize mixed");

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -10,6 +10,8 @@ use thiserror::Error;
 pub struct BenchmarkRun {
     /// Name of the benchmark.
     pub name: String,
+    /// Block used gas
+    pub block_used_gas: u64,
     /// Information about the hardware on which the benchmark was run.
     pub hardware: HardwareInfo,
     /// Metrics collected during run.
@@ -225,6 +227,7 @@ mod tests {
         vec![
             BenchmarkRun {
                 name: "fft_bench".into(),
+                block_used_gas: 12345,
                 hardware: sample_hardware_info(),
                 actions_metrics: vec![
                     ActionMetrics::Execution(ExecutionMetrics::Success {
@@ -243,6 +246,7 @@ mod tests {
             },
             BenchmarkRun {
                 name: "aes_bench".into(),
+                block_used_gas: 67890,
                 hardware: sample_hardware_info(),
                 actions_metrics: vec![ActionMetrics::Execution(ExecutionMetrics::Success {
                     total_num_cycles: 2_000,
@@ -256,6 +260,7 @@ mod tests {
             },
             BenchmarkRun {
                 name: "proving_bench".into(),
+                block_used_gas: 54321,
                 hardware: sample_hardware_info(),
                 actions_metrics: vec![
                     ActionMetrics::Proving(ProvingMetrics::Success {
@@ -300,6 +305,7 @@ mod tests {
     fn test_name_accessor() {
         let benchmark_run = BenchmarkRun {
             name: "test_benchmark".into(),
+            block_used_gas: 11111,
             hardware: sample_hardware_info(),
             actions_metrics: vec![
                 ActionMetrics::Execution(ExecutionMetrics::Success {
@@ -341,6 +347,7 @@ mod tests {
         ];
         let bench = BenchmarkRun {
             name: "mixed_bench".into(),
+            block_used_gas: 22222,
             hardware: sample_hardware_info(),
             actions_metrics: mixed_workloads.clone(),
         };


### PR DESCRIPTION
This PR does the following changes:

- Automatically detects CPU, RAM, and GPUs in the host machine and saves it in a `hardware.json` file at the root of `zkevm-metrics` output folder.
- Adds an extra field in each benchmark run output file named `gas_used` with the amount of gas used in the block. This is useful for later analytics (e.g., having a proving time of 1min in a 10M block is not the same as a 30M block, especially for mainnet block benchmark runs). Also, I'm interested in presenting "proving opcode X has X gas/s proving throughput" which can in trying to make sense of potential repricings.
- Avoid using a separate `crashed` folder for crashed runs. Every run now will have the expected output json file, and will signal `success` or `crashed`. (More about this in example outputs below)
- The output file accepts `execution` and `proving` information, allowing us to support running benchmark both in execution and proving mode. This can be useful to have both details about total/region cycle information in a single file, plus providing information so that the analytics can have everything in a single file. (Will be more evident in the example below).
- Adds the field `proof_size` in proving action mode.

Let’s look at some examples that will make all the above clearer.

At the root of the output folder, a new `hardware.json` is generated like:
```json
{
  "cpu_model": "AMD EPYC 7R13 Processor",
  "total_ram_gib": 248,
  "gpus": [
    {
      "model": "NVIDIA L40S"
    }
  ]
}
```
```
zkevm-metrics
├── hardware.json
└── sp1
    └── tests
        └── zkevm
        ...
```

This is written as a separate file compared to earlier drafts, which always included this (repeated) information in each output file. The future analytics tool can read this file once to contextualize the runs on which hardware was run.

Regarding benchmark outputs, here’s a successful one for an execution run:

```json
[
  {
    "name": "tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_cold[fork_Prague-blockchain_test-absent_accounts_False-opcode_BALANCE]-2",
    "block_used_gas": 36000000,
    "execution": {
      "success": {
        "total_num_cycles": 699424217,
        "region_cycles": {
          "validation": 435721514,
          "decode-headers": 9720,
          "recover-signers": 51887,
          "verify-witness": 287496071,
          "post-state-compute": 525030,
          "read_input": 263698439,
          "block-execution": 144356703
        },
        "execution_duration": {
          "secs": 37,
          "nanos": 479416950
        }
      }
    }
  }
]
```

Note `gas_used`, and `success`.

Compare with a crashed execution output (as a normal output file, i.e., not in a special folder):

```json

[
  {
    "name": "tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Prague-blockchain_test-absent_target_False-opcode_CALL]-1",
    "block_used_gas": 36000000,
    "execution": {
      "crashed": {
        "reason": "SP1 execution failed: execution failed with exit code 1"
      }
    }
  }
]
```

You can see `crashed` with the detailed message. The benefit is that the analyzer can know what happened all in a single file, without looking at different folders. 

Proving run example:

```json
[
  {
    "name": "rpc_block_22756114-22756114",
    "block_used_gas": 34698073,
    "proving": {
      "success": {
        "proof_size": 1477199,
        "proving_time_ms": 734473
      }
    }
  }
]
```

note the new `proof_size` field.

As mentioned before in the bullets, the format of this output is:

```rust
/// Represents a single benchmark run.
#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
pub struct BenchmarkRun {
    /// Name of the benchmark.
    pub name: String,
    /// Block used gas
    pub block_used_gas: u64,
    /// Execution metrics for the benchmark run.
    #[serde(skip_serializing_if = "Option::is_none")]
    pub execution: Option<ExecutionMetrics>,
    /// Proving metrics for the benchmark run.
    #[serde(skip_serializing_if = "Option::is_none")]
    pub proving: Option<ProvingMetrics>,
}
```

so both `execution` and `proving` are top-level fields. They are optional depending on which action is passed to the tool. This potentially allows for supporting both in the same output file. The CLI still only asks for one action kind — didn’t want to add this feature yet to avoid making the PR bigger, but we can support it in a future PR.