### PR TITLE
benchmark-runner: add flag to handle reruns & add a flag for output folder

### DIFF
--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -1,12 +1,16 @@
 use rayon::prelude::*;
-use std::{any::Any, panic, path::PathBuf, str::FromStr, sync::Arc};
+use std::{any::Any, panic, path::PathBuf, sync::Arc};
 use witness_generator::BlocksAndWitnesses;
 use zkevm_metrics::{BenchmarkRun, CrashInfo, ExecutionMetrics, HardwareInfo, ProvingMetrics};
 use zkvm_interface::{zkVM, Input};
 
+/// RunConfig holds the configuration for running benchmarks
 pub struct RunConfig {
+    /// Output folder where benchmark results will be stored
     pub output_folder: PathBuf,
+    /// Action to perform: either proving or executing
     pub action: Action,
+    /// Force rerun benchmarks even if output files already exist
     pub force_rerun: bool,
 }
 

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -5,6 +5,7 @@ use zkevm_metrics::{BenchmarkRun, CrashInfo, ExecutionMetrics, HardwareInfo, Pro
 use zkvm_interface::{zkVM, Input};
 
 pub struct RunConfig {
+    pub output_folder: PathBuf,
     pub action: Action,
     pub force_rerun: bool,
 }
@@ -25,10 +26,7 @@ pub fn run_benchmark_ere<V>(
 where
     V: zkVM + Sync,
 {
-    HardwareInfo::detect().to_path(format!(
-        "{}/zkevm-metrics/hardware.json",
-        env!("CARGO_WORKSPACE_DIR")
-    ))?;
+    HardwareInfo::detect().to_path(run_config.output_folder.join(&format!("hardware.json",)))?;
 
     println!("Benchmarking `{}`…", host_name);
     let zkvm_ref = Arc::new(&zkvm_instance);
@@ -72,12 +70,9 @@ where
     println!(" {} ({} blocks)", bw.name, blocks_and_witnesses.len());
     let mut reports = Vec::new();
 
-    let out_path = PathBuf::from_str(&format!(
-        "{}/zkevm-metrics/{}/{}.json",
-        env!("CARGO_WORKSPACE_DIR"),
-        host_name,
-        bw.name
-    ))?;
+    let out_path = run_config
+        .output_folder
+        .join(&format!("{}/{}.json", host_name, bw.name));
 
     for ci in blocks_and_witnesses {
         if !run_config.force_rerun && out_path.exists() {

--- a/crates/ere-hosts/readme.md
+++ b/crates/ere-hosts/readme.md
@@ -101,6 +101,18 @@ cargo run --features sp1 -- --action execute tests
 cargo run --features sp1 -- --action prove tests
 ```
 
+### Force Rerun
+
+By default, the benchmarker will skip tests that already have output files in the `zkevm-metrics/` directory to avoid redundant computation. Use `--force-rerun` to override this behavior:
+
+```bash
+# Skip tests that already have results (default behavior)
+cargo run --features sp1 -- tests
+
+# Rerun all tests, overwriting existing results
+cargo run --features sp1 -- --force-rerun tests
+```
+
 ### Combined Examples
 
 Run SP1 and OpenVM with GPU proving on RPC data:
@@ -121,12 +133,22 @@ cargo run --features "sp1,risc0,openvm,pico" -- \
   tests --directory-path ./my-test-files
 ```
 
+Force rerun all benchmarks for SP1 and RISC0, overwriting existing results:
+
+```bash
+cargo run --features "sp1,risc0" -- \
+  --force-rerun \
+  --action execute \
+  tests
+```
+
 ## Command Line Options
 
 | Option | Short | Description | Default | Values |
 |--------|-------|-------------|---------|---------|
 | `--resource` | `-r` | Choose compute resource type | `cpu` | `cpu`, `gpu` |
 | `--action` | `-a` | Select benchmark operation | `execute` | `execute`, `prove` |
+| `--force-rerun` | - | Rerun benchmarks even if output files already exist | `false` | `true`, `false` |
 | `--help` | `-h` | Show help information | - | - |
 | `--version` | `-V` | Show version information | - | - |
 

--- a/crates/ere-hosts/readme.md
+++ b/crates/ere-hosts/readme.md
@@ -113,6 +113,23 @@ cargo run --features sp1 -- tests
 cargo run --features sp1 -- --force-rerun tests
 ```
 
+### Output Folder Configuration
+
+By default, benchmark results are saved to the `zkevm-metrics/` directory. You can specify a custom output directory using the `--output-folder` flag:
+
+```bash
+# Use default output folder (zkevm-metrics/)
+cargo run --features sp1 -- tests
+
+# Use custom output folder
+cargo run --features sp1 -- --output-folder my-custom-results tests
+
+# Use absolute path
+cargo run --features sp1 -- --output-folder /tmp/benchmark-results tests
+```
+
+The benchmark results will be organized by zkVM type within the specified folder (e.g., `my-custom-results/sp1/`, `my-custom-results/risc0/`, etc.).
+
 ### Combined Examples
 
 Run SP1 and OpenVM with GPU proving on RPC data:
@@ -142,12 +159,22 @@ cargo run --features "sp1,risc0" -- \
   tests
 ```
 
+Run SP1 with custom output directory:
+
+```bash
+cargo run --features sp1 -- \
+  --output-folder custom-benchmarks \
+  --action execute \
+  tests
+```
+
 ## Command Line Options
 
 | Option | Short | Description | Default | Values |
 |--------|-------|-------------|---------|---------|
 | `--resource` | `-r` | Choose compute resource type | `cpu` | `cpu`, `gpu` |
 | `--action` | `-a` | Select benchmark operation | `execute` | `execute`, `prove` |
+| `--output-folder` | `-o` | Output folder for benchmark results | `zkevm-metrics` | Any valid directory path |
 | `--force-rerun` | - | Rerun benchmarks even if output files already exist | `false` | `true`, `false` |
 | `--help` | `-h` | Show help information | - | - |
 | `--version` | `-V` | Show version information | - | - |

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -39,6 +39,10 @@ struct Cli {
     #[arg(short, long, value_enum, default_value = "execute")]
     action: BenchmarkAction,
 
+    /// Rerun the benchmarks even if the output folder already contains results
+    #[arg(long, default_value_t = false)]
+    force_rerun: bool,
+
     /// Source of blocks and witnesses
     #[command(subcommand)]
     source: SourceCommand,
@@ -165,7 +169,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("sp1")?;
         let sp1_zkvm = new_sp1_zkvm(resource.clone())?;
-        run_benchmark_ere("sp1", sp1_zkvm, action, &corpuses)?;
+        run_benchmark_ere("sp1", sp1_zkvm, action, &corpuses, cli.force_rerun)?;
         ran_any = true;
     }
 
@@ -181,7 +185,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("risc0")?;
         let risc0_zkvm = new_risczero_zkvm(resource.clone())?;
-        run_benchmark_ere("risc0", risc0_zkvm, action, &corpuses)?;
+        run_benchmark_ere("risc0", risc0_zkvm, action, &corpuses, cli.force_rerun)?;
         ran_any = true;
     }
 
@@ -189,7 +193,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("openvm")?;
         let openvm_zkvm = new_openvm_zkvm(resource.clone())?;
-        run_benchmark_ere("openvm", openvm_zkvm, action, &corpuses)?;
+        run_benchmark_ere("openvm", openvm_zkvm, action, &corpuses, cli.force_rerun)?;
         ran_any = true;
     }
 
@@ -197,7 +201,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("pico")?;
         let pico_zkvm = new_pico_zkvm(resource.clone())?;
-        run_benchmark_ere("pico", pico_zkvm, action, &corpuses)?;
+        run_benchmark_ere("pico", pico_zkvm, action, &corpuses, cli.force_rerun)?;
         ran_any = true;
     }
 

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -7,7 +7,7 @@ use witness_generator::{
     witness_generator::WitnessGenerator,
 };
 
-use benchmark_runner::{Action, run_benchmark_ere};
+use benchmark_runner::{Action, RunConfig, run_benchmark_ere};
 
 use zkvm_interface::{Compiler, ProverResourceType};
 
@@ -165,11 +165,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set to true once a zkvm has ran
     let mut ran_any = false;
 
+    let run_config = RunConfig {
+        action,
+        force_rerun: cli.force_rerun,
+    };
+
     #[cfg(feature = "sp1")]
     {
         run_cargo_patch_command("sp1")?;
         let sp1_zkvm = new_sp1_zkvm(resource.clone())?;
-        run_benchmark_ere("sp1", sp1_zkvm, action, &corpuses, cli.force_rerun)?;
+        run_benchmark_ere("sp1", sp1_zkvm, &run_config, &corpuses)?;
         ran_any = true;
     }
 
@@ -177,7 +182,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("zisk")?;
         let zisk_zkvm = new_zisk_zkvm(resource.clone())?;
-        run_benchmark_ere("zisk", zisk_zkvm, action, &corpuses, cli.force_rerun)?;
+        run_benchmark_ere("zisk", zisk_zkvm, &run_config, &corpuses)?;
         ran_any = true;
     }
 
@@ -185,7 +190,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("risc0")?;
         let risc0_zkvm = new_risczero_zkvm(resource.clone())?;
-        run_benchmark_ere("risc0", risc0_zkvm, action, &corpuses, cli.force_rerun)?;
+        run_benchmark_ere("risc0", risc0_zkvm, &run_config, &corpuses)?;
         ran_any = true;
     }
 
@@ -193,7 +198,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("openvm")?;
         let openvm_zkvm = new_openvm_zkvm(resource.clone())?;
-        run_benchmark_ere("openvm", openvm_zkvm, action, &corpuses, cli.force_rerun)?;
+        run_benchmark_ere("openvm", openvm_zkvm, action, &run_config, &corpuses)?;
         ran_any = true;
     }
 
@@ -201,7 +206,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("pico")?;
         let pico_zkvm = new_pico_zkvm(resource.clone())?;
-        run_benchmark_ere("pico", pico_zkvm, action, &corpuses, cli.force_rerun)?;
+        run_benchmark_ere("pico", pico_zkvm, &run_config, &corpuses)?;
         ran_any = true;
     }
 

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -177,7 +177,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("zisk")?;
         let zisk_zkvm = new_zisk_zkvm(resource.clone())?;
-        run_benchmark_ere("zisk", zisk_zkvm, action, &corpuses)?;
+        run_benchmark_ere("zisk", zisk_zkvm, action, &corpuses, cli.force_rerun)?;
         ran_any = true;
     }
 

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -203,7 +203,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         run_cargo_patch_command("openvm")?;
         let openvm_zkvm = new_openvm_zkvm(resource.clone())?;
-        run_benchmark_ere("openvm", openvm_zkvm, action, &run_config, &corpuses)?;
+        run_benchmark_ere("openvm", openvm_zkvm, &run_config, &corpuses)?;
         ran_any = true;
     }
 

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -43,6 +43,10 @@ struct Cli {
     #[arg(long, default_value_t = false)]
     force_rerun: bool,
 
+    /// Output folder for benchmark results
+    #[arg(short, long, default_value = "zkevm-metrics")]
+    output_folder: PathBuf,
+
     /// Source of blocks and witnesses
     #[command(subcommand)]
     source: SourceCommand,
@@ -166,6 +170,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut ran_any = false;
 
     let run_config = RunConfig {
+        output_folder: cli.output_folder,
         action,
         force_rerun: cli.force_rerun,
     };


### PR DESCRIPTION
Yesterday, the prover we're using for running the benchmark suite crashed because of OOM. If we re-run the suite, it will start from scratch. 

This PR changes the behavior of `ere-hosts` in the following way:
- By default, if it detects that in the output folder the to-be-run case exists, it skips it and prints a message in stdout. (e.g. `Skipping tests/zkevm/test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_False-SSTORE same value]-2 (already exists)`)
- The user can provide a `--force-rerun` flag to override this default behavior.

I'm not sure which default behavior was the best. I suspect that if the user decides to keep an existing `zkevm-metrics` folder and rerun it, it is probably for a retry, since the most natural thing for a fresh run would be to delete the output folder (at least for me).

I also added a flag for controlling the output folder.

BTW, I suspect we'll need some opposite of `--filter`. That is, whenever we identify a benchmark case that crashes the prover, we'll probably want to use `--exclude <problematic_one>` or a similar option. But let's first reproduce the crash. (I realize now that existing `--filter` flag might not have the best name)