### PR TITLE
metrics: add timestamp

### DIFF
--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -10,6 +10,7 @@ zkevm-metrics.workspace = true
 zkvm-interface.workspace = true
 tracing.workspace = true
 anyhow = "*"
+chrono = "0.4.41"
 
 [lints]
 workspace = true

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -123,6 +123,7 @@ where
     };
     let report = BenchmarkRun {
         name: format!("{}-{}", bw.name, block_number),
+        end_timestamp: chrono::Utc::now(),
         block_used_gas,
         execution,
         proving,

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -123,7 +123,7 @@ where
     };
     let report = BenchmarkRun {
         name: format!("{}-{}", bw.name, block_number),
-        end_timestamp: chrono::Utc::now(),
+        timestamp_completed: chrono::Utc::now(),
         block_used_gas,
         execution,
         proving,

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -11,6 +11,7 @@ thiserror.workspace = true
 serde_json.workspace = true
 serde_derive.workspace = true
 sysinfo = "0.26"
+chrono = { version = "0.4.41", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -11,6 +11,8 @@ use thiserror::Error;
 pub struct BenchmarkRun {
     /// Name of the benchmark.
     pub name: String,
+    /// Timestamp when the benchmark run ended.
+    pub end_timestamp: chrono::DateTime<chrono::Utc>,
     /// Block used gas
     pub block_used_gas: u64,
     /// Execution metrics for the benchmark run.
@@ -218,6 +220,7 @@ mod tests {
         vec![
             BenchmarkRun {
                 name: "fft_bench".into(),
+                end_timestamp: chrono::Utc::now(),
                 block_used_gas: 12345,
                 execution: Some(ExecutionMetrics::Success {
                     total_num_cycles: 1_000,
@@ -232,6 +235,7 @@ mod tests {
             },
             BenchmarkRun {
                 name: "aes_bench".into(),
+                end_timestamp: chrono::Utc::now(),
                 block_used_gas: 67890,
                 execution: Some(ExecutionMetrics::Success {
                     total_num_cycles: 2_000,
@@ -249,6 +253,7 @@ mod tests {
             },
             BenchmarkRun {
                 name: "proving_bench".into(),
+                end_timestamp: chrono::Utc::now(),
                 block_used_gas: 54321,
                 execution: None,
                 proving: Some(ProvingMetrics::Success {
@@ -289,6 +294,7 @@ mod tests {
     fn test_name_accessor() {
         let benchmark_run = BenchmarkRun {
             name: "test_benchmark".into(),
+            end_timestamp: chrono::Utc::now(),
             block_used_gas: 11111,
             execution: Some(ExecutionMetrics::Success {
                 total_num_cycles: 1000,
@@ -305,6 +311,7 @@ mod tests {
     fn test_mixed_metrics_serialization() {
         let bench = BenchmarkRun {
             name: "mixed_bench".into(),
+            end_timestamp: chrono::Utc::now(),
             block_used_gas: 22222,
             execution: Some(ExecutionMetrics::Success {
                 total_num_cycles: 500,

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -12,7 +12,7 @@ pub struct BenchmarkRun {
     /// Name of the benchmark.
     pub name: String,
     /// Timestamp when the benchmark run ended.
-    pub end_timestamp: chrono::DateTime<chrono::Utc>,
+    pub timestamp_completed: chrono::DateTime<chrono::Utc>,
     /// Block used gas
     pub block_used_gas: u64,
     /// Execution metrics for the benchmark run.
@@ -220,7 +220,7 @@ mod tests {
         vec![
             BenchmarkRun {
                 name: "fft_bench".into(),
-                end_timestamp: chrono::Utc::now(),
+                timestamp_completed: chrono::Utc::now(),
                 block_used_gas: 12345,
                 execution: Some(ExecutionMetrics::Success {
                     total_num_cycles: 1_000,
@@ -235,7 +235,7 @@ mod tests {
             },
             BenchmarkRun {
                 name: "aes_bench".into(),
-                end_timestamp: chrono::Utc::now(),
+                timestamp_completed: chrono::Utc::now(),
                 block_used_gas: 67890,
                 execution: Some(ExecutionMetrics::Success {
                     total_num_cycles: 2_000,
@@ -253,7 +253,7 @@ mod tests {
             },
             BenchmarkRun {
                 name: "proving_bench".into(),
-                end_timestamp: chrono::Utc::now(),
+                timestamp_completed: chrono::Utc::now(),
                 block_used_gas: 54321,
                 execution: None,
                 proving: Some(ProvingMetrics::Success {
@@ -294,7 +294,7 @@ mod tests {
     fn test_name_accessor() {
         let benchmark_run = BenchmarkRun {
             name: "test_benchmark".into(),
-            end_timestamp: chrono::Utc::now(),
+            timestamp_completed: chrono::Utc::now(),
             block_used_gas: 11111,
             execution: Some(ExecutionMetrics::Success {
                 total_num_cycles: 1000,
@@ -311,7 +311,7 @@ mod tests {
     fn test_mixed_metrics_serialization() {
         let bench = BenchmarkRun {
             name: "mixed_bench".into(),
-            end_timestamp: chrono::Utc::now(),
+            timestamp_completed: chrono::Utc::now(),
             block_used_gas: 22222,
             execution: Some(ExecutionMetrics::Success {
                 total_num_cycles: 500,


### PR DESCRIPTION
Add a `timestamp_completed` field so we know when a run was executed.