### PR TITLE
Update ere for OpenVM proving fix

### DIFF
--- a/.github/workflows/run-benchmark.yml
+++ b/.github/workflows/run-benchmark.yml
@@ -25,7 +25,7 @@ jobs:
     name: ${{ inputs.zkvm }} / ${{ inputs.el }}
     runs-on: [self-hosted-ghr, size-xl-x64]
     env:
-      ERE_TAG: 0.0.14-1de217d
+      ERE_TAG: 0.0.14-7b8bb6a
       OPENVM_RUST_TOOLCHAIN: nightly-2025-08-07
       RUSTC_WRAPPER: sccache
       SCCACHE_DIR: ${{ github.workspace }}/.sccache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "ere-build-utils"
 version = "0.0.14"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=98bded75ec5e59a78fd34c786c8530a989874d95#98bded75ec5e59a78fd34c786c8530a989874d95"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8#7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8"
 dependencies = [
  "cargo_metadata",
 ]
@@ -2584,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "ere-dockerized"
 version = "0.0.14"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=98bded75ec5e59a78fd34c786c8530a989874d95#98bded75ec5e59a78fd34c786c8530a989874d95"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8#7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8"
 dependencies = [
  "anyhow",
  "ere-build-utils",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "ere-io-serde"
 version = "0.0.14"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=98bded75ec5e59a78fd34c786c8530a989874d95#98bded75ec5e59a78fd34c786c8530a989874d95"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8#7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "ere-server"
 version = "0.0.14"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=98bded75ec5e59a78fd34c786c8530a989874d95#98bded75ec5e59a78fd34c786c8530a989874d95"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8#7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "ere-zkvm-interface"
 version = "0.0.14"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=98bded75ec5e59a78fd34c786c8530a989874d95#98bded75ec5e59a78fd34c786c8530a989874d95"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8#7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8"
 dependencies = [
  "anyhow",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,9 +113,9 @@ guest-libs = { path = "ere-guests/libs" }
 reth-guest-io = { path = "ere-guests/stateless-validator/reth/io" }
 block-encoding-length-io = { path = "ere-guests/block-encoding-length/io" }
 
-ere-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "98bded75ec5e59a78fd34c786c8530a989874d95", package = "ere-zkvm-interface" }
-ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", rev = "98bded75ec5e59a78fd34c786c8530a989874d95", package = "ere-dockerized" }
-ere-io-serde = { git = "https://github.com/eth-applied-research-group/ere", rev = "98bded75ec5e59a78fd34c786c8530a989874d95", package = "ere-io-serde" }
+ere-zkvm-interface = { git = "https://github.com/eth-applied-research-group/ere", rev = "7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8", package = "ere-zkvm-interface" }
+ere-dockerized = { git = "https://github.com/eth-applied-research-group/ere", rev = "7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8", package = "ere-dockerized" }
+ere-io-serde = { git = "https://github.com/eth-applied-research-group/ere", rev = "7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8", package = "ere-io-serde" }
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.

--- a/ere-guests/Cargo.lock
+++ b/ere-guests/Cargo.lock
@@ -1994,7 +1994,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-io-serde"
 version = "0.0.14"
-source = "git+https://github.com/eth-applied-research-group/ere?rev=98bded75ec5e59a78fd34c786c8530a989874d95#98bded75ec5e59a78fd34c786c8530a989874d95"
+source = "git+https://github.com/eth-applied-research-group/ere?rev=7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8#7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8"
 dependencies = [
  "bincode 2.0.1",
  "serde",

--- a/ere-guests/Cargo.toml
+++ b/ere-guests/Cargo.toml
@@ -128,7 +128,7 @@ guest-libs = { path = "libs", default-features = false }
 reth-guest = { path = "stateless-validator/reth/guest", default-features = false }
 reth-guest-io = { path = "stateless-validator/reth/io", default-features = false }
 block-encoding-length-io = { path = "block-encoding-length/io", default-features = false }
-ere-io-serde = { git = "https://github.com/eth-applied-research-group/ere", rev = "98bded75ec5e59a78fd34c786c8530a989874d95", default-features = false }
+ere-io-serde = { git = "https://github.com/eth-applied-research-group/ere", rev = "7b8bb6adcdaae68b2b3c1c410b1d3c40721a82e8", default-features = false }
 
 sp1-zkvm = "5.2.2"
 pico-sdk = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.7" }


### PR DESCRIPTION
Update ere to contain https://github.com/eth-act/ere/pull/208 so OpenVM can work for GPU proving without RUSTFLAGS for AMD CPUs.
