### PR TITLE
ci: bump rust version for witness-generator-cli image generation

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,11 +21,6 @@ jobs:
         with:
           components: clippy, rustfmt
       
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: integration-witness
-      
       - name: Download and Extract Fixtures
         run: |
           chmod +x ./scripts/download-and-extract-fixtures.sh
@@ -71,11 +66,6 @@ jobs:
           ./scripts/download-and-extract-fixtures.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.zkvm }}
       
       - name: Install C toolchain dependencies
         run: |
@@ -127,11 +117,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
-      
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.zkvm }}
       
       - name: Install C toolchain dependencies
         run: |

--- a/crates/witness-generator-cli/Dockerfile
+++ b/crates/witness-generator-cli/Dockerfile
@@ -1,5 +1,5 @@
 # Build the witness-generator
-FROM rust:1.85 AS builder
+FROM rust:1.86 AS builder
 RUN apt-get update && apt-get install -y build-essential libclang-dev
 WORKDIR /usr/src/zkevm-benchmark-workload
 COPY . .


### PR DESCRIPTION
Fixes `witness-generation-cli` CI [failure](https://github.com/eth-act/zkevm-benchmark-workload/actions/runs/16680811518/job/47218771788) that only runs in `master`.