### PR TITLE
zisk: update ere for latest zisk rustc compiler & enable mainnet blocks in integration testing

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  ERE_TAG: 0.0.12-7514710
+  ERE_TAG: 0.0.12-2f979db
 
 jobs: 
   witness-generator:
@@ -52,13 +52,16 @@ jobs:
           - execute_mainnet_blocks
           - execute_invalid_block
           - prove_empty_block
-        zkvm: [sp1, risc0, openvm, pico]
+        zkvm: [sp1, risc0, openvm, pico, zisk]
         el: [reth, ethrex]
         exclude:
-          # Pico - Skipped combinations
+          # Pico
           - zkvm: pico
             test: prove_empty_block # See https://github.com/eth-act/ere/issues/173
-          # Ethrex - Skipped combinations
+          # ZisK
+          - zkvm: zisk
+            test: prove_empty_block # ere image intentionally doesn't bake big proving key for CI 
+          # Ethrex
           - el: ethrex
             test: execute_mainnet_blocks # Still quite heavy to run in CI
           - el: ethrex

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,7 +1504,7 @@ dependencies = [
 [[package]]
 name = "build-utils"
 version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=75147106b299cb7e9dcc30077d50c1f7b019979d#75147106b299cb7e9dcc30077d50c1f7b019979d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=2f979dbd01fc11a08a6c9d650f5f8fad698e8469#2f979dbd01fc11a08a6c9d650f5f8fad698e8469"
 dependencies = [
  "cargo_metadata",
  "thiserror 2.0.12",
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "ere-cli"
 version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=75147106b299cb7e9dcc30077d50c1f7b019979d#75147106b299cb7e9dcc30077d50c1f7b019979d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=2f979dbd01fc11a08a6c9d650f5f8fad698e8469#2f979dbd01fc11a08a6c9d650f5f8fad698e8469"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2600,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "ere-dockerized"
 version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=75147106b299cb7e9dcc30077d50c1f7b019979d#75147106b299cb7e9dcc30077d50c1f7b019979d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=2f979dbd01fc11a08a6c9d650f5f8fad698e8469#2f979dbd01fc11a08a6c9d650f5f8fad698e8469"
 dependencies = [
  "bincode",
  "build-utils",
@@ -10516,7 +10516,7 @@ dependencies = [
 [[package]]
 name = "zkvm-interface"
 version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=75147106b299cb7e9dcc30077d50c1f7b019979d#75147106b299cb7e9dcc30077d50c1f7b019979d"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=2f979dbd01fc11a08a6c9d650f5f8fad698e8469#2f979dbd01fc11a08a6c9d650f5f8fad698e8469"
 dependencies = [
  "auto_impl",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 guest-libs = { path = "ere-guests/libs" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "75147106b299cb7e9dcc30077d50c1f7b019979d", package = "zkvm-interface" }
-ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", rev = "75147106b299cb7e9dcc30077d50c1f7b019979d", package = "ere-dockerized" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "2f979dbd01fc11a08a6c9d650f5f8fad698e8469", package = "zkvm-interface" }
+ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", rev = "2f979dbd01fc11a08a6c9d650f5f8fad698e8469", package = "ere-dockerized" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.

--- a/tests/src/stateless_validator.rs
+++ b/tests/src/stateless_validator.rs
@@ -38,10 +38,12 @@ mod tests {
             (ExecutionClient::Reth, ErezkVM::Risc0),
             (ExecutionClient::Reth, ErezkVM::OpenVM),
             (ExecutionClient::Reth, ErezkVM::Pico),
+            (ExecutionClient::Reth, ErezkVM::Zisk),
             (ExecutionClient::Ethrex, ErezkVM::SP1),
             // (ExecutionClient::Ethrex, ErezkVM::Risc0), // See https://github.com/eth-act/ere/issues/121
             // (ExecutionClient::Ethrex, ErezkVM::OpenVM), // See https://github.com/eth-act/ere/issues/168
             // (ExecutionClient::Ethrex, ErezkVM::Pico), // See https://github.com/eth-act/ere/issues/174
+            // (ExecutionClient::Ethrex, ErezkVM::Zisk), // See https://github.com/eth-act/ere/issues/XXX
         ]);
         empty_block(Action::Execute, &el_zkvms).await;
     }
@@ -53,6 +55,7 @@ mod tests {
             ErezkVM::Risc0,
             ErezkVM::OpenVM,
             ErezkVM::Pico,
+            ErezkVM::Zisk,
         ]);
         for zkvm in &zkvms {
             println!("Using zkVM: {zkvm}");
@@ -67,14 +70,18 @@ mod tests {
                 .join("mainnet-zkevm-fixtures-input");
             let mut expected_inputs = 15;
 
-            // See issue https://github.com/eth-act/zkevm-benchmark-workload/issues/175
-            if zkvm == &ErezkVM::Pico {
-                let skipped = ["rpc_block_22974584.json", "rpc_block_22974587.json"];
-                for file in &skipped {
-                    println!("Skipping problematic block {file}");
-                    std::fs::remove_file(input_folder.join(file)).unwrap();
-                    expected_inputs -= 1;
+            let skipped = match zkvm {
+                // See https://github.com/eth-act/zkevm-benchmark-workload/issues/175
+                // See https://github.com/eth-act/zkevm-benchmark-workload/issues/XXX
+                ErezkVM::Pico | ErezkVM::Zisk => {
+                    vec!["rpc_block_22974584.json", "rpc_block_22974587.json"]
                 }
+                _ => vec![],
+            };
+            for file in &skipped {
+                println!("Skipping problematic block {file}");
+                std::fs::remove_file(input_folder.join(file)).unwrap();
+                expected_inputs -= 1;
             }
 
             let output_folder = tempdir().unwrap();
@@ -126,6 +133,7 @@ mod tests {
                 ErezkVM::Risc0,
                 ErezkVM::OpenVM,
                 ErezkVM::Pico,
+                ErezkVM::Zisk,
             ]),
             inputs,
             output_folder.path(),


### PR DESCRIPTION
This PR:
- Updates to the latest ere, which contains [merged PR](https://github.com/eth-act/ere/pull/133) with rebuilt ZisK using rustc 1.89.
- Since #142 was a blocker for `stateless-validator` compiling, we can now enable execution of the `execute_mainnet_blocks` integration testing for ZisK.


Fixes #142 