### PR TITLE
witness-generator: add follow feature

### DIFF
--- a/crates/witness-generator/Cargo.toml
+++ b/crates/witness-generator/Cargo.toml
@@ -32,6 +32,7 @@ anyhow.workspace = true
 alloy-rpc-types-eth.workspace = true
 tokio.workspace = true
 clap.workspace = true
+tokio-util = "0.7.15"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/witness-generator/src/blocks_and_witnesses.rs
+++ b/crates/witness-generator/src/blocks_and_witnesses.rs
@@ -100,4 +100,11 @@ pub trait WitnessGenerator {
     /// Returns an error if the generation process fails, including network issues,
     /// file I/O problems, or data processing errors.
     async fn generate(&self) -> Result<Vec<BlocksAndWitnesses>>;
+
+    /// Generates `BlocksAndWitnesses` and writes them to the specified path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the generation fails or if writing to the path fails.
+    async fn generate_to_path(&self, path: &Path) -> Result<usize>;
 }

--- a/crates/witness-generator/src/eest_generator.rs
+++ b/crates/witness-generator/src/eest_generator.rs
@@ -178,6 +178,19 @@ impl WitnessGenerator for ExecSpecTestBlocksAndWitnesses {
 
         bws
     }
+
+    async fn generate_to_path(&self, path: &Path) -> Result<usize> {
+        let bws = self.generate().await?;
+        for bw in &bws {
+            let output_path = path.join(format!("{}.json", bw.name));
+            let output_data = serde_json::to_string_pretty(&bw)
+                .with_context(|| format!("Failed to serialize fixture: {}", bw.name))?;
+
+            std::fs::write(&output_path, output_data)
+                .with_context(|| format!("Failed to write fixture to: {output_path:?}"))?;
+        }
+        Ok(bws.len())
+    }
 }
 
 /// Recursively finds all files within `path` that end with `extension`.


### PR DESCRIPTION
This PR adds a new feature `--follow` to the `rpc` generator, which more smartly follows the targeted chain to minimize RPC calls.

This was an ask from https://github.com/ethereum/devops/issues/1826 since they weren't fully convinced of the kind of polling available before.

Example of usage:
```
$ cargo run -p witness-generator --release -- rpc --follow --rpc-url <redacted> 
Generating fixtures in folder: "zkevm-fixtures-input"
Generating fixtures...
^CStopping...
Generated 4 blocks and witnesses
```
It runs until Ctrl+C as a stop signal.

Pending:
- [ ] Dockerfile
- [ ] Cleanup, method comments, and README.md documentation