### PR TITLE
ethrex: remove forked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,8 +1280,8 @@ dependencies = [
  "ere-dockerized",
  "ethrex-common",
  "ethrex-rlp",
- "ethrex-trie",
  "guest-libs",
+ "guest_program",
  "rayon",
  "reth-stateless",
  "rkyv",
@@ -1294,7 +1294,6 @@ dependencies = [
  "witness-generator",
  "zkevm-metrics",
  "zkvm-interface",
- "zkvm_interface",
 ]
 
 [[package]]
@@ -2714,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "ethrex-blockchain"
 version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2734,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "ethrex-common"
 version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2762,12 +2761,12 @@ dependencies = [
 [[package]]
 name = "ethrex-crypto"
 version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
 
 [[package]]
 name = "ethrex-l2-common"
 version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2778,6 +2777,7 @@ dependencies = [
  "ethrex-vm",
  "keccak-hash",
  "lambdaworks-crypto",
+ "secp256k1 0.29.1",
  "serde",
  "sha3",
  "thiserror 2.0.12",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "ethrex-levm"
 version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2818,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "ethrex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
 dependencies = [
  "ethrex-common",
  "serde",
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rlp"
 version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2844,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "ethrex-storage"
 version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2865,7 +2865,7 @@ dependencies = [
 [[package]]
 name = "ethrex-trie"
 version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2885,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "ethrex-vm"
 version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
 dependencies = [
  "bincode",
  "bytes",
@@ -3370,6 +3370,26 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+]
+
+[[package]]
+name = "guest_program"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef86eae5348be046740a1045e551ce90c742caf9#ef86eae5348be046740a1045e551ce90c742caf9"
+dependencies = [
+ "ethrex-blockchain",
+ "ethrex-common",
+ "ethrex-l2-common",
+ "ethrex-rlp",
+ "ethrex-storage",
+ "ethrex-trie",
+ "ethrex-vm",
+ "hex",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -10503,26 +10523,6 @@ dependencies = [
  "erased-serde",
  "indexmap 2.10.0",
  "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "zkvm_interface"
-version = "0.1.0"
-source = "git+https://github.com/jsign/ethrex.git?rev=d77ca445024800e981dab5ddcc69f4d55622d6c1#d77ca445024800e981dab5ddcc69f4d55622d6c1"
-dependencies = [
- "ethrex-blockchain",
- "ethrex-common",
- "ethrex-l2-common",
- "ethrex-rlp",
- "ethrex-storage",
- "ethrex-trie",
- "ethrex-vm",
- "hex",
- "rkyv",
- "serde",
- "serde_json",
- "serde_with",
  "thiserror 2.0.12",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,10 +121,9 @@ reth-errors = { git = "https://github.com/kevaundray/reth", rev = "fa3efe112aaaf
 reth-trie-common = { git = "https://github.com/kevaundray/reth", rev = "fa3efe112aaaf1d18b56212d537a83c3cc681782" }
 reth-chainspec = { git = "https://github.com/kevaundray/reth", rev = "fa3efe112aaaf1d18b56212d537a83c3cc681782" }
 
-ethrex-zkvm_interface = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", package = "zkvm_interface" }
-ethrex-common = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
-ethrex-rlp = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
-ethrex-trie = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
+ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", package = "guest_program" }
+ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
+ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
 
 
 # alloy

--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -17,10 +17,9 @@ alloy-eips.workspace = true
 
 reth-stateless.workspace = true
 
-ethrex-zkvm_interface.workspace = true
+ethrex-guest-program.workspace = true
 ethrex-common.workspace = true
 ethrex-rlp.workspace = true
-ethrex-trie.workspace = true
 
 rayon.workspace = true
 tracing.workspace = true

--- a/ere-guests/stateless-validator/ethrex/risc0/Cargo.toml
+++ b/ere-guests/stateless-validator/ethrex/risc0/Cargo.toml
@@ -12,18 +12,18 @@ risc0-zkvm = { version = "3.0.3", default-features = false, features = [
 ] }
 rkyv = "0.8.10"
 
-zkvm_interface = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false, features = [
+zkvm_interface = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false, features = [
     "c-kzg",
 ] }
 
-ethrex-common = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
-ethrex-storage = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
-ethrex-rlp = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1" }
-ethrex-vm = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false, features = [
+ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
+ethrex-storage = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
+ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9" }
+ethrex-vm = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false, features = [
     "c-kzg",
 ] }
-ethrex-blockchain = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
-ethrex-l2-common = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
+ethrex-blockchain = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
+ethrex-l2-common = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }

--- a/ere-guests/stateless-validator/ethrex/sp1/Cargo.toml
+++ b/ere-guests/stateless-validator/ethrex/sp1/Cargo.toml
@@ -6,17 +6,18 @@ edition = "2024"
 [workspace]
 
 [dependencies]
-sp1-zkvm = { version = "=5.0.8", features = ["embedded"] }
-rkyv = "0.8.10"
+sp1-zkvm = { version = "=5.0.8" }
+rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
 
-zkvm_interface = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1" }
 
-ethrex-common = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
-ethrex-storage = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
-ethrex-rlp = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1" }
-ethrex-vm = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
-ethrex-blockchain = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
-ethrex-l2-common = { git = "https://github.com/jsign/ethrex.git", rev = "d77ca445024800e981dab5ddcc69f4d55622d6c1", default-features = false }
+guest_program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9" }
+
+ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
+ethrex-storage = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
+ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9" }
+ethrex-vm = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
+ethrex-blockchain = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
+ethrex-l2-common = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef86eae5348be046740a1045e551ce90c742caf9", default-features = false }
 
 [patch.crates-io]
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
@@ -37,4 +38,4 @@ k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k2
 bls12_381 = { git = "https://github.com/lambdaclass/bls12_381-patch/", branch = "expose-fp-struct" }
 
 [features]
-l2 = ["zkvm_interface/l2"]
+l2 = ["guest_program/l2", "sp1-zkvm/embedded"]

--- a/ere-guests/stateless-validator/ethrex/sp1/src/main.rs
+++ b/ere-guests/stateless-validator/ethrex/sp1/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
+use guest_program::{execution::execution_program, input::ProgramInput};
 use rkyv::rancor::Error;
-use zkvm_interface::{execution::execution_program, io::ProgramInput};
 
 sp1_zkvm::entrypoint!(main);
 


### PR DESCRIPTION
Fixes https://github.com/eth-act/zkevm-benchmark-workload/issues/162

This PR is using the still open https://github.com/lambdaclass/ethrex/pull/4317 to have quick feedback that the PR intention is doing what we need. 

For now all is looking good -- I'll keep this in draft until the underlying PR is merged, switch to the corresponding `ethrex@main` commit and then merge.