### PR TITLE
ci: optimize checks

### DIFF
--- a/.github/workflows/rust_checks.yml
+++ b/.github/workflows/rust_checks.yml
@@ -20,19 +20,11 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy, rustfmt
-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
+      
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          key: base 
 
       - name: Check formatting
         run: cargo fmt --check --all
@@ -56,13 +48,9 @@ jobs:
   check-ere-host:
     name: Checks crate ere-hosts
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - zkvm: sp1
-          - zkvm: risc0
-          - zkvm: openvm
-          - zkvm: pico
-          - zkvm: zisk
+        zkvm: [sp1, risc0, openvm, pico, zisk]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -73,18 +61,10 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          key: ${{ matrix.zkvm }}
 
       - name: Cargo check (with ${{ matrix.zkvm }} enabled)
         run: cargo check --features ${{ matrix.zkvm }} -p ere-hosts

--- a/.github/workflows/rust_checks.yml
+++ b/.github/workflows/rust_checks.yml
@@ -1,7 +1,7 @@
 name: Rust Checks
 on:
   push:
-    branches: [ main, master, jsign-ci-cache ]
+    branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
 

--- a/.github/workflows/rust_checks.yml
+++ b/.github/workflows/rust_checks.yml
@@ -1,25 +1,20 @@
 name: Rust Checks
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main, master, jsign-ci-cache ]
   pull_request:
     branches: [ main, master ]
 
 env:
   CARGO_TERM_COLOR: always
 
-jobs:
+jobs: 
   check:
     name: Minimal checks on non-zkvm crates
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Download and Extract Fixtures
-        run: |
-          chmod +x ./scripts/download-and-extract-fixtures.sh
-          ./scripts/download-and-extract-fixtures.sh
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
@@ -45,6 +40,19 @@ jobs:
       - name: Run tests
         run: cargo test -p zkevm-metrics -p witness-generator -p ere-hosts
 
+  download-eest-fixtures:
+    name: Download and Extract Fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download and Extract Fixtures
+        run: |
+          chmod +x ./scripts/download-and-extract-fixtures.sh
+          ./scripts/download-and-extract-fixtures.sh
+
   check-ere-host:
     name: Checks crate ere-hosts
     strategy:
@@ -59,11 +67,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Download and Extract Fixtures
-        run: |
-          chmod +x ./scripts/download-and-extract-fixtures.sh
-          ./scripts/download-and-extract-fixtures.sh
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
This PR makes some optimizations in the CI pipeline to avoid duplicated tasks and optimize the cache usage, considering we rely heavily on feature flags.

Usual previous theoretically warm runs [take ~3.5m](https://github.com/eth-act/zkevm-benchmark-workload/actions/runs/15932909249), and [now run in 42s](https://github.com/eth-act/zkevm-benchmark-workload/actions/runs/15937628922?pr=90).