### PR TITLE
witness-generator: accept custom EEST folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Each zkVM benchmark implementation follows a common pattern:
     cd crates/witness-generator
     cargo run --release -- tests --include Prague --include cold
     
+    # Or generate from local EEST fixtures
+    cargo run --release -- tests --eest-fixtures-path /path/to/local/eest/fixtures
+    
     # Or generate from RPC
     cargo run --release -- rpc --last-n-blocks 2 --rpc-url <your-rpc-url>
     ```

--- a/crates/witness-generator/README.md
+++ b/crates/witness-generator/README.md
@@ -13,7 +13,7 @@ It defines the `BlocksAndWitnesses` struct which encapsulates:
 - The `ForkSpec` indicating the network rules under which the test was executed. It is needed for guest execution since we want to execute blocks on a particular network (Mainnet, Hoodi, etc).
 
 The binary provides different data sources:
-- **EEST (Execution Spec Tests)**: Processes blockchain test fixtures using `ef_tests::cases::blockchain_test::run_case`
+- **EEST (Execution Spec Tests)**: Processes blockchain test fixtures using `ef_tests::cases::blockchain_test::run_case`. Can use fixtures from a specific release tag or from a local directory path.
 - **RPC**: Pulls blocks directly from RPC endpoints and generates witnesses
 
 Each test case generates an individual JSON fixture file that can be consumed by the `ere-hosts` benchmark runner.
@@ -34,6 +34,9 @@ cargo run -- tests --tag v0.1.0
 # Include/exclude specific tests
 cargo run -- tests --include "Prague" --exclude "SSTORE"
 
+# Generate from local EEST fixtures path
+cargo run -- tests --eest-fixtures-path /path/to/local/eest/fixtures
+
 # Generate from RPC (last 5 blocks)
 cargo run -- rpc --last-n-blocks 5 --rpc-url "https://mainnet.infura.io/v3/YOUR_KEY"
 
@@ -43,6 +46,15 @@ cargo run -- rpc --block 20000000 --rpc-url "https://mainnet.infura.io/v3/YOUR_K
 # Custom output folder
 cargo run -- --output-folder my-fixtures tests
 ```
+
+### EEST Fixture Sources
+
+When using the `tests` subcommand, you have two options for specifying the source of EEST fixtures:
+
+1. **Release Tag** (default): Use `--tag` to specify a particular EEST release tag (e.g., "v0.1.0"). If no tag is specified, the latest release will be used.
+2. **Local Path**: Use `--eest-fixtures-path` to point to a local directory containing EEST fixture files.
+
+Note: The `--tag` and `--eest-fixtures-path` options are mutually exclusive - you can only use one at a time.
 
 ### Library Usage
 

--- a/crates/witness-generator/README.md
+++ b/crates/witness-generator/README.md
@@ -54,7 +54,12 @@ When using the `tests` subcommand, you have two options for specifying the sourc
 1. **Release Tag** (default): Use `--tag` to specify a particular EEST release tag (e.g., "v0.1.0"). If no tag is specified, the latest release will be used.
 2. **Local Path**: Use `--eest-fixtures-path` to point to a local directory containing EEST fixture files.
 
-Note: The `--tag` and `--eest-fixtures-path` options are mutually exclusive - you can only use one at a time.
+**Note:** The `--tag` and `--eest-fixtures-path` options are mutually exclusive - you can only use one at a time.
+
+**Example with local path:**
+```bash
+cargo run -- tests --eest-fixtures-path ./my-local-fixtures --include "Prague"
+```
 
 ### Library Usage
 

--- a/crates/witness-generator/src/main.rs
+++ b/crates/witness-generator/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
 use witness_generator::{
@@ -26,7 +26,7 @@ enum SourceCommand {
     /// Generate fixtures from execution specification tests
     Tests {
         /// EEST release tag to use (e.g., "v0.1.0"). If empty, the latest release will be used.
-        #[arg(short, long)]
+        #[arg(short, long, conflicts_with = "eest_fixtures_path")]
         tag: Option<String>,
 
         /// Include only test names containing the provided strings.   
@@ -36,6 +36,10 @@ enum SourceCommand {
         /// Exclude all test names containing the provided strings.
         #[arg(short, long)]
         exclude: Option<Vec<String>>,
+
+        /// Optional input folder for EEST files. If not provided, the tag rule will be used.
+        #[arg(short, long, conflicts_with = "tag")]
+        eest_fixtures_path: Option<PathBuf>,
     },
     /// Generate fixtures from an RPC endpoint
     Rpc {
@@ -94,12 +98,23 @@ async fn build_generator(source: SourceCommand) -> Result<Box<dyn WitnessGenerat
             tag,
             include,
             exclude,
+            eest_fixtures_path,
         } => {
-            let mut builder = ExecSpecTestBlocksAndWitnessBuilder::new();
+            let mut builder = ExecSpecTestBlocksAndWitnessBuilder::default();
 
-            if let Some(tag) = tag {
-                builder = builder.with_tag(tag);
+            match (tag, eest_fixtures_path) {
+                (Some(tag), None) => {
+                    builder = builder.with_tag(tag);
+                }
+                (None, None) => {} // No tag or input folder provided, use latest release
+                (None, Some(input_folder)) => {
+                    builder = builder.with_input_folder(input_folder);
+                }
+                (Some(_), Some(_)) => {
+                    bail!("Cannot provide both tag and eest_input_folder")
+                }
             }
+
             if let Some(include) = include {
                 builder = builder.with_includes(include);
             }


### PR DESCRIPTION
This PR adds a new flag in the `tests` command to provide a custom folder for EEST fixtures, since now the only option was using the script to download the latest or provided tag.

I wanted this feature since I was testing a custom filling for Osaka, and wanted to use my own EEST folder rather than using the script.