### PR TITLE
CI: add Zisk to integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,12 +42,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zkvm: [sp1, risc0]
+        zkvm: [sp1, risc0, zisk]
         action: [execute, prove]
         program: [stateless-validator, empty-program]
         exclude:
           - program: stateless-validator
             action: prove
+          - program: stateless-validator # See issue #142
+            zkvm: zisk
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,6 +50,10 @@ jobs:
             action: prove
           - program: stateless-validator # See issue #142
             zkvm: zisk
+          - program: empty-program # Setup too complex for CI and ere image doesn't bake big proving key
+            zkvm: zisk
+            action: prove
+
 
     steps:
       - name: Checkout code

--- a/ere-guests/Cargo.toml
+++ b/ere-guests/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     # Empty program
     "empty-program/sp1",
     "empty-program/risc0",
+    "empty-program/zisk",
 
     # Block encoding length
     "block-encoding-length/sp1",

--- a/ere-guests/empty-program/zisk/Cargo.toml
+++ b/ere-guests/empty-program/zisk/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "zisk-empty-program"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+ziskos = { git = "https://github.com/0xPolygonHermez/zisk.git", rev = "f9a3655" }
+
+[lints]
+workspace = true

--- a/ere-guests/empty-program/zisk/src/main.rs
+++ b/ere-guests/empty-program/zisk/src/main.rs
@@ -1,0 +1,6 @@
+//! ZisK guest program
+#![no_main]
+ziskos::entrypoint!(main);
+
+/// Entry point
+pub fn main() {}


### PR DESCRIPTION
Add Zisk to the integration tests CI, only for the `empty-program` since `stateless-validator` is blocked by #142