### PR TITLE
ci: use lz4 to speedup cache compression

### DIFF
--- a/.github/workflows/run-benchmark.yml
+++ b/.github/workflows/run-benchmark.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler pkg-config libssl-dev sccache build-essential clang libclang-dev
+          sudo apt-get install -y protobuf-compiler pkg-config libssl-dev sccache build-essential clang libclang-dev lz4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Noticed this in the CI runs:
```
...
Archiving 16578 paths
lz4 not found, using gzip compression
/usr/bin/tar --no-recursion -C /opt/actions-runner/_work/zkevm-benchmark-workload/zkevm-benchmark-workload --use-compress-program=gzip -cf /opt/actions-runner/_work/_temp/cache-1763679009628-8eg6a/Linux-cargo-openvm-reth-e4133d195432c7f31177cf6700d48a47e73d4c906f4c8f070c00e3dba403191f.tar.lz4 --files-from /opt/actions-runner/_work/_temp/cache-1763679009628-8eg6a/Linux-cargo-openvm-reth-e4133d195432c7f31177cf6700d48a47e73d4c906f4c8f070c00e3dba403191f.tar.lz4.filelist
Archive created: 1609.79 MB
Compression format: gzip
...
```

Installing LZ4 since it is much faster to compress files, and I noticed this since compressing with gzip for our cache size takes a reasonable time.