### PR TITLE
benchmark-runner: refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,12 +108,12 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 guest-libs = { path = "ere-guests/libs" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.6", package = "zkvm-interface" }
-ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.6", package = "ere-sp1" }
-ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.6", package = "ere-risczero" }
-ere-pico = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.6", package = "ere-pico" }
-ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.6", package = "ere-openvm" }
-ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.6", package = "ere-zisk" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "bf139239722715bf7a57593d8b6acff57a6d4a93", package = "zkvm-interface" }
+ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", rev = "bf139239722715bf7a57593d8b6acff57a6d4a93", package = "ere-sp1" }
+ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", rev = "bf139239722715bf7a57593d8b6acff57a6d4a93", package = "ere-risczero" }
+ere-pico = { git = "https://github.com/eth-applied-research-group/ere", rev = "bf139239722715bf7a57593d8b6acff57a6d4a93", package = "ere-pico" }
+ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", rev = "bf139239722715bf7a57593d8b6acff57a6d4a93", package = "ere-openvm" }
+ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", rev = "bf139239722715bf7a57593d8b6acff57a6d4a93", package = "ere-zisk" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.

--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -11,6 +11,9 @@ guest-libs.workspace = true
 
 rayon.workspace = true
 tracing.workspace = true
+walkdir.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 anyhow = "*"
 
 [lints]

--- a/crates/benchmark-runner/src/guest_programs.rs
+++ b/crates/benchmark-runner/src/guest_programs.rs
@@ -13,8 +13,7 @@ pub trait GuestInputMetadata: Serialize + DeserializeOwned + Clone + Send + Sync
 impl GuestInputMetadata for () {}
 
 /// Represents a guest program input with associated metadata
-#[allow(missing_debug_implementations)]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct GuestInput<M: GuestInputMetadata> {
     /// The name of the guest program input.
     pub name: String,

--- a/crates/benchmark-runner/src/guest_programs.rs
+++ b/crates/benchmark-runner/src/guest_programs.rs
@@ -1,0 +1,106 @@
+//! Guest program type definitions and input preparation
+
+use guest_libs::BincodeBlock;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::path::Path;
+use walkdir::WalkDir;
+use witness_generator::BlockAndWitness;
+use zkvm_interface::Input;
+
+/// Metadata trait for guest program inputs
+pub trait GuestInputMetadata: Serialize + DeserializeOwned + Clone + Send + Sync {}
+impl GuestInputMetadata for () {}
+
+/// Represents a guest program input with associated metadata
+#[allow(missing_debug_implementations)]
+#[derive(Clone)]
+pub struct GuestInput<M: GuestInputMetadata> {
+    /// The name of the guest program input.
+    pub name: String,
+    /// The standard input to be provided to the guest program.
+    pub stdin: Input,
+    /// Associated metadata for the guest program input.
+    pub metadata: M,
+}
+
+/// Generate inputs for the empty program guest program.
+pub fn empty_program_generate_inputs() -> GuestInput<()> {
+    GuestInput {
+        name: "empty_program".to_string(),
+        stdin: Input::new(),
+        metadata: (),
+    }
+}
+
+/// Extra information about the block being benchmarked
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockMetadata {
+    block_used_gas: u64,
+}
+impl GuestInputMetadata for BlockMetadata {}
+
+/// Generate inputs for the stateless validator guest program.
+pub fn stateless_validator_generate_inputs(
+    input_folder: &Path,
+) -> anyhow::Result<Vec<GuestInput<BlockMetadata>>> {
+    let guest_inputs = read_benchmark_fixtures_folder(input_folder)?
+        .into_iter()
+        .map(|bw| {
+            let mut stdin = Input::new();
+            stdin.write(bw.block_and_witness.clone());
+            stdin.write(bw.network);
+            GuestInput {
+                name: bw.name,
+                stdin,
+                metadata: BlockMetadata {
+                    block_used_gas: bw.block_and_witness.block.gas_used,
+                },
+            }
+        })
+        .collect();
+
+    Ok(guest_inputs)
+}
+
+/// Generate inputs for the stateless validator guest program.
+pub fn block_rlp_length_generate_inputs(
+    input_folder: &Path,
+    loop_count: u16,
+) -> anyhow::Result<Vec<GuestInput<()>>> {
+    let guest_inputs = read_benchmark_fixtures_folder(input_folder)?
+        .into_iter()
+        .map(|bw| {
+            let mut stdin = Input::new();
+            stdin.write(BincodeBlock(bw.block_and_witness.block));
+            stdin.write(loop_count);
+            GuestInput {
+                name: bw.name,
+                stdin,
+                metadata: (),
+            }
+        })
+        .collect();
+
+    Ok(guest_inputs)
+}
+
+fn read_benchmark_fixtures_folder(path: &Path) -> anyhow::Result<Vec<BlockAndWitness>> {
+    WalkDir::new(path)
+        .min_depth(1)
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?
+        .into_par_iter()
+        .map(|entry| {
+            if entry.file_type().is_file() {
+                let content = std::fs::read(entry.path())?;
+                let bw: BlockAndWitness = serde_json::from_slice(&content).map_err(|e| {
+                    anyhow::anyhow!("Failed to parse {}: {}", entry.path().display(), e)
+                })?;
+                Ok(bw)
+            } else {
+                anyhow::bail!("Invalid input folder structure: expected files only")
+            }
+        })
+        .collect::<anyhow::Result<Vec<BlockAndWitness>>>()
+}

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -2,13 +2,16 @@
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use guest_libs::BincodeBlock;
-use rayon::prelude::*;
-use std::{any::Any, panic, path::PathBuf, sync::Arc};
+pub mod guest_programs;
+
+use std::path::PathBuf;
+use std::{any::Any, panic};
 use tracing::info;
-use witness_generator::BlockAndWitness;
+
 use zkevm_metrics::{BenchmarkRun, CrashInfo, ExecutionMetrics, HardwareInfo, ProvingMetrics};
-use zkvm_interface::{zkVM, Input};
+use zkvm_interface::zkVM;
+
+use crate::guest_programs::{GuestInput, GuestInputMetadata};
 
 /// Holds the configuration for running benchmarks
 #[derive(Debug, Clone)]
@@ -30,65 +33,43 @@ pub enum Action {
     Execute,
 }
 
-/// Runs the benchmark for a given zkVM instance and RLP encoding length program.
-pub fn run_benchmark_rlp_encoding_length(
-    zkvm_name: &str,
-    zkvm_instance: Box<dyn zkVM + Sync>,
-    run_config: &RunConfig,
-    blocks: &[BincodeBlock],
-    loop_count: u16,
-) -> anyhow::Result<()> {
-    HardwareInfo::detect().to_path(run_config.output_folder.join("hardware.json"))?;
-
-    info!("Benchmarking `{}`…", zkvm_name);
-    let zkvm_ref = Arc::new(&zkvm_instance);
-
-    match run_config.action {
-        Action::Execute => {
-            // Use parallel iteration for execution
-            blocks.into_par_iter().try_for_each(|block| {
-                process_blocks(block, loop_count, zkvm_ref.clone(), zkvm_name, run_config)
-            })?;
-        }
-        Action::Prove => {
-            // Use sequential iteration for proving
-            blocks.iter().try_for_each(|block| {
-                process_blocks(block, loop_count, zkvm_ref.clone(), zkvm_name, run_config)
-            })?;
-        }
-    }
+/// Executes benchmarks for a given guest program type and zkVM
+pub fn run_benchmark<M>(
+    zkvm: Box<dyn zkVM + Sync>,
+    config: &RunConfig,
+    inputs: Vec<GuestInput<M>>,
+) -> anyhow::Result<()>
+where
+    M: GuestInputMetadata,
+{
+    HardwareInfo::detect().to_path(config.output_folder.join("hardware.json"))?;
+    inputs
+        .iter()
+        .try_for_each(|input| process_input(&zkvm, input, config))?;
 
     Ok(())
 }
 
-fn process_blocks<V>(
-    block: &BincodeBlock,
-    loop_count: u16,
-    zkvm_ref: Arc<V>,
-    host_name: &str,
-    run_config: &RunConfig,
-) -> anyhow::Result<()>
+/// Processes a single input through the zkVM
+fn process_input<V, M>(zkvm: &V, input: &GuestInput<M>, config: &RunConfig) -> anyhow::Result<()>
 where
     V: zkVM + Sync,
+    M: GuestInputMetadata,
 {
-    let name = format!("rlp_encoding_length-block_{}", block.hash_slow());
-    let out_path = run_config
+    let zkvm_name = format!("{}-v{}", zkvm.name(), zkvm.sdk_version());
+    let out_path = config
         .output_folder
-        .join(format!("{host_name}/{name}.json"));
+        .join(format!("{zkvm_name}/{}.json", input.name));
 
-    if !run_config.force_rerun && out_path.exists() {
-        info!("Skipping {} (already exists)", &name);
+    if !config.force_rerun && out_path.exists() {
+        info!("Skipping {} (already exists)", &input.name);
         return Ok(());
     }
 
-    let mut stdin = Input::new();
-    stdin.write(block.clone());
-    stdin.write(loop_count);
-
-    info!("Running RLP encoding length for {name}");
-    let (execution, proving) = match run_config.action {
+    info!("Running {}", input.name);
+    let (execution, proving) = match config.action {
         Action::Execute => {
-            let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm_ref.execute(&stdin)));
+            let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm.execute(&input.stdin)));
             let execution = match run {
                 Ok(Ok(report)) => ExecutionMetrics::Success {
                     total_num_cycles: report.total_num_cycles,
@@ -105,7 +86,7 @@ where
             (Some(execution), None)
         }
         Action::Prove => {
-            let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm_ref.prove(&stdin)));
+            let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm.prove(&input.stdin)));
             let proving = match run {
                 Ok(Ok((proof, report))) => ProvingMetrics::Success {
                     proof_size: proof.len(),
@@ -121,174 +102,17 @@ where
             (None, Some(proving))
         }
     };
+
     let report = BenchmarkRun {
-        name: name.clone(),
+        name: input.name.clone(),
         timestamp_completed: zkevm_metrics::chrono::Utc::now(),
-        block_used_gas: 0,
+        metadata: input.metadata.clone(),
         execution,
         proving,
     };
 
-    info!("Saving report for {}", name);
-    BenchmarkRun::to_path(out_path, &[report])?;
-
-    Ok(())
-}
-
-/// Runs the benchmark for a given zkVM instance with an empty program
-pub fn run_benchmark_empty_program(
-    zkvm_name: &str,
-    zkvm_instance: Box<dyn zkVM + Sync>,
-    run_config: &RunConfig,
-) -> anyhow::Result<()> {
-    HardwareInfo::detect().to_path(run_config.output_folder.join("hardware.json"))?;
-
-    info!("Benchmarking `{}`…", zkvm_name);
-    let (execution, proving) = match run_config.action {
-        Action::Execute => {
-            let run = zkvm_instance.execute(&Input::new());
-            let execution = match run {
-                Ok(report) => ExecutionMetrics::Success {
-                    total_num_cycles: report.total_num_cycles,
-                    region_cycles: report.region_cycles.into_iter().collect(),
-                    execution_duration: report.execution_duration,
-                },
-                Err(e) => ExecutionMetrics::Crashed(CrashInfo {
-                    reason: e.to_string(),
-                }),
-            };
-            (Some(execution), None)
-        }
-        Action::Prove => {
-            let run = zkvm_instance.prove(&Input::new());
-            let proving = match run {
-                Ok((proof, report)) => ProvingMetrics::Success {
-                    proof_size: proof.len(),
-                    proving_time_ms: report.proving_time.as_millis(),
-                },
-                Err(e) => ProvingMetrics::Crashed(CrashInfo {
-                    reason: e.to_string(),
-                }),
-            };
-            (None, Some(proving))
-        }
-    };
-    let out_path = run_config
-        .output_folder
-        .join(format!("{zkvm_name}/empty_program.json"));
-
-    let report = BenchmarkRun {
-        name: "empty_program".to_string(),
-        timestamp_completed: zkevm_metrics::chrono::Utc::now(),
-        block_used_gas: 0,
-        execution,
-        proving,
-    };
-    BenchmarkRun::to_path(out_path, &[report])?;
-
-    Ok(())
-}
-
-/// Runs the benchmark for a given zkVM instance and corpus of blocks and witnesses
-pub fn run_benchmark_stateless_validator(
-    zkvm_name: &str,
-    zkvm_instance: Box<dyn zkVM + Sync>,
-    run_config: &RunConfig,
-    corpuses: &[BlockAndWitness],
-) -> anyhow::Result<()> {
-    HardwareInfo::detect().to_path(run_config.output_folder.join("hardware.json"))?;
-
-    info!("Benchmarking `{}`…", zkvm_name);
-    let zkvm_ref = Arc::new(&zkvm_instance);
-
-    match run_config.action {
-        Action::Execute => {
-            // Use parallel iteration for execution
-            corpuses
-                .into_par_iter()
-                .try_for_each(|bw| process_corpus(bw, zkvm_ref.clone(), zkvm_name, run_config))?;
-        }
-        Action::Prove => {
-            // Use sequential iteration for proving
-            corpuses
-                .iter()
-                .try_for_each(|bw| process_corpus(bw, zkvm_ref.clone(), zkvm_name, run_config))?;
-        }
-    }
-
-    Ok(())
-}
-
-fn process_corpus<V>(
-    bw: &BlockAndWitness,
-    zkvm_ref: Arc<V>,
-    host_name: &str,
-    run_config: &RunConfig,
-) -> anyhow::Result<()>
-where
-    V: zkVM + Sync,
-{
-    let out_path = run_config
-        .output_folder
-        .join(format!("{}/{}.json", host_name, bw.name));
-
-    if !run_config.force_rerun && out_path.exists() {
-        info!("Skipping {} (already exists)", bw.name);
-        return Ok(());
-    }
-
-    let block_number = bw.block_and_witness.block.number;
-    let block_used_gas = bw.block_and_witness.block.gas_used;
-    let mut stdin = Input::new();
-    stdin.write(bw.block_and_witness.clone());
-    stdin.write(bw.network);
-
-    info!("Running {}", bw.name);
-    let (execution, proving) = match run_config.action {
-        Action::Execute => {
-            let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm_ref.execute(&stdin)));
-            let execution = match run {
-                Ok(Ok(report)) => ExecutionMetrics::Success {
-                    total_num_cycles: report.total_num_cycles,
-                    region_cycles: report.region_cycles.into_iter().collect(),
-                    execution_duration: report.execution_duration,
-                },
-                Ok(Err(e)) => ExecutionMetrics::Crashed(CrashInfo {
-                    reason: e.to_string(),
-                }),
-                Err(panic_info) => ExecutionMetrics::Crashed(CrashInfo {
-                    reason: get_panic_msg(panic_info),
-                }),
-            };
-            (Some(execution), None)
-        }
-        Action::Prove => {
-            let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm_ref.prove(&stdin)));
-            let proving = match run {
-                Ok(Ok((proof, report))) => ProvingMetrics::Success {
-                    proof_size: proof.len(),
-                    proving_time_ms: report.proving_time.as_millis(),
-                },
-                Ok(Err(e)) => ProvingMetrics::Crashed(CrashInfo {
-                    reason: e.to_string(),
-                }),
-                Err(panic_info) => ProvingMetrics::Crashed(CrashInfo {
-                    reason: get_panic_msg(panic_info),
-                }),
-            };
-            (None, Some(proving))
-        }
-    };
-    let report = BenchmarkRun {
-        name: format!("{}-{}", bw.name, block_number),
-        timestamp_completed: zkevm_metrics::chrono::Utc::now(),
-        block_used_gas,
-        execution,
-        proving,
-    };
-
-    info!("Saving report for {}", bw.name);
-    BenchmarkRun::to_path(out_path, &[report])?;
+    info!("Saving report {}", input.name);
+    report.to_path(out_path)?;
 
     Ok(())
 }

--- a/crates/ere-hosts/Cargo.toml
+++ b/crates/ere-hosts/Cargo.toml
@@ -14,18 +14,12 @@ pico = ["dep:ere-pico"]
 zisk = ["dep:ere-zisk"]
 
 [dependencies]
-rayon.workspace = true
 clap.workspace = true
-walkdir.workspace = true
-anyhow.workspace = true
-serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
 benchmark-runner.workspace = true
 zkvm-interface.workspace = true
-witness-generator.workspace = true
-guest-libs.workspace = true
 
 # Optional dependencies based on features
 ere-sp1 = { workspace = true, optional = true }


### PR DESCRIPTION
This PR is paying some technical debt we have in `benchmark-runner`.

Basically we organize better how the main logic for running benchmarks work by making each guest program type have a separate function that encapsulates how the inputs are generated.