### PR TITLE
witness-generator: derive chain spec from rpc chain id

### DIFF
--- a/crates/witness-generator-cli/src/main.rs
+++ b/crates/witness-generator-cli/src/main.rs
@@ -164,7 +164,10 @@ async fn build_generator(source: SourceCommand) -> Result<Box<dyn WitnessGenerat
             }
 
             Ok(Box::new(
-                builder.build().context("Failed to build RPC generator")?,
+                builder
+                    .build()
+                    .await
+                    .context("Failed to build RPC generator")?,
             ))
         }
     }


### PR DESCRIPTION
This PR makes the `witness-generator` use the corresponding ChainSpec depending on the reported chain id by the RPC.