### PR TITLE
Update ere, enable Pico proving in integration tests & ZisK v0.12.0 adjustments

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,9 +62,6 @@ jobs:
             threads: 2
           - threads: 12
         exclude:
-          # Pico
-          - zkvm: pico
-            test: prove_empty_block # See https://github.com/eth-act/ere/issues/173
           # ZisK
           - zkvm: zisk
             test: prove_empty_block # ere image intentionally doesn't bake big proving key for CI

--- a/.github/workflows/run-benchmark.yml
+++ b/.github/workflows/run-benchmark.yml
@@ -30,7 +30,7 @@ jobs:
     name: ${{ inputs.zkvm }} - ${{ inputs.test }}
     runs-on: [self-hosted-ghr, size-xl-x64]
     env:
-      ERE_TAG: 0.0.12-7ef4598
+      ERE_TAG: 0.0.13-b8a1cfa
       OPENVM_RUST_TOOLCHAIN: nightly-2025-08-07
     steps:
       - name: Checkout code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,8 +1559,8 @@ dependencies = [
 
 [[package]]
 name = "build-utils"
-version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.12#7ef45985942f93dc0a7e49448bd6d0639fa27c41"
+version = "0.0.13"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=b8a1cfae86f18cc9a437b8e8e8bc8d0af5712b17#b8a1cfae86f18cc9a437b8e8e8bc8d0af5712b17"
 dependencies = [
  "cargo_metadata",
  "thiserror 2.0.17",
@@ -2683,8 +2683,8 @@ dependencies = [
 
 [[package]]
 name = "ere-cli"
-version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.12#7ef45985942f93dc0a7e49448bd6d0639fa27c41"
+version = "0.0.13"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=b8a1cfae86f18cc9a437b8e8e8bc8d0af5712b17#b8a1cfae86f18cc9a437b8e8e8bc8d0af5712b17"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2694,8 +2694,8 @@ dependencies = [
 
 [[package]]
 name = "ere-dockerized"
-version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.12#7ef45985942f93dc0a7e49448bd6d0639fa27c41"
+version = "0.0.13"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=b8a1cfae86f18cc9a437b8e8e8bc8d0af5712b17#b8a1cfae86f18cc9a437b8e8e8bc8d0af5712b17"
 dependencies = [
  "bincode",
  "build-utils",
@@ -10643,8 +10643,8 @@ dependencies = [
 
 [[package]]
 name = "zkvm-interface"
-version = "0.0.12"
-source = "git+https://github.com/eth-applied-research-group/ere?tag=v0.0.12#7ef45985942f93dc0a7e49448bd6d0639fa27c41"
+version = "0.0.13"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=b8a1cfae86f18cc9a437b8e8e8bc8d0af5712b17#b8a1cfae86f18cc9a437b8e8e8bc8d0af5712b17"
 dependencies = [
  "auto_impl",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 guest-libs = { path = "ere-guests/libs" }
 
-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.12", package = "zkvm-interface" }
-ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", tag = "v0.0.12", package = "ere-dockerized" }
+zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "b8a1cfae86f18cc9a437b8e8e8bc8d0af5712b17", package = "zkvm-interface" }
+ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", rev = "b8a1cfae86f18cc9a437b8e8e8bc8d0af5712b17", package = "ere-dockerized" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.

--- a/ere-guests/Cargo.toml
+++ b/ere-guests/Cargo.toml
@@ -183,10 +183,6 @@ k256 = { version = "0.13", default-features = false, features = [
 ] }
 sparsestate = { git = "https://github.com/eth-act/zkvm-ethereum-mpt.git", tag = "v0.1.0" }
 
-# Patch `ziskos` of `zisk-patch-*` to pin to the same version of guest.
-[patch."https://github.com/0xPolygonHermez/zisk.git"]
-ziskos = { git = "https://github.com/0xPolygonHermez//zisk.git", tag = "v0.12.0" }
-
 [patch."https://github.com/paradigmxyz/reth"]
 reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "bb7a98e4f9a173d19e2e218126e9bfe344201b8d" }
 reth-errors = { git = "https://github.com/kevaundray/reth", rev = "bb7a98e4f9a173d19e2e218126e9bfe344201b8d" }

--- a/ere-guests/Cargo.toml
+++ b/ere-guests/Cargo.toml
@@ -126,7 +126,7 @@ ere-reth-guest = { path = "stateless-validator/reth/guest" }
 
 sp1-zkvm = "5.0.5"
 pico-sdk = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.7" }
-ziskos = { git = "https://github.com/0xPolygonHermez/zisk.git" }
+ziskos = { git = "https://github.com/0xPolygonHermez/zisk.git", tag = "v0.12.0" }
 risc0-zkvm = { version = "3.0.3", default-features = false, features = [
     "std",
     "unstable",
@@ -185,7 +185,7 @@ sparsestate = { git = "https://github.com/eth-act/zkvm-ethereum-mpt.git", tag = 
 
 # Patch `ziskos` of `zisk-patch-*` to pin to the same version of guest.
 [patch."https://github.com/0xPolygonHermez/zisk.git"]
-ziskos = { git = "https://github.com/0xPolygonHermez//zisk.git", tag = "v0.11.0" }
+ziskos = { git = "https://github.com/0xPolygonHermez//zisk.git", tag = "v0.12.0" }
 
 [patch."https://github.com/paradigmxyz/reth"]
 reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "bb7a98e4f9a173d19e2e218126e9bfe344201b8d" }

--- a/precompile-patches/zisk.toml
+++ b/precompile-patches/zisk.toml
@@ -4,4 +4,4 @@ sha2 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", tag =
 sha3 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", tag = "patch-sha3-0.10.8-zisk-0.12.0" }
 k256 = { git = "https://github.com/0xPolygonHermez/zisk-patch-elliptic-curves.git", tag = "patch-k256-0.13.4-zisk-0.12.0" }
 bn = { git = "https://github.com/0xPolygonHermez/zisk-patch-bn.git", tag = "patch-0.6.0-zisk-0.12.0", package = "substrate-bn" }
-sp1_bls12_381 = { git = "https://github.com/han0110/bls12_381.git", tag = "patch-0.8.0-zisk-0.12.0" }
+sp1_bls12_381 = { git = "https://github.com/jsign/bls12_381.git", tag = "patch-0.8.0-zisk-0.12.0" }

--- a/precompile-patches/zisk.toml
+++ b/precompile-patches/zisk.toml
@@ -1,7 +1,7 @@
 # Copied from https://github.com/0xPolygonHermez/zisk-eth-client/blob/main/bin/client/Cargo.toml
 [patch.crates-io]
-sha2 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", tag = "patch-sha2-0.10.9-zisk-0.11.0" }
-sha3 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", tag = "patch-sha3-0.10.8-zisk-0.11.0" }
-k256 = { git = "https://github.com/0xPolygonHermez/zisk-patch-elliptic-curves.git", tag = "patch-k256-0.13.4-zisk-0.11.0" }
-bn = { git = "https://github.com/0xPolygonHermez/zisk-patch-bn.git", tag = "patch-0.6.0-zisk-0.11.0", package = "substrate-bn" }
-sp1_bls12_381 = { git = "https://github.com/han0110/bls12_381.git", branch = "zisk-patch/v0.8.0-upgrade-sp1-lib" }
+sha2 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", tag = "patch-sha2-0.10.9-zisk-0.12.0" }
+sha3 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", tag = "patch-sha3-0.10.8-zisk-0.12.0" }
+k256 = { git = "https://github.com/0xPolygonHermez/zisk-patch-elliptic-curves.git", tag = "patch-k256-0.13.4-zisk-0.12.0" }
+bn = { git = "https://github.com/0xPolygonHermez/zisk-patch-bn.git", tag = "patch-0.6.0-zisk-0.12.0", package = "substrate-bn" }
+sp1_bls12_381 = { git = "https://github.com/han0110/bls12_381.git", tag = "patch-0.8.0-zisk-0.12.0" }

--- a/tests/src/stateless_validator.rs
+++ b/tests/src/stateless_validator.rs
@@ -22,7 +22,7 @@ mod tests {
             (ExecutionClient::Reth, ErezkVM::SP1),
             (ExecutionClient::Reth, ErezkVM::Risc0),
             (ExecutionClient::Reth, ErezkVM::OpenVM),
-            // (ExecutionClient::Reth, ErezkVM::Pico), // See https://github.com/eth-act/ere/issues/173
+            (ExecutionClient::Reth, ErezkVM::Pico),
             (ExecutionClient::Ethrex, ErezkVM::SP1),
             (ExecutionClient::Ethrex, ErezkVM::Risc0),
             // (ExecutionClient::Ethrex, ErezkVM::OpenVM), // See https://github.com/eth-act/ere/issues/168


### PR DESCRIPTION
This PR updates `ere` to the latest commit, which:
- Enables to fix #173
- Update ZisK related configurations (i.e, precompiles, deps)