### PR TITLE
precompile-patches: update for sp1

### DIFF
--- a/precompile-patches/sp1.toml
+++ b/precompile-patches/sp1.toml
@@ -1,6 +1,9 @@
 [patch.crates-io]
-sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", tag = "patch-sha2-0.10.8-sp1-4.0.0", package = "sha2" }
 bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-5.0.0", package = "substrate-bn" }
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
+crypto-bigint = { git = "https://github.com/sp1-patches/RustCrypto-bigint", tag = "patch-0.5.5-sp1-4.0.0" }
+tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0" }
+curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-5.0.0" }
 k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-5.0.0" }
 p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-5.0.0" }
+ecdsa = { git = "https://github.com/sp1-patches/signatures", tag = "patch-16.9-sp1-4.1.0" }


### PR DESCRIPTION
With the new patches:
```
$ cargo prove build
cargo:warning=rustc +succinct --version: "rustc 1.88.0-dev\n"
[sp1]     Compiling crypto-bigint v0.5.5 (https://github.com/sp1-patches/RustCrypto-bigint?tag=patch-0.5.5-sp1-4.0.0#d4210297)
[sp1]     Compiling serde_with v3.14.0
[sp1]     Compiling bitvec v1.0.1
...
```
So all current PR ones are used.

The `sha2` was removed since it generated a warning from not being use:
```
cargo:warning=rustc +succinct --version: "rustc 1.88.0-dev\n"
[sp1]  warning: Patch `sha2 v0.10.8 (https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388)` was not used in the crate graph.
```