### PR TITLE
feat: allow raw input dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ target
 zkevm-fixtures*
 # zkevm metrics file
 zkevm-metrics*
+# zkevm dump
+zkevm-dump
 
 # vscode settings
 .vscode

--- a/README.md
+++ b/README.md
@@ -137,9 +137,40 @@ This repository contains an `xtask` that will automate this process by calling `
     
     # Use custom input folder for stateless validator benchmarks
     cargo run --release -- stateless-validator --execution-client reth --input-folder my-fixtures
+
+    # Dump raw input files used in benchmarks (opt-in)
+    cargo run --release -- --zkvms sp1 --dump-inputs my-inputs stateless-validator --execution-client reth
     ```
 
     See the respective README files in each crate for detailed usage instructions.
+
+### Dumping Input Files
+
+The `--dump-inputs` flag allows you to save the raw serialized input bytes used for each benchmark run. This is useful for:
+- Debugging guest programs independently
+- Analyzing input data characteristics
+- Replaying specific test cases outside the benchmark framework
+
+When specified, input files are saved to the designated folder with the following structure:
+```
+{dump-folder}/
+  └── {sub-folder}/       # e.g., "reth" for stateless-validator, empty for others
+      └── {name}.bin      # Input files (one per benchmark)
+```
+
+Example usage:
+```bash
+cd crates/ere-hosts
+
+# Dump inputs for stateless validator with Reth
+cargo run --release -- --zkvms sp1 --dump-inputs debug-inputs stateless-validator --execution-client reth
+
+# This creates files like:
+# debug-inputs/reth/block-12345.bin
+# debug-inputs/reth/block-12346.bin
+```
+
+Note: Input files are zkVM-independent (the same input is used across all zkVMs), so they're only written once even when benchmarking multiple zkVMs.
 
 ## Guest Program Types
 

--- a/crates/ere-hosts/src/cli.rs
+++ b/crates/ere-hosts/src/cli.rs
@@ -38,6 +38,10 @@ pub struct Cli {
     /// Output folder for benchmark results
     #[arg(short, long, default_value = "zkevm-metrics")]
     pub output_folder: PathBuf,
+
+    /// Output folder for dumping input files used in benchmarks
+    #[arg(long)]
+    pub dump_inputs: Option<PathBuf>,
 }
 
 /// Subcommands for different guest programs

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -62,6 +62,7 @@ fn main() -> Result<()> {
                 sub_folder: Some(el.as_ref().to_lowercase()),
                 action,
                 force_rerun: cli.force_rerun,
+                dump_inputs_folder: cli.dump_inputs.clone(),
             };
             for zkvm in zkvms {
                 run_benchmark(&zkvm, &config, guest_io.clone())?;
@@ -83,6 +84,7 @@ fn main() -> Result<()> {
                 sub_folder: None,
                 action,
                 force_rerun: cli.force_rerun,
+                dump_inputs_folder: cli.dump_inputs.clone(),
             };
             for zkvm in zkvms {
                 run_benchmark(&zkvm, &config, vec![guest_io.clone()])?;
@@ -116,6 +118,7 @@ fn main() -> Result<()> {
                 sub_folder: None,
                 action,
                 force_rerun: cli.force_rerun,
+                dump_inputs_folder: cli.dump_inputs.clone(),
             };
             for zkvm in zkvms {
                 run_benchmark(&zkvm, &config, guest_io.clone())?;

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -36,6 +36,7 @@ pub(crate) fn run_guest<T, OV>(
         sub_folder,
         action,
         force_rerun: true,
+        dump_inputs_folder: None,
     };
     let instances = get_zkvm_instances(
         zkvms,


### PR DESCRIPTION
This PR adds a new feature via an optional flag to dump the raw inputs passed to the guest programs.

The underlying motivation to simplify using specific zkVM tools directly for deeper debugging or benchmarking, since usually they require the ELF and tha raw inputs directly. It can also be interesting to analyze the raw input size. 

More details in the .md doc update.