### PR TITLE
ci: fix docker building

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./crates/witness-generator/Dockerfile
+          file: ./crates/witness-generator-cli/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
[Fix the CI building the Docker image](https://github.com/eth-act/zkevm-benchmark-workload/actions/runs/16129848928/job/45514989069). We didn't catch this because it only runs in `master`.