### PR TITLE
Use zkVM name + sdk version as full names for outputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,12 +112,12 @@ witness-generator = { path = "crates/witness-generator" }
 zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.3", package = "zkvm-interface" }
-ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.3", package = "ere-sp1" }
-ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.3", package = "ere-risczero" }
-ere-pico = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.3", package = "ere-pico" }
-ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.3", package = "ere-openvm" }
-ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.3", package = "ere-zisk" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "c0b5f4dd53c0c9917135bebfe48489918942ef26", package = "zkvm-interface" }
+ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", rev = "c0b5f4dd53c0c9917135bebfe48489918942ef26", package = "ere-sp1" }
+ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", rev = "c0b5f4dd53c0c9917135bebfe48489918942ef26", package = "ere-risczero" }
+ere-pico = { git = "https://github.com/eth-applied-research-group/ere", rev = "c0b5f4dd53c0c9917135bebfe48489918942ef26", package = "ere-pico" }
+ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", rev = "c0b5f4dd53c0c9917135bebfe48489918942ef26", package = "ere-openvm" }
+ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", rev = "c0b5f4dd53c0c9917135bebfe48489918942ef26", package = "ere-zisk" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -131,8 +131,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(feature = "sp1")]
         {
             run_cargo_patch_command("sp1")?;
-            let sp1_zkvm = new_sp1_zkvm(resource.clone())?;
-            run_benchmark_ere("sp1", sp1_zkvm, &run_config, &corpuses)?;
+            let zkvm = new_sp1_zkvm(resource.clone())?;
+            let fullname = zkvm_fullname(ere_sp1::NAME, ere_sp1::SDK_VERSION);
+            info!("zkVM full name: {:?}", fullname);
+            run_benchmark_ere(&fullname, zkvm, &run_config, &corpuses)?;
             ran_any = true;
         }
 
@@ -242,4 +244,8 @@ fn run_cargo_patch_command(zkvm_name: &str) -> Result<(), Box<dyn std::error::Er
 
     info!("cargo {zkvm_name} completed successfully");
     Ok(())
+}
+
+fn zkvm_fullname(zkvm_name: &str, zkvm_version: &str) -> String {
+    format!("{}-v{}", zkvm_name, zkvm_version)
 }


### PR DESCRIPTION
This PR changes the current way zkVM output folders are named, also to include the corresponding SDK version.

Please see xxx on how `ere` helps into doing this without manual maintenance.

If we run with this implementation, here's an example output result:
```
zkevm-metrics
├── hardware.json
└── sp1-v5.0.6
    ├── rpc_block_22870191.json
    ├── test_worst_bytecode.py::test_worst_creates_collisions[fork_Cancun-blockchain_test_from_state_test-opcode_CREATE2].json
    └── test_worst_bytecode.py::test_worst_creates_collisions[fork_Cancun-blockchain_test_from_state_test-opcode_CREATE].json
```

Note that instead of the previous `sp1` folder naming, now it is `sp1-v5.0.6`. 

This will help when we aggregate results from multiple provers without risking misinterpreting results for different SDKs, since maintaining the latest version on multiple machines is error-prone.

Note: the `ere` version used now is referencing the ere PR. Before merging, it should be using a newly created release tag.