### PR TITLE
ci: use devops cache

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
       

--- a/.github/workflows/run-benchmark.yml
+++ b/.github/workflows/run-benchmark.yml
@@ -46,7 +46,7 @@ jobs:
           sudo apt-get install -y protobuf-compiler pkg-config libssl-dev sccache build-essential clang libclang-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Restore Rust cache
         uses: EthDevOps/action-cache@846782e812a5f02b48f3317d7dee5bff3d9e34de

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
        
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
This PR adds the new devops cache capability to speed up a bit the compiling work in the custom runners (https://github.com/ethereum/devops/issues/2018).