### PR TITLE
Patches zisk more

### DIFF
--- a/ere-guests/stateless-validator/zisk/Cargo.toml
+++ b/ere-guests/stateless-validator/zisk/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-ziskos = { git = "https://github.com/0xPolygonHermez/zisk.git", rev = "f9a3655" }
+ziskos = { git = "https://github.com/0xPolygonHermez/zisk.git" }
 bincode.workspace = true
 reth-stateless.workspace = true
 reth-ethereum-primitives = { workspace = true, features = [
@@ -17,10 +17,14 @@ reth-primitives-traits = { workspace = true, features = [
     "serde",
     "serde-bincode-compat",
 ] }
+revm = { version = "26.0.1", default-features = false, features = [
+    "kzg-rs",
+    "bn",
+] }
 alloy-primitives = { workspace = true, default-features = false, features = [
     "map-foldhash",
     "serde",
-    "tiny-keccak",
+    "sha3-keccak",
 ] }
 reth-evm-ethereum = { workspace = true }
 reth-chainspec = { workspace = true }

--- a/precompile-patches/zisk.toml
+++ b/precompile-patches/zisk.toml
@@ -1,2 +1,7 @@
+# Copied from https://github.com/0xPolygonHermez/zisk-eth-client/blob/main/bin/client/Cargo.toml
 [patch.crates-io]
-tiny-keccak = { git = "https://github.com/0xPolygonHermez/zisk-patch-tiny-keccak.git", branch = "zisk" }
+sha2 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", branch = "zisk-patch-sha2/v0.10.9" }
+sha3 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", branch = "zisk-patch-sha3/v0.10.8" }
+k256 = { git = "https://github.com/0xPolygonHermez/zisk-patch-elliptic-curves.git", branch = "zisk-patch-k256/v0.13.4" }
+bn = { git = "https://github.com/0xPolygonHermez/zisk-patch-bn.git", branch = "zisk-patch-bn/v0.6.0", package = "substrate-bn" }
+sp1_bls12_381 = { git = "https://github.com/0xPolygonHermez/zisk-patch-bls12_381.git", branch = "zisk-patch/v0.8.0" }


### PR DESCRIPTION
- Patches is copied from https://github.com/0xPolygonHermez/zisk-eth-client/blob/main/bin/client/Cargo.toml
- Now it doesn't compile because there is a version conflict like this:
  ```
  error: failed to select a version for `p3-baby-bear`.
      ... required by package `sp1-primitives v4.0.0`
      ... which satisfies dependency `sp1-primitives = "^4.0.0"` of package `sp1-lib v4.0.0`
      ... which satisfies dependency `sp1-lib = "^4.0.0"` of package `sp1_bls12_381 v0.8.0-sp1-5.0.0 (https://github.com/0xPolygonHermez/zisk-patch-bls12_381.git?branch=zisk-patch%2Fv0.8.0#128623e8)`
      ... which satisfies dependency `bls12_381 = "=0.8.0-sp1-5.0.0"` (locked to 0.8.0-sp1-5.0.0) of package `kzg-rs v0.2.7`
      ... which satisfies dependency `kzg-rs = "^0.2.7"` (locked to 0.2.7) of package `revm-precompile v23.0.0`
      ... which satisfies dependency `precompile = "^23.0.0"` (locked to 23.0.0) of package `revm v26.0.1`
      ... which satisfies dependency `revm = "^26.0.1"` (locked to 26.0.1) of package `risc0-guest v0.1.0 (/home/han/playground/arg/zkevm-benchmark-workload/ere-guests/stateless-validator/risc0/guest)`
  versions that meet the requirements `=0.2.0-succinct` are: 0.2.0-succinct

  all possible versions conflict with previously selected packages.

    previously selected package `p3-baby-bear v0.2.3-succinct`
      ... which satisfies dependency `p3-baby-bear = "=0.2.3-succinct"` (locked to 0.2.3-succinct) of package `sp1-primitives v5.0.8`
      ... which satisfies dependency `sp1-primitives = "^5.0.5"` (locked to 5.0.8) of package `sp1-zkvm v5.0.8`
      ... which satisfies dependency `sp1-zkvm = "^5.0.5"` (locked to 5.0.8) of package `succinct-empty-guest v0.1.0 (/home/han/playground/arg/zkevm-benchmark-workload/ere-guests/empty-program/sp1)`

  failed to select a version for `p3-baby-bear` which could resolve this conflict
  ```
  It seems Rust patching doesn't patch the patched crates, so it seems we could only wait for https://github.com/0xPolygonHermez/zisk-patch-bls12_381 to upgrade `sp1-lib` dep to `^5.0.0`, not sure if there is other trick to overcome this.