### PR TITLE
[DONOTMERGE] zisk: reproducer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 guest-libs = { path = "ere-guests/libs" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.12", package = "zkvm-interface" }
-ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.12", package = "ere-dockerized" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "4fd2d5203b80ac6c13b2e5c72a808afa95323811", package = "zkvm-interface" }
+ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", rev = "4fd2d5203b80ac6c13b2e5c72a808afa95323811", package = "ere-dockerized" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.


### PR DESCRIPTION
Steps to reproduce:

1. Pull this branch.
2. Do `export CUDA_ARCH=sm_89` or matching gpu arch if your GPU isn’t `sm_90`. (If you're curious about this [see here](https://github.com/eth-act/ere/issues/134) and [underlying PR](https://github.com/eth-act/ere/pull/137) that we merged to workaround -- but this is not related to this prob :))
3. Run `RUST_LOG=info RUSTFLAGS="-C target-cpu=native -C target-feature=+avx512f" cargo run --release -p ere-hosts -- --zkvms zisk --action prove --resource gpu stateless-validator --execution-client reth` (remove avx512f flag depending on your CPU)

The first time you run 3. you'll see many docker builds. That should only happen once (and whenever you change the `ere` dependency if you want to experiment with changing things there).

Notes:

- This branch already has a `zkevm-fixtures-input` with a mainnet block to simplify not having to generate inputs to run.
- This [branch has a variant of ere](https://github.com/eth-act/ere/compare/jsign-shm-32) with the `--shm-size=32GB` change.
- If you [do `export ZISK_UNLOCK_MAPPED_MEMORY=1`](https://github.com/eth-act/ere/blob/3e4491d043cdd83098c1036a447012742c94b171/crates/ere-zisk/src/lib.rs#L68) and run, then things work okay -- so you can play also with it.
- Delete `zkevm-metrics` after run, so when you try re-running it won't skip the failed fixture.

---

Ran this in a L40 and host with 128GiB of RAM:
<img width="2546" height="2412" alt="image" src="https://github.com/user-attachments/assets/6a4a2ff6-01da-4d84-a69a-aff681acb1f3" />
