### PR TITLE
ci: use ere images

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,15 +35,19 @@ jobs:
             echo "zkevm-fixtures-input folder is empty"
             exit 1
           fi
-  
-  stateless-validator:
-    name: Stateless validator guest
+
+  guest:
+    name: "${{ matrix.program }} (${{ matrix.zkvm }} / ${{ matrix.action }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         zkvm: [sp1, risc0]
-        action: [execute]
+        action: [execute, prove]
+        program: [stateless-validator, empty-program]
+        exclude:
+          - program: stateless-validator
+            action: prove
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -52,10 +56,11 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
       
       - name: Generate benchmark fixtures
+        if: matrix.program == 'stateless-validator'
         run: RUST_LOG=info cargo run -p witness-generator-cli --release -- tests --include 1M- --include Prague --include empty_block
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Pull ere images
         run: |
           for variant in "" "-${{ matrix.zkvm }}"; do
@@ -66,9 +71,10 @@ jobs:
           done
 
       - name: Run benchmark
-        run: RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} stateless-validator
+        run: RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} ${{ matrix.program }}
 
-      - name: Check zkevm-metrics folder
+      - name: Locate metrics folder (common checks)
+        id: metrics
         run: |
           find ./zkevm-metrics
           if [ ! -d "./zkevm-metrics" ]; then
@@ -84,58 +90,25 @@ jobs:
             echo "No ${{ matrix.zkvm }} folder found in zkevm-metrics"
             exit 1
           fi
+          echo "folder=$zkvm_folder" >> "$GITHUB_OUTPUT"
+
+      - name: Extra checks for stateless-validator
+        if: matrix.program == 'stateless-validator'
+        run: |
+          zkvm_folder='${{ steps.metrics.outputs.folder }}'
           ls -l ./zkevm-fixtures-input
-          ls -l $zkvm_folder
+          ls -l "$zkvm_folder"
           input_files_count=$(find ./zkevm-fixtures-input -type f | wc -l)
-          zkvm_files_count=$(find $zkvm_folder -type f | wc -l)
+          zkvm_files_count=$(find "$zkvm_folder" -type f | wc -l)
           if [ "$input_files_count" -ne "$zkvm_files_count" ]; then
             echo "Mismatch in number of files: zkevm-fixtures-input has $input_files_count files, $zkvm_folder has $zkvm_files_count files"
             exit 1
           fi
 
-  empty-program:
-    name: Empty program guest
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        zkvm: [sp1, risc0]
-        action: [execute, prove]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-      
-      - name: Pull ere images
+      - name: Extra checks for empty-program
+        if: matrix.program == 'empty-program'
         run: |
-          for variant in "" "-${{ matrix.zkvm }}"; do
-            src="ghcr.io/eth-act/ere/ere-base${variant}:${ERE_TAG}"
-            dst="ere-base${variant}:${ERE_TAG}"
-            docker pull "$src"
-            docker tag "$src" "$dst"
-          done
-      
-      - name: Run benchmark
-        run: RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} empty-program
-      
-      - name: Check zkevm-metrics folder
-        run: |
-          find ./zkevm-metrics
-          if [ ! -d "./zkevm-metrics" ]; then
-            echo "zkevm-metrics folder does not exist"
-            exit 1
-          fi
-          if [ ! -f "./zkevm-metrics/hardware.json" ]; then
-            echo "hardware.json file does not exist in zkevm-metrics folder"
-            exit 1
-          fi
-          zkvm_folder=$(find ./zkevm-metrics -type d -name "${{ matrix.zkvm }}-*" | head -n 1)
-          if [ -z "$zkvm_folder" ]; then
-            echo "No ${{ matrix.zkvm }} folder found in zkevm-metrics"
-            exit 1
-          fi
+          zkvm_folder='${{ steps.metrics.outputs.folder }}'
           if [ ! -f "$zkvm_folder/empty_program.json" ]; then
             echo "empty_program.json file does not exist in $zkvm_folder"
             exit 1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,13 +55,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull ere image
+      - name: Run benchmark
         run: |
           docker pull ghcr.io/eth-act/ere/ere-base:0.0.11-06d15a4
+          docker tag  ghcr.io/eth-act/ere/ere-base:0.0.11-06d15a4 ere-base:0.0.11-06d15a4
           docker pull ghcr.io/eth-act/ere/ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4
+          docker tag  ghcr.io/eth-act/ere/ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4 ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4
 
-      - name: Run benchmark
-        run: RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} stateless-validator
+          RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} stateless-validator
 
       - name: Check zkevm-metrics folder
         run: |
@@ -103,13 +104,14 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
       
-      - name: Pull ere image
+      - name: Run benchmark
         run: |
           docker pull ghcr.io/eth-act/ere/ere-base:0.0.11-06d15a4
+          docker tag  ghcr.io/eth-act/ere/ere-base:0.0.11-06d15a4 ere-base:0.0.11-06d15a4
           docker pull ghcr.io/eth-act/ere/ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4
+          docker tag  ghcr.io/eth-act/ere/ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4 ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4
 
-      - name: Run benchmark
-        run: RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} empty-program
+          RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} empty-program
       
       - name: Check zkevm-metrics folder
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 env:
   CARGO_TERM_COLOR: always
+  ERE_TAG: 0.0.11-06d15a4
 
 jobs: 
   witness-generator:
@@ -54,15 +55,18 @@ jobs:
         run: RUST_LOG=info cargo run -p witness-generator-cli --release -- tests --include 1M- --include Prague --include empty_block
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Pull ere images
+        run: |
+          for variant in "" "-${{ matrix.zkvm }}"; do
+            src="ghcr.io/eth-act/ere/ere-base${variant}:${ERE_TAG}"
+            dst="ere-base${variant}:${ERE_TAG}"
+            docker pull "$src"
+            docker tag "$src" "$dst"
+          done
 
       - name: Run benchmark
-        run: |
-          docker pull ghcr.io/eth-act/ere/ere-base:0.0.11-06d15a4
-          docker tag  ghcr.io/eth-act/ere/ere-base:0.0.11-06d15a4 ere-base:0.0.11-06d15a4
-          docker pull ghcr.io/eth-act/ere/ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4
-          docker tag  ghcr.io/eth-act/ere/ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4 ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4
-
-          RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} stateless-validator
+        run: RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} stateless-validator
 
       - name: Check zkevm-metrics folder
         run: |
@@ -104,14 +108,17 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
       
-      - name: Run benchmark
+      - name: Pull ere images
         run: |
-          docker pull ghcr.io/eth-act/ere/ere-base:0.0.11-06d15a4
-          docker tag  ghcr.io/eth-act/ere/ere-base:0.0.11-06d15a4 ere-base:0.0.11-06d15a4
-          docker pull ghcr.io/eth-act/ere/ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4
-          docker tag  ghcr.io/eth-act/ere/ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4 ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4
-
-          RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} empty-program
+          for variant in "" "-${{ matrix.zkvm }}"; do
+            src="ghcr.io/eth-act/ere/ere-base${variant}:${ERE_TAG}"
+            dst="ere-base${variant}:${ERE_TAG}"
+            docker pull "$src"
+            docker tag "$src" "$dst"
+          done
+      
+      - name: Run benchmark
+        run: RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} empty-program
       
       - name: Check zkevm-metrics folder
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ env:
 jobs: 
   witness-generator:
     name: Generate EEST benchmark fixtures
-    runs-on: [self-hosted-ghr, size-xl-x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -20,18 +20,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy, rustfmt
-      
-      - name: Download and Extract Fixtures
-        run: |
-          chmod +x ./scripts/download-and-extract-fixtures.sh
-          ./scripts/download-and-extract-fixtures.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install C toolchain dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential clang libclang-dev
       
       - name: Generate benchmark fixtures
         run: RUST_LOG=info cargo run -p witness-generator-cli --release -- tests --include 1M- --include Prague
@@ -49,7 +37,7 @@ jobs:
   
   stateless-validator:
     name: Stateless validator guest
-    runs-on: [self-hosted-ghr, size-xl-x64]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -62,28 +50,18 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
       
-      - name: Download and Extract Fixtures
-        run: |
-          chmod +x ./scripts/download-and-extract-fixtures.sh
-          ./scripts/download-and-extract-fixtures.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Install C toolchain dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential clang libclang-dev
-      
       - name: Generate benchmark fixtures
         run: RUST_LOG=info cargo run -p witness-generator-cli --release -- tests --include 1M- --include Prague --include empty_block
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull ere image
+        run: |
+          docker pull ghcr.io/eth-act/ere/ere-base:0.0.11-06d15a4
+          docker pull ghcr.io/eth-act/ere/ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4
+
       - name: Run benchmark
         run: RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} stateless-validator
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
       - name: Check zkevm-metrics folder
         run: |
@@ -112,7 +90,7 @@ jobs:
 
   empty-program:
     name: Empty program guest
-    runs-on: [self-hosted-ghr, size-xl-x64]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -125,16 +103,13 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
       
-      - name: Install C toolchain dependencies
+      - name: Pull ere image
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential clang libclang-dev
+          docker pull ghcr.io/eth-act/ere/ere-base:0.0.11-06d15a4
+          docker pull ghcr.io/eth-act/ere/ere-base-${{ matrix.zkvm }}:0.0.11-06d15a4
 
       - name: Run benchmark
         run: RUST_LOG=info cargo run -p ere-hosts --release -- --zkvms ${{ matrix.zkvm }} --action ${{ matrix.action }} empty-program
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       
       - name: Check zkevm-metrics folder
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "build-utils"
 version = "0.0.11"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=cb037368d6ac02486deede9b059202a355b0234f#cb037368d6ac02486deede9b059202a355b0234f"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=06d15a4a77feef4772a37bee964dcec5733f9eff#06d15a4a77feef4772a37bee964dcec5733f9eff"
 dependencies = [
  "cargo_metadata",
  "thiserror 2.0.12",
@@ -2467,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "ere-cli"
 version = "0.0.11"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=cb037368d6ac02486deede9b059202a355b0234f#cb037368d6ac02486deede9b059202a355b0234f"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=06d15a4a77feef4772a37bee964dcec5733f9eff#06d15a4a77feef4772a37bee964dcec5733f9eff"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "ere-dockerized"
 version = "0.0.11"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=cb037368d6ac02486deede9b059202a355b0234f#cb037368d6ac02486deede9b059202a355b0234f"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=06d15a4a77feef4772a37bee964dcec5733f9eff#06d15a4a77feef4772a37bee964dcec5733f9eff"
 dependencies = [
  "bincode",
  "build-utils",
@@ -9581,7 +9581,7 @@ dependencies = [
 [[package]]
 name = "zkvm-interface"
 version = "0.0.11"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=cb037368d6ac02486deede9b059202a355b0234f#cb037368d6ac02486deede9b059202a355b0234f"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=06d15a4a77feef4772a37bee964dcec5733f9eff#06d15a4a77feef4772a37bee964dcec5733f9eff"
 dependencies = [
  "auto_impl",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,8 +108,8 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 guest-libs = { path = "ere-guests/libs" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "cb037368d6ac02486deede9b059202a355b0234f", package = "zkvm-interface" }
-ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", rev = "cb037368d6ac02486deede9b059202a355b0234f", package = "ere-dockerized" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "06d15a4a77feef4772a37bee964dcec5733f9eff", package = "zkvm-interface" }
+ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", rev = "06d15a4a77feef4772a37bee964dcec5733f9eff", package = "ere-dockerized" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.


### PR DESCRIPTION
This PR:
- Use `ere` images so we avoid building base and SDK docker images which take a lot of time and generate GH rate limiting problems.
- I switched to using GH runners instead of devops. Now that the pipeline is less heavy it's better, since devops needed also an extra step to instal the C toolchain which takes time. Plus, sometimes it took 2m just to start the workflow compared to GH runners which start immediately.
- Refactor the guest program runs so we avoid duplication