### PR TITLE
xtask: update sp1 patches

### DIFF
--- a/precompile-patches/sp1.toml
+++ b/precompile-patches/sp1.toml
@@ -1,9 +1,10 @@
 [patch.crates-io]
-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-5.0.0", package = "substrate-bn" }
-sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
+sha2-v0-10-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.9-sp1-4.0.0" }
+sha3-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
 crypto-bigint = { git = "https://github.com/sp1-patches/RustCrypto-bigint", tag = "patch-0.5.5-sp1-4.0.0" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0" }
 curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-5.0.0" }
 k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-5.0.0" }
 p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-5.0.0" }
+substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-5.0.0" }
 ecdsa = { git = "https://github.com/sp1-patches/signatures", tag = "patch-16.9-sp1-4.1.0" }


### PR DESCRIPTION
Recently, I [added](https://github.com/eth-act/zkevm-benchmark-workload/pull/153) a CI workflow which fails if some existing patch is claimed not to be applied, which probably means the patch is outdated compared to waht the `stateless-validator` dependency graph is using.

That's okay, but we still once in a while have to double check if any patch is missing since that's not detectable via CI of course.

This PR contains some changes for SP1:
- Adds some missing patches that are used indeed (not quite useful, but still apply so I think is better to stick to that rule).
- I keep the same ordering and naming as the [SP1 table docs](https://docs.succinct.xyz/docs/sp1/optimizing-programs/precompiles#patched-crates). This reduces the risk of manual checking, since different ordering or renamings can increase the risk of missing something.