### PR TITLE
zisk: fix v0.11.0 precompiles

### DIFF
--- a/precompile-patches/zisk.toml
+++ b/precompile-patches/zisk.toml
@@ -1,7 +1,7 @@
 # Copied from https://github.com/0xPolygonHermez/zisk-eth-client/blob/main/bin/client/Cargo.toml
 [patch.crates-io]
-sha2 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", branch = "zisk-patch-sha2/v0.10.9" }
-sha3 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", branch = "zisk-patch-sha3/v0.10.8" }
-k256 = { git = "https://github.com/0xPolygonHermez/zisk-patch-elliptic-curves.git", branch = "zisk-patch-k256/v0.13.4" }
-bn = { git = "https://github.com/0xPolygonHermez/zisk-patch-bn.git", branch = "zisk-patch-bn/v0.6.0", package = "substrate-bn" }
+sha2 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", tag = "patch-sha2-0.10.9-zisk-0.11.0" }
+sha3 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", tag = "patch-sha3-0.10.8-zisk-0.11.0" }
+k256 = { git = "https://github.com/0xPolygonHermez/zisk-patch-elliptic-curves.git", tag = "patch-k256-0.13.4-zisk-0.11.0" }
+bn = { git = "https://github.com/0xPolygonHermez/zisk-patch-bn.git", tag = "patch-0.6.0-zisk-0.11.0", package = "substrate-bn" }
 sp1_bls12_381 = { git = "https://github.com/han0110/bls12_381.git", branch = "zisk-patch/v0.8.0-upgrade-sp1-lib" }


### PR DESCRIPTION
The new precompiles are now scoped to SDK v0.11.0, since the previous tags were force pushed by the ZisK team preparing for the v0.12.0 release.