### PR TITLE
chore: use tracing for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,5 +146,7 @@ jsonrpsee = "0.25.1"
 anyhow = "1.0"
 async-trait = "0.1.88"
 tokio = { version = "1.45.1" }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [patch.crates-io]

--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -8,4 +8,5 @@ rayon.workspace = true
 witness-generator.workspace = true
 zkevm-metrics.workspace = true
 zkvm-interface.workspace = true
+tracing.workspace = true
 anyhow = "*"

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -1,5 +1,6 @@
 use rayon::prelude::*;
 use std::{any::Any, panic, path::PathBuf, sync::Arc};
+use tracing::info;
 use witness_generator::BlocksAndWitnesses;
 use zkevm_metrics::{BenchmarkRun, CrashInfo, ExecutionMetrics, HardwareInfo, ProvingMetrics};
 use zkvm_interface::{zkVM, Input};
@@ -32,7 +33,7 @@ where
 {
     HardwareInfo::detect().to_path(run_config.output_folder.join(&format!("hardware.json",)))?;
 
-    println!("Benchmarking `{}`…", host_name);
+    info!("Benchmarking `{}`…", host_name);
     let zkvm_ref = Arc::new(&zkvm_instance);
 
     match run_config.action {
@@ -66,7 +67,7 @@ where
         .join(&format!("{}/{}.json", host_name, bw.name));
 
     if !run_config.force_rerun && out_path.exists() {
-        println!("Skipping {} (already exists)", bw.name);
+        info!("Skipping {} (already exists)", bw.name);
         return Ok(());
     }
 
@@ -76,7 +77,7 @@ where
     stdin.write(bw.block_and_witness.clone());
     stdin.write(bw.network);
 
-    println!("Running {}", bw.name);
+    info!("Running {}", bw.name);
     let (execution, proving) = match run_config.action {
         Action::Execute => {
             let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm_ref.execute(&stdin)));
@@ -119,7 +120,7 @@ where
         proving,
     };
 
-    println!("Saving report for {}", bw.name);
+    info!("Saving report for {}", bw.name);
     BenchmarkRun::to_path(out_path, &vec![report])?;
 
     Ok(())

--- a/crates/ere-hosts/Cargo.toml
+++ b/crates/ere-hosts/Cargo.toml
@@ -20,6 +20,8 @@ walkdir.workspace = true
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 benchmark-runner.workspace = true
 zkvm-interface.workspace = true

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -4,6 +4,7 @@ use clap::{Parser, ValueEnum};
 use rayon::prelude::*;
 use std::{path::PathBuf, process::Command};
 use tracing::{error, info};
+use tracing_subscriber::EnvFilter;
 use walkdir::WalkDir;
 
 use witness_generator::BlocksAndWitnesses;
@@ -86,7 +87,7 @@ impl From<BenchmarkAction> for Action {
 /// Main entry point for the host benchmarker
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
-        .with_env_filter("info,sp1_core_executor=warn,sp1_prover=warn")
+        .with_env_filter(EnvFilter::from_default_env())
         .init();
     let cli = Cli::parse();
 

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -3,6 +3,7 @@
 use clap::{Parser, ValueEnum};
 use rayon::prelude::*;
 use std::{path::PathBuf, process::Command};
+use tracing::{error, info};
 use walkdir::WalkDir;
 
 use witness_generator::BlocksAndWitnesses;
@@ -84,12 +85,15 @@ impl From<BenchmarkAction> for Action {
 
 /// Main entry point for the host benchmarker
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info,sp1_core_executor=warn,sp1_prover=warn")
+        .init();
     let cli = Cli::parse();
 
     let resource: ProverResourceType = cli.resource.into();
     let action: Action = cli.action.into();
 
-    println!("Loading corpuses from: {}", cli.input_folder.display());
+    info!("Loading corpuses from: {}", cli.input_folder.display());
     let corpuses = WalkDir::new(&cli.input_folder)
         .min_depth(1)
         .into_iter()
@@ -117,7 +121,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         force_rerun: cli.force_rerun,
     };
 
-    println!("Running benchmarks with resource: {:?}", resource);
+    info!("Running benchmarks with resource: {:?}", resource);
     #[cfg(feature = "sp1")]
     {
         run_cargo_patch_command("sp1")?;
@@ -210,7 +214,7 @@ fn new_pico_zkvm(
 
 /// Patches the precompiles for a specific zkvm
 fn run_cargo_patch_command(zkvm_name: &str) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Running cargo {}...", zkvm_name);
+    info!("Running cargo {}...", zkvm_name);
 
     let output = Command::new("cargo").arg(zkvm_name).output()?;
 
@@ -218,17 +222,17 @@ fn run_cargo_patch_command(zkvm_name: &str) -> Result<(), Box<dyn std::error::Er
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stdout = String::from_utf8_lossy(&output.stdout);
 
-        eprintln!(
+        error!(
             "cargo {} failed with exit code: {:?}",
             zkvm_name,
             output.status.code()
         );
-        eprintln!("stdout: {}", stdout);
-        eprintln!("stderr: {}", stderr);
+        error!("stdout: {}", stdout);
+        error!("stderr: {}", stderr);
 
         return Err(format!("cargo {} command failed", zkvm_name).into());
     }
 
-    println!("cargo {} completed successfully", zkvm_name);
+    info!("cargo {} completed successfully", zkvm_name);
     Ok(())
 }

--- a/crates/witness-generator/Cargo.toml
+++ b/crates/witness-generator/Cargo.toml
@@ -6,9 +6,24 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-ef-tests.workspace = true
 walkdir.workspace = true
 rayon.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+jsonrpsee.workspace = true
+http = "1.0"
+anyhow.workspace = true
+tokio.workspace = true
+clap.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+alloy-eips = { workspace = true }
+alloy-rpc-types-eth.workspace = true
+alloy-primitives = { workspace = true, features = ["serde"] }
+ef-tests.workspace = true
 reth-stateless.workspace = true
 reth-ethereum-primitives = { workspace = true, features = [
     "serde",
@@ -18,20 +33,8 @@ reth-primitives-traits = { workspace = true, features = [
     "serde",
     "serde-bincode-compat",
 ] }
-serde.workspace = true
-serde_json.workspace = true
-thiserror.workspace = true
-async-trait.workspace = true
 reth-chainspec.workspace = true
-alloy-primitives = { workspace = true, features = ["serde"] }
 reth-rpc-api = { workspace = true, features = ["client"] }
-jsonrpsee.workspace = true
-http = "1.0"
-alloy-eips = { workspace = true }
-anyhow.workspace = true
-alloy-rpc-types-eth.workspace = true
-tokio.workspace = true
-clap.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/witness-generator/src/eest_generator.rs
+++ b/crates/witness-generator/src/eest_generator.rs
@@ -10,6 +10,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
+use tracing::error;
 use walkdir::{DirEntry, WalkDir};
 
 use crate::{BlocksAndWitnesses, blocks_and_witnesses::WitnessGenerator};
@@ -110,7 +111,7 @@ impl Drop for ExecSpecTestBlocksAndWitnesses {
         if self.delete_eest_folder && self.directory_path.exists() {
             match std::fs::remove_dir_all(&self.directory_path) {
                 Ok(_) => {}
-                Err(e) => eprintln!(
+                Err(e) => error!(
                     "Failed to remove directory {}: {}",
                     self.directory_path.display(),
                     e
@@ -137,7 +138,7 @@ impl WitnessGenerator for ExecSpecTestBlocksAndWitnesses {
             let test_case = match BlockchainTestCase::load(&path) {
                 Ok(case) => case,
                 Err(e) => {
-                    eprintln!("Failed to load test case from {}: {e}", path.display());
+                    error!("Failed to load test case from {}: {e}", path.display());
                     continue;
                 }
             };

--- a/crates/witness-generator/src/main.rs
+++ b/crates/witness-generator/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result, anyhow};
 use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
 use tracing::info;
+use tracing_subscriber::EnvFilter;
 use witness_generator::{
     WitnessGenerator,
     eest_generator::ExecSpecTestBlocksAndWitnessBuilder,
@@ -64,7 +65,9 @@ enum SourceCommand {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt().with_env_filter("info").init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
     let cli = Cli::parse();
 
     info!("Generating fixtures in folder: {:?}", cli.output_folder);

--- a/crates/witness-generator/src/main.rs
+++ b/crates/witness-generator/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, anyhow};
 use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
+use tracing::info;
 use witness_generator::{
     WitnessGenerator,
     eest_generator::ExecSpecTestBlocksAndWitnessBuilder,
@@ -63,9 +64,10 @@ enum SourceCommand {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
     let cli = Cli::parse();
 
-    println!("Generating fixtures in folder: {:?}", cli.output_folder);
+    info!("Generating fixtures in folder: {:?}", cli.output_folder);
     if !cli.output_folder.exists() {
         std::fs::create_dir_all(&cli.output_folder)
             .with_context(|| format!("Failed to create output folder: {:?}", cli.output_folder))?;
@@ -73,22 +75,22 @@ async fn main() -> Result<()> {
 
     let generator: Box<dyn WitnessGenerator> = build_generator(cli.source).await?;
 
-    println!("Generating fixtures...");
+    info!("Generating fixtures...");
     let bws = generator
         .generate()
         .await
         .context("Failed to generate blocks and witnesses")?;
 
-    println!("Generated {} blocks and witnesses", bws.len());
+    info!("Generated {} blocks and witnesses", bws.len());
 
     if bws.is_empty() {
-        println!("No blocks and witnesses generated. Exiting.");
+        info!("No blocks and witnesses generated. Exiting.");
         return Ok(());
     }
 
     write_fixtures_to_disk(&cli.output_folder, &bws).context("Failed to write fixtures to disk")?;
 
-    println!("Fixtures written successfully.");
+    info!("Fixtures written successfully.");
     Ok(())
 }
 
@@ -155,7 +157,7 @@ fn write_fixtures_to_disk(
     output_folder: &Path,
     bws: &[witness_generator::BlocksAndWitnesses],
 ) -> Result<()> {
-    println!("Writing fixtures to output folder...");
+    info!("Writing fixtures to output folder...");
 
     for bw in bws {
         let output_path = output_folder.join(format!("{}.json", bw.name));


### PR DESCRIPTION
Fixes #95 

Example:
```
$ cargo run --release -p witness-generator tests --include Prague --include cold
   Compiling witness-generator v0.1.0 (/home/ignacio/code/zkevm-benchmark-workload/crates/witness-generator)
    Finished `release` profile [optimized] target(s) in 5.83s
     Running `target/release/witness-generator tests --include Prague --include cold`
2025-07-01T14:36:38.232563Z  INFO witness_generator: Generating fixtures in folder: "zkevm-fixtures-input"
2025-07-01T14:36:40.964797Z  INFO witness_generator: Generating fixtures...
2025-07-01T14:36:41.071549Z ERROR witness_generator::eest_generator: Failed to load test case from ./zkevm-fixtures/fixtures/blockchain_tests/prague/eip2537_bls_12_381_precompiles/bls12_precompiles_before_fork/precompile_before_fork.json: an error occurred deserializing the test at ./zkevm-fixtures/fixtures/blockchain_tests/prague/eip2537_bls_12_381_precompiles/bls12_precompiles_before_fork/precompile_before_fork.json: unknown variant `CancunToPragueAtTime15k`, expected one of `Frontier`, `FrontierToHomesteadAt5`, `Homestead`, `HomesteadToDaoAt5`, `HomesteadToEIP150At5`, `EIP150`, `EIP158`, `EIP158ToByzantiumAt5`, `Byzantium`, `ByzantiumToConstantinopleAt5`, `ByzantiumToConstantinopleFixAt5`, `Constantinople`, `ConstantinopleFix`, `Istanbul`, `Berlin`, `BerlinToLondonAt5`, `London`, `Merge`, `Shanghai`, `Merge+3540+3670`, `MergeEOF`, `Merge+3860`, `MergeMeterInitCode`, `Merge+3855`, `MergePush0`, `Cancun`, `Prague` at line 3 column 44
2025-07-01T14:36:41.758787Z  INFO witness_generator: Generated 8 blocks and witnesses
2025-07-01T14:36:41.758804Z  INFO witness_generator: Writing fixtures to output folder...
2025-07-01T14:36:41.791668Z  INFO witness_generator: Fixtures written successfully.
```
Note the `ERROR` is expected -- that test will go away in a future release since we removed it from EEST now, but it serves as an example for logging output now.

Then:
```
$ cargo run --release -p ere-hosts --features sp1                               
2025-07-01T14:38:07.487298Z  INFO ere_hosts: Loading corpuses from: zkevm-fixtures-input
2025-07-01T14:38:07.501608Z  INFO ere_hosts: Running benchmarks with resource: Cpu
2025-07-01T14:38:07.501628Z  INFO ere_hosts: Running cargo sp1...
2025-07-01T14:38:07.983954Z  INFO ere_hosts: cargo sp1 completed successfully
2025-07-01T14:38:07.983980Z  INFO ere_succinct::compile: Compiling SP1 program at /home/ignacio/code/zkevm-benchmark-workload/ere-guests/sp1
2025-07-01T14:38:07.984102Z  INFO ere_succinct::compile: Parsed program name: succinct-guest
2025-07-01T14:38:07.984178Z  INFO ere_succinct::compile: Running `cargo prove build` → dir: /home/ignacio/code/zkevm-benchmark-workload/ere-guests/sp1/.tmp3claf6, ELF: succinct-guest.elf
cargo:warning=rustc +succinct --version: "rustc 1.87.0-dev\n"
[sp1]  warning: Patch `sha2 v0.10.8 (https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388)` was not used in the crate graph.
[sp1]  Check that the patched package version and available features are compatible
[sp1]  with the dependency requirements. If the patch has a different version from
[sp1]  what is locked in the Cargo.lock file, run `cargo update` to use the new
[sp1]  version. This may also occur with an optional dependency that is not enabled.
[sp1]      Blocking waiting for file lock on package cache
[sp1]      Blocking waiting for file lock on package cache
[sp1]      Blocking waiting for file lock on package cache
[sp1]      Finished `release` profile [optimized] target(s) in 0.92s
cargo:rustc-env=SP1_ELF_succinct-guest=/home/ignacio/code/zkevm-benchmark-workload/target/elf-compilation/riscv32im-succinct-zkvm-elf/release/succinct-guest
2025-07-01T14:38:11.793944Z  INFO ere_succinct::compile: SP1 program compiled OK – 5054280 bytes
2025-07-01T14:38:18.385314Z  INFO benchmark_runner: Benchmarking `sp1`…
2025-07-01T14:38:18.385454Z  INFO benchmark_runner: Running test_worst_stateful_opcodes.py::test_worst_address_state_cold[fork_Prague-blockchain_test-absent_accounts_True-opcode_BALANCE]
2025-07-01T14:38:18.385549Z  INFO benchmark_runner: Running test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_True-SSTORE new value]
2025-07-01T14:38:18.385716Z  INFO benchmark_runner: Running test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_True-SSTORE same value]
2025-07-01T14:38:18.386228Z  INFO benchmark_runner: Running test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_False-SSTORE new value]
2025-07-01T14:38:18.386266Z  INFO benchmark_runner: Running test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_True-SSLOAD]
2025-07-01T14:38:18.386408Z  INFO benchmark_runner: Running test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_False-SSLOAD]
2025-07-01T14:38:18.386827Z  INFO benchmark_runner: Running test_worst_stateful_opcodes.py::test_worst_address_state_cold[fork_Prague-blockchain_test-absent_accounts_False-opcode_BALANCE]
2025-07-01T14:38:18.386869Z  INFO benchmark_runner: Running test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_False-SSTORE same value]
2025-07-01T14:38:44.008969Z  INFO benchmark_runner: Saving report for test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_True-SSTORE new value]
2025-07-01T14:38:46.281047Z  INFO benchmark_runner: Saving report for test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_True-SSTORE same value]
2025-07-01T14:38:49.897701Z  INFO benchmark_runner: Saving report for test_worst_stateful_opcodes.py::test_worst_address_state_cold[fork_Prague-blockchain_test-absent_accounts_True-opcode_BALANCE]
2025-07-01T14:38:51.402356Z  INFO benchmark_runner: Saving report for test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_True-SSLOAD]
2025-07-01T14:38:53.600583Z  INFO benchmark_runner: Saving report for test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_False-SSTORE new value]
2025-07-01T14:39:01.869490Z  INFO benchmark_runner: Saving report for test_worst_stateful_opcodes.py::test_worst_address_state_cold[fork_Prague-blockchain_test-absent_accounts_False-opcode_BALANCE]
2025-07-01T14:39:06.229883Z  INFO benchmark_runner: Saving report for test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_False-SSTORE same value]
2025-07-01T14:39:07.003703Z  INFO benchmark_runner: Saving report for test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Prague-blockchain_test-absent_slots_False-SSLOAD]
```
(Note the SHA2 patch seems to be unnecessary now -- maybe related to a recent Reth upgrade)

In the code changes you'll see some tracing defaults: I had to downgrade sp1 tracing to `warn` since they've many noisy info levels like:
```
2025-07-01T14:30:05.055780Z  INFO execute: sp1_core_executor::executor: clk = 50000000 pc = 0x2e632c
2025-07-01T14:30:05.104719Z  INFO execute: sp1_core_executor::executor: clk = 50000000 pc = 0x2decec
2025-07-01T14:30:05.121017Z  INFO execute: sp1_core_executor::executor: clk = 50000000 pc = 0x2e6300
2025-07-01T14:30:05.156850Z  INFO execute: sp1_core_executor::executor: clk = 60000000 pc = 0x2dee5c
```
If the user is interested, it can control this via `RUST_LOG`. I've the sensation will keep discovering nosily logs in other zkVMs but we can keep adding sane defaults as we discover them.