### PR TITLE
guest-programs: use new workspace mounting from ere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,8 +1362,12 @@ name = "benchmark-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "guest-libs",
  "rayon",
+ "serde",
+ "serde_json",
  "tracing",
+ "walkdir",
  "witness-generator",
  "zkevm-metrics",
  "zkvm-interface",
@@ -1654,9 +1658,11 @@ dependencies = [
 [[package]]
 name = "build-utils"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.5#94b026dc4b07600f5f5f6dcc04276a56ec9b306d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=v0.0.8#f05aa500327fd130582b2732ce0e2c7a64e74214"
 dependencies = [
  "cargo_metadata 0.20.0",
+ "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]
@@ -3089,7 +3095,6 @@ dependencies = [
 name = "ere-hosts"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "benchmark-runner",
  "clap",
  "ere-openvm",
@@ -3097,19 +3102,15 @@ dependencies = [
  "ere-risczero",
  "ere-sp1",
  "ere-zisk",
- "rayon",
- "serde_json",
  "tracing",
  "tracing-subscriber 0.3.19",
- "walkdir",
- "witness-generator",
  "zkvm-interface",
 ]
 
 [[package]]
 name = "ere-openvm"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.5#94b026dc4b07600f5f5f6dcc04276a56ec9b306d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=v0.0.8#f05aa500327fd130582b2732ce0e2c7a64e74214"
 dependencies = [
  "build-utils",
  "openvm-build",
@@ -3124,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "ere-pico"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.5#94b026dc4b07600f5f5f6dcc04276a56ec9b306d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=v0.0.8#f05aa500327fd130582b2732ce0e2c7a64e74214"
 dependencies = [
  "bincode",
  "build-utils",
@@ -3136,13 +3137,14 @@ dependencies = [
 [[package]]
 name = "ere-risczero"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.5#94b026dc4b07600f5f5f6dcc04276a56ec9b306d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=v0.0.8#f05aa500327fd130582b2732ce0e2c7a64e74214"
 dependencies = [
  "anyhow",
  "borsh",
  "build-utils",
  "hex",
  "risc0-zkvm",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.12",
@@ -3153,14 +3155,13 @@ dependencies = [
 [[package]]
 name = "ere-sp1"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.5#94b026dc4b07600f5f5f6dcc04276a56ec9b306d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=v0.0.8#f05aa500327fd130582b2732ce0e2c7a64e74214"
 dependencies = [
  "bincode",
  "build-utils",
  "sp1-sdk",
  "tempfile",
  "thiserror 2.0.12",
- "toml",
  "tracing",
  "zkvm-interface",
 ]
@@ -3168,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "ere-zisk"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.5#94b026dc4b07600f5f5f6dcc04276a56ec9b306d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=v0.0.8#f05aa500327fd130582b2732ce0e2c7a64e74214"
 dependencies = [
  "bincode",
  "blake3",
@@ -3732,6 +3733,17 @@ dependencies = [
  "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "guest-libs"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -10497,9 +10509,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714776c8ccf3e206ecf499dab6561259beef6e7a82dfb49ccf5c911c7350dd5e"
+checksum = "62ffc0f135e6c1e9851e7e19438d03ff41a9d49199ee4f6c17b8bb30b4f83910"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -10637,9 +10649,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59aaf1898f2f5d526a79d53dbe6288aeb1ce52a17184b85af84d06dedb1a367"
+checksum = "9684b333c1c5d83f29ce2a92314ccfafd9d8cdfa6c4e19c07b97015d2f1eb9d0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14062,7 +14074,7 @@ dependencies = [
 [[package]]
 name = "zkvm-interface"
 version = "0.1.0"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.5#94b026dc4b07600f5f5f6dcc04276a56ec9b306d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=v0.0.8#f05aa500327fd130582b2732ce0e2c7a64e74214"
 dependencies = [
  "anyhow",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,12 +108,12 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 guest-libs = { path = "ere-guests/libs" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "zkvm-interface" }
-ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "ere-sp1" }
-ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "ere-risczero" }
-ere-pico = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "ere-pico" }
-ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "ere-openvm" }
-ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "ere-zisk" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "v0.0.8", package = "zkvm-interface" }
+ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", rev = "v0.0.8", package = "ere-sp1" }
+ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", rev = "v0.0.8", package = "ere-risczero" }
+ere-pico = { git = "https://github.com/eth-applied-research-group/ere", rev = "v0.0.8", package = "ere-pico" }
+ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", rev = "v0.0.8", package = "ere-openvm" }
+ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", rev = "v0.0.8", package = "ere-zisk" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,12 +108,12 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 guest-libs = { path = "ere-guests/libs" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "zkvm-interface" }
-ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "ere-sp1" }
-ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "ere-risczero" }
-ere-pico = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "ere-pico" }
-ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "ere-openvm" }
-ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "ere-zisk" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "zkvm-interface" }
+ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "ere-sp1" }
+ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "ere-risczero" }
+ere-pico = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "ere-pico" }
+ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "ere-openvm" }
+ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", rev = "9444a2ba73ba933b573b80d9c66c4fbc3bcbe024", package = "ere-zisk" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,12 +108,12 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 guest-libs = { path = "ere-guests/libs" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.7", package = "zkvm-interface" }
-ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.7", package = "ere-sp1" }
-ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.7", package = "ere-risczero" }
-ere-pico = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.7", package = "ere-pico" }
-ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.7", package = "ere-openvm" }
-ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.7", package = "ere-zisk" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "zkvm-interface" }
+ere-sp1 = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "ere-sp1" }
+ere-risczero = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "ere-risczero" }
+ere-pico = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "ere-pico" }
+ere-openvm = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "ere-openvm" }
+ere-zisk = { git = "https://github.com/eth-applied-research-group/ere", rev = "1bfacf473846cb6115382b2a2d23d6cc9f02546e", package = "ere-zisk" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.

--- a/ere-guests/Cargo.toml
+++ b/ere-guests/Cargo.toml
@@ -13,6 +13,9 @@ members = [
 
     # RLP encoding
     "rlp-encoding-length/sp1",
+
+    # Libs
+    "libs",
 ]
 resolver = "2"
 
@@ -105,6 +108,8 @@ while_float = "warn"
 zero_sized_map_values = "warn"
 
 [workspace.dependencies]
+guest-libs = { path = "libs" }
+
 sp1-zkvm = "5.0.5"
 
 # branch is kw/zkevm-benchmark-workload-repo
@@ -117,10 +122,16 @@ reth-evm-ethereum = { git = "https://github.com/kevaundray/reth", rev = "03364a8
 
 # alloy
 alloy-primitives = { version = "1.2.0", default-features = false }
+alloy-consensus = { version = "1.0.18", default-features = false }
+
+# revm
+revm = { version = "26.0.1", default-features = false }
 
 # misc
 bincode = "1.3"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+serde = { version = "1.0", default-features = false }
+serde_with = "3"
 
 [patch.crates-io]

--- a/ere-guests/empty-program/sp1/Cargo.toml
+++ b/ere-guests/empty-program/sp1/Cargo.toml
@@ -6,6 +6,4 @@ rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-sp1-zkvm = "5.0.5"
-
-[patch.crates-io]
+sp1-zkvm.workspace = true

--- a/ere-guests/rlp-encoding-length/sp1/Cargo.toml
+++ b/ere-guests/rlp-encoding-length/sp1/Cargo.toml
@@ -6,18 +6,18 @@ rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-sp1-zkvm = "5.0.5"
+sp1-zkvm.workspace = true
+
+guest-libs.workspace = true
 
 tracing = "*"
 tracing-subscriber = "*"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_with = "3"
 
-reth-ethereum-primitives = { git = "https://github.com/kevaundray/reth", rev = "75092d6aa098311db96c06b97a252a6f2b42dbaf", features = [
+reth-ethereum-primitives = { workspace = true, features = [
     "serde",
     "serde-bincode-compat",
 ] }
-alloy-consensus = { version = "1.0.18", default-features = false }
-reth-primitives-traits = { git = "https://github.com/kevaundray/reth", rev = "75092d6aa098311db96c06b97a252a6f2b42dbaf" }
-
-[patch.crates-io]
+alloy-consensus.workspace = true
+reth-primitives-traits.workspace = true

--- a/ere-guests/rlp-encoding-length/sp1/src/main.rs
+++ b/ere-guests/rlp-encoding-length/sp1/src/main.rs
@@ -12,7 +12,7 @@ sp1_zkvm::entrypoint!(main);
 /// Entry point.
 pub fn main() {
     println!("cycle-tracker-report-start: read_input");
-    let block = sp1_zkvm::io::read::<BincodeBlock>();
+    let block = sp1_zkvm::io::read::<guest_libs::BincodeBlock>();
     let iterations = sp1_zkvm::io::read::<u16>();
     println!("cycle-tracker-report-end: read_input");
 
@@ -21,23 +21,4 @@ pub fn main() {
         Block::rlp_length_for(&block.header, &block.body);
     }
     println!("cycle-tracker-report-end: rlp_encoding");
-}
-
-/// Block wrapper that supports bincode serialization
-/// NOTE: Very soon this definition will disappear when guests-lib is used as a workspace dependency.
-#[serde_as]
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct BincodeBlock(
-    #[serde_as(
-        as = "reth_primitives_traits::serde_bincode_compat::Block<reth_ethereum_primitives::TransactionSigned, alloy_consensus::Header>"
-    )]
-    pub Block,
-);
-
-impl Deref for BincodeBlock {
-    type Target = Block;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
 }

--- a/ere-guests/stateless-validator/sp1/Cargo.toml
+++ b/ere-guests/stateless-validator/sp1/Cargo.toml
@@ -7,29 +7,27 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-sp1-zkvm = "5.0.5"
-reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "03364a836774c72f4e354de924330fee6a41be68" }
-reth-ethereum-primitives = { git = "https://github.com/kevaundray/reth", rev = "03364a836774c72f4e354de924330fee6a41be68", features = [
+sp1-zkvm.workspace = true
+reth-stateless.workspace = true
+reth-ethereum-primitives = { workspace = true, features = [
     "serde",
     "serde-bincode-compat",
 ] }
-reth-primitives-traits = { git = "https://github.com/kevaundray/reth", rev = "03364a836774c72f4e354de924330fee6a41be68", features = [
+reth-primitives-traits = { workspace = true, features = [
     "serde",
     "serde-bincode-compat",
 ] }
-reth-evm-ethereum = { git = "https://github.com/kevaundray/reth", rev = "03364a836774c72f4e354de924330fee6a41be68" }
-reth-chainspec = { git = "https://github.com/kevaundray/reth", rev = "03364a836774c72f4e354de924330fee6a41be68" }
+reth-evm-ethereum.workspace = true
+reth-chainspec.workspace = true
 
-revm = { version = "26.0.1", default-features = false, features = [
+revm = { workspace = true, default-features = false, features = [
     "kzg-rs",
     "bn",
 ] }
-alloy-primitives = { version = "1.2.0", default-features = false, features = [
+alloy-primitives = { workspace = true, default-features = false, features = [
     "map-foldhash",
     "serde",
     "sha3-keccak",
 ] }
 tracing-subscriber = "*"
 tracing = "*"
-
-[patch.crates-io]


### PR DESCRIPTION
This PR updates to a new `ere` version which allows to distinguish between:
- Workspace directory: which directory gets mounted at compilation time.
- Guest program directory: a _relative_ path within the workspace to be compiled.

The main benefits are:
- We can switch again guest program types for zkVMs to use workspace dependencies, which reduces the burden of matching dependency versions.
- Guest programs can now use the `guest-libs` as a dependency, which will help reduce repetition in all guest program types.

As a first example of the latter, the `BincodeBlock` type that we had to duplicate before is now shared between `ere-hosts` (which is the "sender" of the stdin) and the guest program (which is the receiver).