### PR TITLE
guests: add extra public inputs to do proper CL checks

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,7 +1,8 @@
 name: Integration tests
 on:
   push:
-    branches: [ master ]
+    # branches: [ master ]
+    branches: **
   pull_request:
     branches: [ master ]
   workflow_dispatch:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,8 +1,7 @@
 name: Integration tests
 on:
   push:
-    # branches: [ master ]
-    branches: **
+    branches: [ master ]
   pull_request:
     branches: [ master ]
   workflow_dispatch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,6 +3444,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
  "ethereum_ssz",
  "ethereum_ssz_derive",

--- a/crates/benchmark-runner/src/stateless_validator.rs
+++ b/crates/benchmark-runner/src/stateless_validator.rs
@@ -164,7 +164,14 @@ impl OutputVerifier for ProgramOutputVerifier {
                 }
             }
             ErezkVM::OpenVM | ErezkVM::Zisk => {
-                let public_inputs = (self.block_hash, self.parent_hash, self.success);
+                let public_inputs = (
+                    self.block_hash,
+                    self.parent_hash,
+                    self.versioned_hashes_hash,
+                    self.parent_beacon_block_root,
+                    self.requests_hash,
+                    self.success,
+                );
                 let public_inputs_hash =
                     Sha256::digest(bincode::serialize(&public_inputs).unwrap());
 

--- a/ere-guests/Cargo.toml
+++ b/ere-guests/Cargo.toml
@@ -154,6 +154,7 @@ reth-trie-common = { git = "https://github.com/kevaundray/reth", rev = "bb7a98e4
 alloy-primitives = { version = "1.3.1", default-features = false }
 alloy-consensus = { version = "1.0.35", default-features = false }
 alloy-eips = { version = "1.0.35" }
+alloy-genesis = { version = "1.0.35", default-features = false }
 alloy-hardforks = { version = "0.3.5", default-features = false }
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-rlp = { version = "0.3.10", default-features = false }

--- a/ere-guests/libs/Cargo.toml
+++ b/ere-guests/libs/Cargo.toml
@@ -16,6 +16,7 @@ reth-chainspec.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
+alloy-genesis.workspace = true
 
 serde = { workspace = true, features = ["derive"] }
 serde_with.workspace = true

--- a/ere-guests/libs/src/blobs.rs
+++ b/ere-guests/libs/src/blobs.rs
@@ -1,0 +1,27 @@
+//! Utilities for working with blob versioned hashes in Ethereum blocks.
+//!
+//! This module is currently used as a temporary workaround to allow proper validation of CL kzg blob commitments
+//! against the execution block, until this is properly implemented as a formal EL header field.
+
+use alloy_genesis::ChainConfig;
+use k256::sha2::{Digest, Sha256};
+use reth_ethereum_primitives::Block;
+
+/// Calculates the hash of all versioned hashes in a block if Cancun is active at the block's number and timestamp.
+pub fn calculate_versioned_hashes_hash(
+    chain_config: &ChainConfig,
+    block: &Block,
+) -> Option<[u8; 32]> {
+    chain_config
+        .is_cancun_active_at_block_and_timestamp(block.number, block.timestamp)
+        .then_some(
+            Sha256::digest(block.body.blob_versioned_hashes_iter().fold(
+                Vec::new(),
+                |mut acc, hash| {
+                    acc.extend_from_slice(&hash.0);
+                    acc
+                },
+            ))
+            .into(),
+        )
+}

--- a/ere-guests/libs/src/lib.rs
+++ b/ere-guests/libs/src/lib.rs
@@ -7,6 +7,7 @@ use reth_ethereum_primitives::Block;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
+pub mod blobs;
 pub mod block_ssz;
 pub mod senders;
 

--- a/ere-guests/stateless-validator/ethrex/risc0/Cargo.toml
+++ b/ere-guests/stateless-validator/ethrex/risc0/Cargo.toml
@@ -17,6 +17,7 @@ guest_program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "cfb8
     "c-kzg",
 ] }
 rkyv = { version = "0.8.10", features = ["unaligned"] }
+k256 = { version = "=0.13.4", default-features = false }
 
 
 ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", rev = "cfb805c6c70df1f6172f1982c9ed8952b7399d28", default-features = false }

--- a/ere-guests/stateless-validator/ethrex/risc0/src/main.rs
+++ b/ere-guests/stateless-validator/ethrex/risc0/src/main.rs
@@ -1,6 +1,7 @@
 use risc0_zkvm::guest::env;
 
 use guest_program::{execution::execution_program, input::ProgramInput};
+use k256::sha2::{Digest, Sha256};
 use rkyv::rancor::Error;
 
 fn main() {
@@ -18,6 +19,26 @@ fn main() {
     // and just checking them again.
     input.blocks[0].header.hash = Default::default();
     let parent_hash = input.blocks[0].header.parent_hash;
+    let versioned_hashes_hash: Option<[u8; 32]> = input
+        .execution_witness
+        .chain_config
+        .is_cancun_activated(input.blocks[0].header.timestamp)
+        .then_some(
+            Sha256::digest(
+                input.blocks[0]
+                    .body
+                    .transactions
+                    .iter()
+                    .flat_map(|tx| tx.blob_versioned_hashes())
+                    .fold(Vec::new(), |mut acc, h| {
+                        acc.extend_from_slice(&h.0);
+                        acc
+                    }),
+            )
+            .into(),
+        );
+    let parent_beacon_block_root = input.blocks[0].header.parent_beacon_block_root.map(|h| h.0);
+    let requests_hash = input.blocks[0].header.requests_hash.map(|h| h.0);
     let end = env::cycle_count();
     eprintln!("public inputs preparation (cycle tracker): {}", end - start);
 
@@ -26,6 +47,9 @@ fn main() {
     if input.blocks.len() != 1 {
         env::commit(&block_hash.0);
         env::commit(&parent_hash.0);
+        env::commit(&versioned_hashes_hash);
+        env::commit(&parent_beacon_block_root);
+        env::commit(&requests_hash);
         env::commit(&false);
         return;
     }
@@ -43,11 +67,17 @@ fn main() {
         Ok(out) => {
             env::commit(&out.last_block_hash.0);
             env::commit(&parent_hash.0);
+            env::commit(&versioned_hashes_hash);
+            env::commit(&parent_beacon_block_root);
+            env::commit(&requests_hash);
             env::commit(&true);
         }
         Err(_) => {
             env::commit(&block_hash.0);
             env::commit(&parent_hash.0);
+            env::commit(&versioned_hashes_hash);
+            env::commit(&parent_beacon_block_root);
+            env::commit(&requests_hash);
             env::commit(&false);
         }
     }

--- a/ere-guests/stateless-validator/ethrex/sp1/Cargo.toml
+++ b/ere-guests/stateless-validator/ethrex/sp1/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 [dependencies]
 sp1-zkvm = { version = "=5.0.8" }
 rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
+k256 = { version = "=0.13.4", default-features = false }
 
 
 guest_program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "cfb805c6c70df1f6172f1982c9ed8952b7399d28" }

--- a/ere-guests/stateless-validator/ethrex/sp1/src/main.rs
+++ b/ere-guests/stateless-validator/ethrex/sp1/src/main.rs
@@ -1,6 +1,7 @@
 #![no_main]
 
 use guest_program::{execution::execution_program, input::ProgramInput};
+use k256::sha2::{Digest, Sha256};
 use rkyv::rancor::Error;
 
 sp1_zkvm::entrypoint!(main);
@@ -17,12 +18,35 @@ pub fn main() {
     // and just checking them again.
     input.blocks[0].header.hash = Default::default();
     let parent_hash = input.blocks[0].header.parent_hash;
+    let versioned_hashes_hash: Option<[u8; 32]> = input
+        .execution_witness
+        .chain_config
+        .is_cancun_activated(input.blocks[0].header.timestamp)
+        .then_some(
+            Sha256::digest(
+                input.blocks[0]
+                    .body
+                    .transactions
+                    .iter()
+                    .flat_map(|tx| tx.blob_versioned_hashes())
+                    .fold(Vec::new(), |mut acc, h| {
+                        acc.extend_from_slice(&h.0);
+                        acc
+                    }),
+            )
+            .into(),
+        );
+    let parent_beacon_block_root = input.blocks[0].header.parent_beacon_block_root.map(|h| h.0);
+    let requests_hash = input.blocks[0].header.requests_hash.map(|h| h.0);
     println!("cycle-tracker-report-end: public_inputs_preparation");
 
     println!("cycle-tracker-report-start: validation");
     if input.blocks.len() != 1 {
         sp1_zkvm::io::commit(&block_hash.0);
         sp1_zkvm::io::commit(&parent_hash.0);
+        sp1_zkvm::io::commit(&versioned_hashes_hash);
+        sp1_zkvm::io::commit(&parent_beacon_block_root);
+        sp1_zkvm::io::commit(&requests_hash);
         sp1_zkvm::io::commit(&false);
         return;
     }
@@ -34,11 +58,17 @@ pub fn main() {
         Ok(out) => {
             sp1_zkvm::io::commit(&out.last_block_hash.0);
             sp1_zkvm::io::commit(&parent_hash.0);
+            sp1_zkvm::io::commit(&versioned_hashes_hash);
+            sp1_zkvm::io::commit(&parent_beacon_block_root);
+            sp1_zkvm::io::commit(&requests_hash);
             sp1_zkvm::io::commit(&true);
         }
         Err(_) => {
             sp1_zkvm::io::commit(&block_hash.0);
             sp1_zkvm::io::commit(&parent_hash.0);
+            sp1_zkvm::io::commit(&versioned_hashes_hash);
+            sp1_zkvm::io::commit(&parent_beacon_block_root);
+            sp1_zkvm::io::commit(&requests_hash);
             sp1_zkvm::io::commit(&false);
         }
     }

--- a/ere-guests/stateless-validator/reth/guest/src/sdk.rs
+++ b/ere-guests/stateless-validator/reth/guest/src/sdk.rs
@@ -8,9 +8,18 @@ pub trait SDK {
     /// Reads the expected inputs for the block validation.
     fn read_inputs() -> (StatelessInput, Vec<VerifyingKey>);
     /// Commits the outputs from the block validation.
-    fn commit_outputs(block_hash: [u8; 32], parent_hash: [u8; 32], is_valid: bool);
+    fn commit_outputs(pi: &PublicInputs);
     /// Prints a message to the host environment.
     fn cycle_scope(scope: ScopeMarker, message: &str);
+}
+
+pub struct PublicInputs {
+    pub block_hash: [u8; 32],
+    pub parent_hash: [u8; 32],
+    pub versioned_hashes_hash: Option<[u8; 32]>,
+    pub parent_beacon_block_root: Option<[u8; 32]>,
+    pub requests_hash: Option<[u8; 32]>,
+    pub is_valid: bool,
 }
 
 /// Enum to represent the start and end of a cycle scope for tracking purposes.

--- a/ere-guests/stateless-validator/reth/openvm/src/main.rs
+++ b/ere-guests/stateless-validator/reth/openvm/src/main.rs
@@ -2,7 +2,7 @@
 
 use ere_reth_guest::{
     guest::ethereum_guest,
-    sdk::{ScopeMarker, SDK},
+    sdk::{PublicInputs, ScopeMarker, SDK},
 };
 use k256::ecdsa::VerifyingKey;
 use openvm::io::{read, reveal_bytes32};
@@ -23,8 +23,15 @@ impl SDK for OpenVMSDK {
         (input, public_keys)
     }
 
-    fn commit_outputs(block_hash: [u8; 32], parent_hash: [u8; 32], is_valid: bool) {
-        let public_inputs = (block_hash, parent_hash, is_valid);
+    fn commit_outputs(pi: &PublicInputs) {
+        let public_inputs = (
+            pi.block_hash,
+            pi.parent_hash,
+            pi.versioned_hashes_hash,
+            pi.parent_beacon_block_root,
+            pi.requests_hash,
+            pi.is_valid,
+        );
         let public_inputs_hash = Sha256::digest(bincode::serialize(&public_inputs).unwrap());
         reveal_bytes32(public_inputs_hash.into());
     }

--- a/ere-guests/stateless-validator/reth/pico/src/main.rs
+++ b/ere-guests/stateless-validator/reth/pico/src/main.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use ere_reth_guest::{
     guest::ethereum_guest,
-    sdk::{SDK, ScopeMarker},
+    sdk::{PublicInputs, SDK, ScopeMarker},
 };
 use k256::ecdsa::VerifyingKey;
 use pico_sdk::io::{commit, read_as};
@@ -23,10 +23,13 @@ impl SDK for PicoSDK {
         (input, public_keys)
     }
 
-    fn commit_outputs(block_hash: [u8; 32], parent_hash: [u8; 32], is_valid: bool) {
-        commit(&block_hash);
-        commit(&parent_hash);
-        commit(&is_valid);
+    fn commit_outputs(pi: &PublicInputs) {
+        commit(&pi.block_hash);
+        commit(&pi.parent_hash);
+        commit(&pi.versioned_hashes_hash);
+        commit(&pi.parent_beacon_block_root);
+        commit(&pi.requests_hash);
+        commit(&pi.is_valid);
     }
 
     fn cycle_scope(scope: ScopeMarker, message: &str) {

--- a/ere-guests/stateless-validator/reth/risc0/src/main.rs
+++ b/ere-guests/stateless-validator/reth/risc0/src/main.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 
 use ere_reth_guest::{
     guest::ethereum_guest,
-    sdk::{ScopeMarker, SDK},
+    sdk::{PublicInputs, ScopeMarker, SDK},
 };
 use k256::ecdsa::VerifyingKey;
 use reth_stateless::StatelessInput;
@@ -19,10 +19,13 @@ impl SDK for Risc0SDK {
         (input, public_keys)
     }
 
-    fn commit_outputs(block_hash: [u8; 32], parent_hash: [u8; 32], is_valid: bool) {
-        env::commit(&block_hash);
-        env::commit(&parent_hash);
-        env::commit(&is_valid);
+    fn commit_outputs(pi: &PublicInputs) {
+        env::commit(&pi.block_hash);
+        env::commit(&pi.parent_hash);
+        env::commit(&pi.versioned_hashes_hash);
+        env::commit(&pi.parent_beacon_block_root);
+        env::commit(&pi.requests_hash);
+        env::commit(&pi.is_valid);
     }
 
     fn cycle_scope(_scope: ScopeMarker, _message: &str) {}

--- a/ere-guests/stateless-validator/reth/sp1/src/main.rs
+++ b/ere-guests/stateless-validator/reth/sp1/src/main.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use ere_reth_guest::{
     guest::ethereum_guest,
-    sdk::{ScopeMarker, SDK},
+    sdk::{PublicInputs, SDK, ScopeMarker},
 };
 use k256::ecdsa::VerifyingKey;
 use reth_stateless::StatelessInput;
@@ -24,10 +24,13 @@ impl SDK for SP1SDK {
         (input, public_keys)
     }
 
-    fn commit_outputs(block_hash: [u8; 32], parent_hash: [u8; 32], is_valid: bool) {
-        sp1_zkvm::io::commit(&block_hash);
-        sp1_zkvm::io::commit(&parent_hash);
-        sp1_zkvm::io::commit(&is_valid);
+    fn commit_outputs(pi: &PublicInputs) {
+        sp1_zkvm::io::commit(&pi.block_hash);
+        sp1_zkvm::io::commit(&pi.parent_hash);
+        sp1_zkvm::io::commit(&pi.versioned_hashes_hash);
+        sp1_zkvm::io::commit(&pi.parent_beacon_block_root);
+        sp1_zkvm::io::commit(&pi.requests_hash);
+        sp1_zkvm::io::commit(&pi.is_valid);
     }
 
     fn cycle_scope(scope: ScopeMarker, message: &str) {

--- a/ere-guests/stateless-validator/reth/zisk/src/main.rs
+++ b/ere-guests/stateless-validator/reth/zisk/src/main.rs
@@ -6,7 +6,7 @@ use std::io::Cursor;
 
 use ere_reth_guest::{
     guest::ethereum_guest,
-    sdk::{ScopeMarker, SDK},
+    sdk::{PublicInputs, SDK, ScopeMarker},
 };
 use k256::ecdsa::VerifyingKey;
 use reth_stateless::StatelessInput;
@@ -25,8 +25,15 @@ impl SDK for ZiskSDK {
         (input, public_keys)
     }
 
-    fn commit_outputs(block_hash: [u8; 32], parent_hash: [u8; 32], is_valid: bool) {
-        let public_inputs = (block_hash, parent_hash, is_valid);
+    fn commit_outputs(pi: &PublicInputs) {
+        let public_inputs = (
+            pi.block_hash,
+            pi.parent_hash,
+            pi.versioned_hashes_hash,
+            pi.parent_beacon_block_root,
+            pi.requests_hash,
+            pi.is_valid,
+        );
         let public_inputs_hash = Sha256::digest(bincode::serialize(&public_inputs).unwrap());
         public_inputs_hash
             .chunks_exact(4)


### PR DESCRIPTION
This is a workaround until we decide on a full solution to address https://github.com/ethereum/consensus-specs/issues/4637. 

This PR adds three extra public inputs to do proper assertions in zkCLs regarding the EL block validity.