### PR TITLE
chore: update ere to v0.0.12

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  ERE_TAG: 0.0.12-2f979db
+  ERE_TAG: 0.0.12-7ef4598
   OPENVM_RUST_TOOLCHAIN: nightly-2025-08-07
 
 jobs: 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "build-utils"
 version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=2f979dbd01fc11a08a6c9d650f5f8fad698e8469#2f979dbd01fc11a08a6c9d650f5f8fad698e8469"
+source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.12#7ef45985942f93dc0a7e49448bd6d0639fa27c41"
 dependencies = [
  "cargo_metadata",
  "thiserror 2.0.16",
@@ -2666,7 +2666,7 @@ dependencies = [
 [[package]]
 name = "ere-cli"
 version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=2f979dbd01fc11a08a6c9d650f5f8fad698e8469#2f979dbd01fc11a08a6c9d650f5f8fad698e8469"
+source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.12#7ef45985942f93dc0a7e49448bd6d0639fa27c41"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "ere-dockerized"
 version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=2f979dbd01fc11a08a6c9d650f5f8fad698e8469#2f979dbd01fc11a08a6c9d650f5f8fad698e8469"
+source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.12#7ef45985942f93dc0a7e49448bd6d0639fa27c41"
 dependencies = [
  "bincode",
  "build-utils",
@@ -2687,6 +2687,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 2.0.16",
+ "tracing",
  "zkvm-interface",
 ]
 
@@ -10636,7 +10637,7 @@ dependencies = [
 [[package]]
 name = "zkvm-interface"
 version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=2f979dbd01fc11a08a6c9d650f5f8fad698e8469#2f979dbd01fc11a08a6c9d650f5f8fad698e8469"
+source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.12#7ef45985942f93dc0a7e49448bd6d0639fa27c41"
 dependencies = [
  "auto_impl",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 guest-libs = { path = "ere-guests/libs" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "2f979dbd01fc11a08a6c9d650f5f8fad698e8469", package = "zkvm-interface" }
-ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", rev = "2f979dbd01fc11a08a6c9d650f5f8fad698e8469", package = "ere-dockerized" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.12", package = "zkvm-interface" }
+ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.12", package = "ere-dockerized" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.


### PR DESCRIPTION
Update ere to v0.0.12. In particular, because it has a temporary workaround to allow using ZisK without patching ere's dep in this repo (https://github.com/eth-act/ere/pull/137).

To use ZisK remember to export:
- `CUDA_ARCH=sm_{xx}` to your corresponding GPU arch.
- For 4090/L40s you will need also `ZISK_UNLOCK_MAPPED_MEMORY=1`