### PR TITLE
reth: stop using custom fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.23.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527b47dc39850c6168002ddc1f7a2063e15d26137c1bb5330f6065a7524c1aa9"
+checksum = "01be36ba6f5e6e62563b369e03ca529eac46aea50677f84655084b4750816574"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -242,8 +242,7 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.0.1",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
+ "op-alloy",
  "op-revm",
  "revm",
  "thiserror 2.0.17",
@@ -266,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e29d7eacf42f89c21d7f089916d0bdb4f36139a31698790e8837d2dbbd4b2c3"
+checksum = "2d9a33550fc21fd77a3f8b63e99969d17660eec8dcc50a95a80f7c9964f7680b"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -372,6 +371,42 @@ dependencies = [
  "serde",
  "sha3",
  "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d369e12c92870d069e0c9dc5350377067af8a056e29e3badf8446099d7e00889"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-sol-types",
+ "alloy-transport",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru 0.13.0",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -1174,6 +1209,28 @@ name = "asn1_der"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "async-trait"
@@ -2476,7 +2533,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2600,8 +2657,8 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2858,7 +2915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4924,6 +4981,15 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
@@ -5160,7 +5226,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "mpt"
 version = "0.1.0"
-source = "git+https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.3.0#c927b843a6c6104c5cc1de069f626de07cb090e0"
+source = "git+https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.4.0#d4d8f968c183aedc23100c3a5634dee14c320757"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5301,7 +5367,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5478,6 +5544,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "op-alloy"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b13412d297c1f9341f678b763750b120a73ffe998fa54a94d6eda98449e7ca"
+dependencies = [
+ "op-alloy-consensus",
+ "op-alloy-network",
+ "op-alloy-provider",
+ "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
+]
+
+[[package]]
 name = "op-alloy-consensus"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5485,13 +5564,65 @@ checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-eth",
  "alloy-serde",
  "arbitrary",
  "derive_more 2.0.1",
  "serde",
  "serde_with",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "op-alloy-network"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63f27e65be273ec8fcb0b6af0fd850b550979465ab93423705ceb3dfddbd2ab"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "op-alloy-consensus",
+ "op-alloy-rpc-types",
+]
+
+[[package]]
+name = "op-alloy-provider"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71456699aa256dc20119736422ad9a44da8b9585036117afb936778122093b9"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
+ "async-trait",
+ "op-alloy-rpc-types-engine",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562dd4462562c41f9fdc4d860858c40e14a25df7f983ae82047f15f08fce4d19"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "derive_more 2.0.1",
+ "op-alloy-consensus",
+ "serde",
+ "serde_json",
  "thiserror 2.0.17",
 ]
 
@@ -5518,9 +5649,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "12.0.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31622d03b29c826e48800f4c8f389c8a9c440eb796a3e35203561a288f12985"
+checksum = "1475a779c73999fc803778524042319691b31f3d6699d2b560c4ed8be1db802a"
 dependencies = [
  "auto_impl",
  "revm",
@@ -6438,7 +6569,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6705,8 +6836,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6729,8 +6860,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6760,8 +6891,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6780,8 +6911,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6797,8 +6928,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6817,8 +6948,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6827,14 +6958,15 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "eyre",
  "humantime-serde",
  "reth-network-types",
  "reth-prune-types",
  "reth-stages-types",
+ "reth-static-file-types",
  "serde",
  "toml",
  "url",
@@ -6842,8 +6974,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6855,8 +6987,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6867,8 +6999,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -6893,8 +7025,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6921,8 +7053,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6951,8 +7083,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6966,8 +7098,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6991,8 +7123,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7015,8 +7147,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7039,8 +7171,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7052,7 +7184,6 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "futures",
- "generic-array",
  "hmac",
  "pin-project",
  "rand 0.8.5",
@@ -7065,13 +7196,12 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "typenum",
 ]
 
 [[package]]
 name = "reth-engine-local"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7083,6 +7213,7 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-payload-builder",
  "reth-payload-primitives",
+ "reth-primitives-traits",
  "reth-storage-api",
  "reth-transaction-pool",
  "tokio",
@@ -7092,8 +7223,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7117,8 +7248,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7128,8 +7259,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7156,8 +7287,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7177,8 +7308,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7193,8 +7324,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7211,8 +7342,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7224,8 +7355,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7244,8 +7375,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7254,8 +7385,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7275,8 +7406,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7296,8 +7427,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7309,8 +7440,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7327,8 +7458,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "serde",
  "serde_json",
@@ -7358,8 +7489,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -7374,8 +7505,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "bindgen",
  "cc",
@@ -7383,8 +7514,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "futures",
  "metrics",
@@ -7395,16 +7526,17 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
+ "ipnet",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7417,8 +7549,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7472,8 +7604,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7497,8 +7629,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7519,8 +7651,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7534,8 +7666,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7548,8 +7680,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -7565,8 +7697,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7589,8 +7721,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7602,6 +7734,7 @@ dependencies = [
  "eyre",
  "futures",
  "humantime",
+ "ipnet",
  "rand 0.9.2",
  "reth-chainspec",
  "reth-cli-util",
@@ -7613,11 +7746,13 @@ dependencies = [
  "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-forks",
+ "reth-net-banlist",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
+ "reth-provider",
  "reth-prune-types",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
@@ -7632,6 +7767,7 @@ dependencies = [
  "serde",
  "shellexpand",
  "strum 0.27.2",
+ "thiserror 2.0.17",
  "toml",
  "tracing",
  "url",
@@ -7641,8 +7777,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7653,28 +7789,23 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
- "bytes",
- "modular-bitfield",
  "op-alloy-consensus",
- "reth-codecs",
  "reth-primitives-traits",
- "reth-zstd-compressors",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7694,8 +7825,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7706,9 +7837,10 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -7718,7 +7850,9 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
+ "reth-execution-types",
  "reth-primitives-traits",
+ "reth-trie-common",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -7726,8 +7860,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7759,8 +7893,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7803,8 +7937,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7818,8 +7952,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -7831,8 +7965,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7859,10 +7993,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
+ "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -7874,14 +8009,13 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
- "revm-context",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7924,8 +8058,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7971,8 +8105,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7987,8 +8121,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8001,8 +8135,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8026,13 +8160,12 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror 2.0.17",
- "tracing",
 ]
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -8042,8 +8175,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8061,12 +8194,13 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "revm-database",
+ "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8081,8 +8215,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8099,8 +8233,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8109,8 +8243,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "clap",
  "eyre",
@@ -8124,8 +8258,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "clap",
  "eyre",
@@ -8141,8 +8275,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8181,8 +8315,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8192,6 +8326,7 @@ dependencies = [
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
+ "parking_lot",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -8206,8 +8341,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8233,8 +8368,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8246,8 +8381,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8263,17 +8398,17 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "31.0.2"
+version = "33.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb67a5223602113cae59a305acde2d9936bc18f2478dda879a6124b267cebfb6"
+checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -8302,9 +8437,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "11.0.2"
+version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92850e150f4f99d46c05a20ad0cd09286a7ad4ee21866fffb87101de6e602231"
+checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
 dependencies = [
  "bitvec",
  "cfg-if 1.0.4",
@@ -8319,9 +8454,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "12.0.1"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d701e2c2347d65216b066489ab22a0a8e1f7b2568256110d73a7d5eff3385c"
+checksum = "431c9a14e4ef1be41ae503708fd02d974f80ef1f2b6b23b5e402e8d854d1b225"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -8362,9 +8497,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "12.0.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45418ed95cfdf0cb19effdbb7633cf2144cab7fb0e6ffd6b0eb9117a50adff6"
+checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -8381,9 +8516,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "12.0.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99801eac7da06cc112df2244bd5a64024f4ef21240e923b26e73c4b4a0e5da6"
+checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
 dependencies = [
  "auto_impl",
  "either",
@@ -8399,9 +8534,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21caa99f22184a6818946362778cccd3ff02f743c1e085bee87700671570ecb7"
+checksum = "a91cee0a75ef5f96b7e86f6c6a8bd4fda86eb37b57d501df6790418ee2b03c18"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -8417,9 +8552,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "29.0.1"
+version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22789ce92c5808c70185e3bc49732f987dc6fd907f77828c8d3470b2299c9c65"
+checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -8430,9 +8565,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "29.0.1"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968b124028960201abf6d6bf8e223f15fadebb4307df6b7dc9244a0aab5d2d05"
+checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8688,7 +8823,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9332,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "sparsestate"
 version = "0.1.0"
-source = "git+https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.3.0#c927b843a6c6104c5cc1de069f626de07cb090e0"
+source = "git+https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.4.0#d4d8f968c183aedc23100c3a5634dee14c320757"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9590,7 +9725,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,17 +122,17 @@ ere-io = { git = "https://github.com/eth-applied-research-group/ere", rev = "626
 
 # branch is kw/zkevm-benchmark-workload-repo
 # NOTE: We are using a branch of a branch that has not yet been merged into master.
-ef-tests = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-ethereum-primitives = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-rpc-api = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-primitives-traits = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-errors = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-trie-common = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-chainspec = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-evm-ethereum = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
+ef-tests = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241" }
+reth-stateless = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241" }
 
-sparsestate = { git = "https://github.com/eth-act/zkvm-ethereum-mpt.git", tag = "v0.3.0" }
+sparsestate = { git = "https://github.com/eth-act/zkvm-ethereum-mpt.git", tag = "v0.4.0" }
 
 ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "c68e76d6b569c60a667a1240a91e637bf2ea0d0b", package = "guest_program" }
 ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", rev = "c68e76d6b569c60a667a1240a91e637bf2ea0d0b", default-features = false }
@@ -140,20 +140,20 @@ ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex.git", rev = "c68e76d
 ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex.git", rev = "c68e76d6b569c60a667a1240a91e637bf2ea0d0b", default-features = false }
 
 # alloy
-alloy-eips = { version = "1.0.41" }
-alloy-rpc-types-eth = "1.0.41"
-alloy-consensus = { version = "1.0.41", default-features = false }
+alloy-eips = { version = "1.1.2" }
+alloy-rpc-types-eth = "1.1.2"
+alloy-consensus = { version = "1.1.2", default-features = false }
 alloy-primitives = { version = "1.4.1", default-features = false }
-alloy-hardforks = { version = "0.4.3", default-features = false }
+alloy-hardforks = { version = "0.4.5", default-features = false }
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-rlp = { version = "0.3.10", default-features = false }
 alloy-trie = { version = "0.9.1", default-features = false }
-alloy-genesis = { version = "1.0.41", default-features = false }
+alloy-genesis = { version = "1.1.2", default-features = false }
 
 ethereum_ssz_derive = "0.9"
 ethereum_ssz = "0.9"
 
-revm-bytecode = { version = "7.1.0", default-features = false }
+revm-bytecode = { version = "7.1.1", default-features = false }
 
 k256 = { version = "0.13", default-features = false }
 
@@ -182,9 +182,3 @@ bytes = "1.10"
 erased-serde = "0.4.8"
 once_cell = { version = "1.21", default-features = false }
 auto_impl = "1.3.0"
-
-[patch."https://github.com/paradigmxyz/reth"]
-reth-revm = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-errors = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-trie-common = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }

--- a/crates/witness-generator/src/rpc_generator.rs
+++ b/crates/witness-generator/src/rpc_generator.rs
@@ -10,7 +10,7 @@ use jsonrpsee::{
     http_client::{HeaderMap, HttpClient, HttpClientBuilder},
     tracing::{error, info},
 };
-use reth_chainspec::{Chain, HOLESKY, HOODI, MAINNET, NamedChain, SEPOLIA};
+use reth_chainspec::{Chain, HOLESKY, HOODI, NamedChain, SEPOLIA, mainnet_chain_config};
 use reth_ethereum_primitives::TransactionSigned;
 use reth_rpc_api::{DebugApiClient, EthApiClient};
 use reth_stateless::StatelessInput;
@@ -91,7 +91,7 @@ impl RpcBlocksAndWitnessesBuilder {
         let chain = Chain::from_id(chain_id.to());
 
         let chain_config = match chain.named() {
-            Some(NamedChain::Mainnet) => MAINNET.genesis.config.clone(),
+            Some(NamedChain::Mainnet) => mainnet_chain_config(),
             Some(NamedChain::Sepolia) => SEPOLIA.genesis.config.clone(),
             Some(NamedChain::Hoodi) => HOODI.genesis.config.clone(),
             Some(NamedChain::Holesky) => HOLESKY.genesis.config.clone(),

--- a/ere-guests/Cargo.lock
+++ b/ere-guests/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b151e38e42f1586a01369ec52a6934702731d07e8509a7307331b09f6c46dc"
+checksum = "8b6440213a22df93a87ed512d2f668e7dc1d62a05642d107f82d61edc9e12370"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -81,6 +81,7 @@ dependencies = [
  "alloy-trie 0.9.1",
  "alloy-tx-macros",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
@@ -96,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2d5e8668ef6215efdb7dcca6f22277b4e483a5650e05f5de22b2350971f4b8"
+checksum = "15d0bea09287942405c4f9d2a4f22d1e07611c2dbd9d5bf94b75366340f9e6e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -123,23 +124,25 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_with",
@@ -148,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5434834adaf64fa20a6fb90877bc1d33214c41b055cc49f82189c98614368cc"
+checksum = "4bd2c7ae05abcab4483ce821f12f285e01c0b33804e6883dd9ca1569a87ee2be"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -159,6 +162,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
@@ -170,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.22.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb19405755c6f94c9bb856f2b1449767074b7e2002e1ab2be0a79b9b28db322"
+checksum = "01be36ba6f5e6e62563b369e03ca529eac46aea50677f84655084b4750816574"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -181,46 +185,30 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.0.1",
- "revm 30.1.2",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "alloy-evm"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d4291974e3564db30f1d2bcb3ba4a53dbc927e9a6fce2edaf389a712204fbd"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-hardforks",
- "alloy-primitives",
- "alloy-sol-types",
- "auto_impl",
- "derive_more 2.0.1",
- "revm 31.0.0",
+ "revm 33.1.0",
  "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919a8471cfbed7bcd8cf1197a57dda583ce0e10c6385f6ff4e8b41304b223392"
+checksum = "fc47eaae86488b07ea8e20236184944072a78784a1f4993f8ec17b3aa5d08c21"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie 0.9.1",
+ "borsh",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e7f93a60ef3d867c93d43442ef3f2d8a1095450131c3d4e16bbbbf2166b9bd"
+checksum = "2d9a33550fc21fd77a3f8b63e99969d17660eec8dcc50a95a80f7c9964f7680b"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -231,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58f4f345cef483eab7374f2b6056973c7419ffe8ad35e994b7a7f5d8e0c7ba4"
+checksum = "7805124ad69e57bbae7731c9c344571700b2a18d351bda9e0eba521c991d1bcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -293,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388cf910e66bd4f309a81ef746dcf8f9bca2226e3577890a8d56c5839225cf46"
+checksum = "1b2ca3a434a6d49910a7e8e51797eb25db42ef8a5578c52d877fcb26d0afe7bc"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -305,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605ec375d91073851f566a3082548af69a28dca831b27a8be7c1b4c49f5c6ca2"
+checksum = "d9c4c53a8b0905d931e7921774a1830609713bd3e8222347963172b03a3ecc68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -319,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361cd87ead4ba7659bda8127902eda92d17fa7ceb18aba1676f7be10f7222487"
+checksum = "ed5fafb741c19b3cca4cdd04fa215c89413491f9695a3e928dee2ae5657f607e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -340,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64600fc6c312b7e0ba76f73a381059af044f4f21f43e07f51f1fa76c868fe302"
+checksum = "a6f180c399ca7c1e2fe17ea58343910cad0090878a696ff5a50241aee12fc529"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -351,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20d867dcf42019d4779519a1ceb55eba8d7f3d0e4f0a89bcba82b8f9eb01e48"
+checksum = "f3ce480400051b5217f19d6e9a82d9010cdde20f1ae9c00d53591e4a1afbb312"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -365,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74e91b0b553c115d14bd0ed41898309356dc85d0e3d4b9014c4e7715e48c8ad"
+checksum = "6d792e205ed3b72f795a8044c52877d2e6b6e9b1d13f431478121d8d4eaa9028"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -383,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84194d31220803f5f62d0a00f583fd3a062b36382e2bea446f1af96727754565"
+checksum = "0bd1247a8f90b465ef3f1207627547ec16940c35597875cdc09c49d58b19693c"
 dependencies = [
  "const-hex",
  "dunce",
@@ -399,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5383d34ea00079e6dd89c652bcbdb764db160cef84e6250926961a0b2295d04"
+checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -440,11 +428,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e52276fdb553d3c11563afad2898f4085165e4093604afe3d78b69afbf408f"
+checksum = "ae109e33814b49fc0a62f2528993aa8a2dd346c26959b151f05441dc0b9da292"
 dependencies = [
- "alloy-primitives",
  "darling 0.21.3",
  "proc-macro2",
  "quote",
@@ -1101,7 +1088,7 @@ dependencies = [
  "ere-platform-trait",
  "ethereum_ssz",
  "guest-libs",
- "reth-ethereum-primitives 1.8.3",
+ "reth-ethereum-primitives",
  "serde",
 ]
 
@@ -2172,7 +2159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2798,8 +2785,8 @@ dependencies = [
  "ere-platform-trait",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "reth-ethereum-primitives 1.8.3",
- "reth-primitives-traits 1.8.3",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
  "reth-stateless",
  "serde",
  "serde_json",
@@ -3686,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "mpt"
 version = "0.1.0"
-source = "git+https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.3.0#c927b843a6c6104c5cc1de069f626de07cb090e0"
+source = "git+https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.4.0#d4d8f968c183aedc23100c3a5634dee14c320757"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3919,7 +3906,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -3997,9 +3984,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42e9de945efe3c2fbd207e69720c9c1af2b8caa6872aee0e216450c25a3ca70"
+checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5570,58 +5557,38 @@ dependencies = [
  "ere-platform-airbender",
  "guest-libs",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "reth-ethereum-primitives 1.8.3",
+ "reth-ethereum-primitives",
  "reth-guest",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
  "reth-stateless",
- "revm 31.0.0",
+ "revm 33.1.0",
  "sha2",
 ]
 
 [[package]]
 name = "reth-chainspec"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.22.3",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie 0.9.1",
  "auto_impl",
  "derive_more 2.0.1",
- "reth-ethereum-forks 1.8.2",
- "reth-network-peers 1.8.2",
- "reth-primitives-traits 1.8.2",
- "serde_json",
-]
-
-[[package]]
-name = "reth-chainspec"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
-dependencies = [
- "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm 0.23.0",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie 0.9.1",
- "auto_impl",
- "derive_more 2.0.1",
- "reth-ethereum-forks 1.8.3",
- "reth-network-peers 1.8.3",
- "reth-primitives-traits 1.8.3",
+ "reth-ethereum-forks",
+ "reth-network-peers",
+ "reth-primitives-traits",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-codecs"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5638,8 +5605,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5648,92 +5615,70 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
- "reth-execution-types 1.8.3",
- "reth-primitives-traits 1.8.3",
+ "reth-execution-types",
+ "reth-primitives-traits",
  "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "reth-chainspec 1.8.3",
+ "reth-chainspec",
  "reth-consensus",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-db-models"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "reth-primitives-traits 1.8.2",
-]
-
-[[package]]
-name = "reth-db-models"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
- "reth-storage-errors 1.8.3",
+ "reth-storage-errors",
  "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "reth-chainspec 1.8.3",
+ "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
- "reth-execution-types 1.8.3",
- "reth-primitives-traits 1.8.3",
+ "reth-execution-types",
+ "reth-primitives-traits",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -5744,20 +5689,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "reth-primitives-traits 1.8.2",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5766,95 +5699,79 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "reth-codecs",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-evm"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.23.0",
+ "alloy-evm",
  "alloy-primitives",
  "auto_impl",
  "derive_more 2.0.1",
  "futures-util",
  "reth-execution-errors",
- "reth-execution-types 1.8.3",
- "reth-primitives-traits 1.8.3",
- "reth-storage-api 1.8.3",
- "reth-storage-errors 1.8.3",
+ "reth-execution-types",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-storage-errors",
  "reth-trie-common",
- "revm 31.0.0",
+ "revm 33.1.0",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.23.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "reth-chainspec 1.8.3",
- "reth-ethereum-forks 1.8.3",
- "reth-ethereum-primitives 1.8.3",
+ "reth-chainspec",
+ "reth-ethereum-forks",
+ "reth-ethereum-primitives",
  "reth-evm",
- "reth-execution-types 1.8.3",
- "reth-primitives-traits 1.8.3",
- "reth-storage-errors 1.8.3",
- "revm 31.0.0",
+ "reth-execution-types",
+ "reth-primitives-traits",
+ "reth-storage-errors",
+ "revm 33.1.0",
 ]
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
- "alloy-evm 0.23.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles 0.4.4",
- "reth-storage-errors 1.8.3",
+ "reth-storage-errors",
  "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "reth-execution-types"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.22.3",
+ "alloy-evm",
  "alloy-primitives",
  "derive_more 2.0.1",
- "reth-ethereum-primitives 1.8.2",
- "reth-primitives-traits 1.8.2",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
  "reth-trie-common",
- "revm 30.1.2",
-]
-
-[[package]]
-name = "reth-execution-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm 0.23.0",
- "alloy-primitives",
- "derive_more 2.0.1",
- "reth-ethereum-primitives 1.8.3",
- "reth-primitives-traits 1.8.3",
- "reth-trie-common",
- "revm 31.0.0",
+ "revm 33.1.0",
 ]
 
 [[package]]
@@ -5867,10 +5784,10 @@ dependencies = [
  "guest-libs",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
- "reth-chainspec 1.8.3",
- "reth-ethereum-primitives 1.8.3",
+ "reth-chainspec",
+ "reth-ethereum-primitives",
  "reth-evm-ethereum",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
  "reth-stateless",
  "reth-trie-common",
  "serde",
@@ -5880,20 +5797,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "serde_with",
- "thiserror 2.0.16",
- "url",
-]
-
-[[package]]
-name = "reth-network-peers"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5914,9 +5819,9 @@ dependencies = [
  "openvm-algebra-guest",
  "openvm-ecc-guest",
  "openvm-revm-crypto",
- "reth-ethereum-primitives 1.8.3",
+ "reth-ethereum-primitives",
  "reth-guest",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
  "reth-stateless",
  "sha2",
 ]
@@ -5930,39 +5835,18 @@ dependencies = [
  "guest-libs",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kzg-rs 0.2.7 (git+https://github.com/brevis-network/kzg-rs?rev=b93499a67494bc6d34e108032fd11d375fb886e0)",
- "reth-ethereum-primitives 1.8.3",
+ "reth-ethereum-primitives",
  "reth-guest",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
  "reth-stateless",
- "revm 31.0.0",
+ "revm 33.1.0",
  "sha2",
 ]
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie 0.9.1",
- "auto_impl",
- "bytes",
- "derive_more 2.0.1",
- "once_cell",
- "revm-bytecode 7.1.0",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5977,9 +5861,9 @@ dependencies = [
  "once_cell",
  "op-alloy-consensus",
  "reth-codecs",
- "revm-bytecode 7.1.0",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
+ "revm-bytecode 7.1.1",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
@@ -5988,18 +5872,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.0.1",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "reth-prune-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -6009,26 +5883,14 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
- "reth-primitives-traits 1.8.2",
- "reth-storage-api 1.8.2",
- "reth-storage-errors 1.8.2",
- "revm 30.1.2",
-]
-
-[[package]]
-name = "reth-revm"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
-dependencies = [
- "alloy-primitives",
- "reth-primitives-traits 1.8.3",
- "reth-storage-api 1.8.3",
- "reth-storage-errors 1.8.3",
- "revm 31.0.0",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "revm 33.1.0",
 ]
 
 [[package]]
@@ -6039,11 +5901,11 @@ dependencies = [
  "ere-platform-risc0",
  "guest-libs",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "reth-ethereum-primitives 1.8.3",
+ "reth-ethereum-primitives",
  "reth-guest",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
  "reth-stateless",
- "revm 31.0.0",
+ "revm 33.1.0",
  "sha2",
 ]
 
@@ -6055,11 +5917,11 @@ dependencies = [
  "ere-platform-sp1",
  "guest-libs",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "reth-ethereum-primitives 1.8.3",
+ "reth-ethereum-primitives",
  "reth-guest",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
  "reth-stateless",
- "revm 31.0.0",
+ "revm 33.1.0",
  "sha2",
  "tracing",
  "tracing-subscriber 0.3.20",
@@ -6067,17 +5929,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
-dependencies = [
- "alloy-primitives",
- "reth-trie-common",
-]
-
-[[package]]
-name = "reth-stages-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -6085,8 +5938,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6096,37 +5949,25 @@ dependencies = [
  "alloy-trie 0.9.1",
  "itertools 0.14.0",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "reth-chainspec 1.8.3",
+ "reth-chainspec",
  "reth-consensus",
  "reth-errors",
  "reth-ethereum-consensus",
- "reth-ethereum-primitives 1.8.3",
+ "reth-ethereum-primitives",
  "reth-evm",
- "reth-primitives-traits 1.8.3",
- "reth-revm 1.8.3",
+ "reth-primitives-traits",
+ "reth-revm",
  "reth-trie-common",
  "reth-trie-sparse",
  "serde",
  "serde_with",
  "thiserror 2.0.16",
- "tracing",
 ]
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.0.1",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -6136,84 +5977,46 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
- "reth-chainspec 1.8.2",
- "reth-db-models 1.8.2",
- "reth-ethereum-primitives 1.8.2",
- "reth-execution-types 1.8.2",
- "reth-primitives-traits 1.8.2",
- "reth-prune-types 1.8.2",
- "reth-stages-types 1.8.2",
- "reth-storage-errors 1.8.2",
+ "reth-chainspec",
+ "reth-db-models",
+ "reth-ethereum-primitives",
+ "reth-execution-types",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
  "reth-trie-common",
- "revm-database 9.0.3",
-]
-
-[[package]]
-name = "reth-storage-api"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "auto_impl",
- "reth-chainspec 1.8.3",
- "reth-db-models 1.8.3",
- "reth-ethereum-primitives 1.8.3",
- "reth-execution-types 1.8.3",
- "reth-primitives-traits 1.8.3",
- "reth-prune-types 1.8.3",
- "reth-stages-types 1.8.3",
- "reth-storage-errors 1.8.3",
- "reth-trie-common",
- "revm-database 9.0.3",
+ "revm-database 9.0.6",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more 2.0.1",
- "reth-primitives-traits 1.8.2",
- "reth-prune-types 1.8.2",
- "reth-static-file-types 1.8.2",
- "revm-database-interface 8.0.4",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "reth-storage-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more 2.0.1",
- "reth-primitives-traits 1.8.3",
- "reth-prune-types 1.8.3",
- "reth-static-file-types 1.8.3",
- "revm-database-interface 8.0.4",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-static-file-types",
+ "revm-database-interface 8.0.5",
  "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "reth-trie-common"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6222,21 +6025,21 @@ dependencies = [
  "derive_more 2.0.1",
  "itertools 0.14.0",
  "nybbles 0.4.4",
- "reth-primitives-traits 1.8.3",
- "revm-database 9.0.3",
+ "reth-primitives-traits",
+ "revm-database 9.0.6",
 ]
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie 0.9.1",
  "auto_impl",
  "reth-execution-errors",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
  "reth-trie-common",
  "smallvec",
  "tracing",
@@ -6251,18 +6054,18 @@ dependencies = [
  "ere-platform-zisk",
  "guest-libs",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "reth-ethereum-primitives 1.8.3",
+ "reth-ethereum-primitives",
  "reth-guest",
- "reth-primitives-traits 1.8.3",
+ "reth-primitives-traits",
  "reth-stateless",
- "revm 31.0.0",
+ "revm 33.1.0",
  "sha2",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "zstd",
 ]
@@ -6288,40 +6091,21 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "30.1.2"
+version = "33.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fad790fa1836288df2698203f996e04f942b0eec69fc7f614f0386b78d9f8a5"
+checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
 dependencies = [
- "revm-bytecode 7.1.0",
- "revm-context 10.1.2",
- "revm-context-interface 11.1.2",
- "revm-database 9.0.3",
- "revm-database-interface 8.0.4",
- "revm-handler 11.1.2",
- "revm-inspector 11.1.2",
- "revm-interpreter 27.0.2",
- "revm-precompile 28.1.1",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
-]
-
-[[package]]
-name = "revm"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7bba993ce958f0b6eb23d2644ea8360982cb60baffedf961441e36faba6a2ca"
-dependencies = [
- "revm-bytecode 7.1.0",
- "revm-context 11.0.0",
- "revm-context-interface 12.0.0",
- "revm-database 9.0.3",
- "revm-database-interface 8.0.4",
- "revm-handler 12.0.0",
- "revm-inspector 12.0.0",
- "revm-interpreter 29.0.0",
- "revm-precompile 29.0.0",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
+ "revm-bytecode 7.1.1",
+ "revm-context 12.1.0",
+ "revm-context-interface 13.1.0",
+ "revm-database 9.0.6",
+ "revm-database-interface 8.0.5",
+ "revm-handler 14.1.0",
+ "revm-inspector 14.1.0",
+ "revm-interpreter 31.1.0",
+ "revm-precompile 31.0.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
 ]
 
 [[package]]
@@ -6338,13 +6122,13 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2b51c414b7e79edd4a0569d06e2c4c029f8b60e5f3ee3e2fa21dc6c3717ee3"
+checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
- "revm-primitives 21.0.1",
+ "revm-primitives 21.0.2",
  "serde",
 ]
 
@@ -6367,34 +6151,18 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "10.1.2"
+version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7adcce0c14cf59b7128de34185a0fbf8f63309539b9263b35ead870d73584114"
+checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
 dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode 7.1.0",
- "revm-context-interface 11.1.2",
- "revm-database-interface 8.0.4",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
-]
-
-[[package]]
-name = "revm-context"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69efee45130bd9e5b0a7af27552fddc70bc161dafed533c2f818a2d1eb654e6"
-dependencies = [
- "bitvec",
- "cfg-if",
- "derive-where",
- "revm-bytecode 7.1.0",
- "revm-context-interface 12.0.0",
- "revm-database-interface 8.0.4",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
+ "revm-bytecode 7.1.1",
+ "revm-context-interface 13.1.0",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "serde",
 ]
 
@@ -6416,32 +6184,17 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "11.1.2"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d620a9725e443c171fb195a074331fa4a745fa5cbb0018b4bbf42619e64b563"
+checksum = "431c9a14e4ef1be41ae503708fd02d974f80ef1f2b6b23b5e402e8d854d1b225"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface 8.0.4",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
-]
-
-[[package]]
-name = "revm-context-interface"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce2525e93db0ae2a3ec7dcde5443dfdb6fbf321c5090380d775730c67bc6cee"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "auto_impl",
- "either",
- "revm-database-interface 8.0.4",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "serde",
 ]
 
@@ -6461,15 +6214,15 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "9.0.3"
+version = "9.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2602625aa11ab1eda8e208e96b652c0bfa989b86c104a36537a62b081228af9"
+checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
 dependencies = [
  "alloy-eips",
- "revm-bytecode 7.1.0",
- "revm-database-interface 8.0.4",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
+ "revm-bytecode 7.1.1",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "serde",
 ]
 
@@ -6488,14 +6241,14 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a4621143d6515e32f969306d9c85797ae0d3fe0c74784f1fda02ba441e5a08"
+checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "serde",
 ]
 
@@ -6520,38 +6273,20 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "11.1.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54384bb0b081184c3ba3fc66e72781ff6ca5a8408067000f58255ab515b2fdb0"
+checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode 7.1.0",
- "revm-context 10.1.2",
- "revm-context-interface 11.1.2",
- "revm-database-interface 8.0.4",
- "revm-interpreter 27.0.2",
- "revm-precompile 28.1.1",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
-]
-
-[[package]]
-name = "revm-handler"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e756198d43b6c4c5886548ffbc4594412d1a82b81723525c6e85ed6da0e91c5f"
-dependencies = [
- "auto_impl",
- "derive-where",
- "revm-bytecode 7.1.0",
- "revm-context 11.0.0",
- "revm-context-interface 12.0.0",
- "revm-database-interface 8.0.4",
- "revm-interpreter 29.0.0",
- "revm-precompile 29.0.0",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
+ "revm-bytecode 7.1.1",
+ "revm-context 12.1.0",
+ "revm-context-interface 13.1.0",
+ "revm-database-interface 8.0.5",
+ "revm-interpreter 31.1.0",
+ "revm-precompile 31.0.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "serde",
 ]
 
@@ -6574,34 +6309,18 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "11.1.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0ed01fe30ba5f5690115cbe531962bbbfc12603c695ceaddc28d457a646a05"
+checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context 10.1.2",
- "revm-database-interface 8.0.4",
- "revm-handler 11.1.2",
- "revm-interpreter 27.0.2",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
-]
-
-[[package]]
-name = "revm-inspector"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fdd1e74cc99c6173c8692b6e480291e2ad0c21c716d9dc16e937ab2e0da219"
-dependencies = [
- "auto_impl",
- "either",
- "revm-context 11.0.0",
- "revm-database-interface 8.0.4",
- "revm-handler 12.0.0",
- "revm-interpreter 29.0.0",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
+ "revm-context 12.1.0",
+ "revm-database-interface 8.0.5",
+ "revm-handler 14.1.0",
+ "revm-interpreter 31.1.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "serde",
  "serde_json",
 ]
@@ -6620,26 +6339,14 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "27.0.2"
+version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0834fc25c020061f0f801d8de8bb53c88a63631cca5884a6c65b90c85e241138"
+checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
 dependencies = [
- "revm-bytecode 7.1.0",
- "revm-context-interface 11.1.2",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "29.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44efb7c2f4034a5bfd3d71ebfed076e48ac75e4972f1c117f2a20befac7716cd"
-dependencies = [
- "revm-bytecode 7.1.0",
- "revm-context-interface 12.0.0",
- "revm-primitives 21.0.1",
- "revm-state 8.1.0",
+ "revm-bytecode 7.1.1",
+ "revm-context-interface 13.1.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "serde",
 ]
 
@@ -6666,30 +6373,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "28.1.1"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57aadd7a2087705f653b5aaacc8ad4f8e851f5d330661e3f4c43b5475bbceae"
-dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "arrayref",
- "aurora-engine-modexp",
- "cfg-if",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "revm-primitives 21.0.1",
- "ripemd",
- "sha2",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "29.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585098ede6d84d6fc6096ba804b8e221c44dc77679571d32664a55e665aa236b"
+checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -6703,7 +6389,7 @@ dependencies = [
  "cfg-if",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "revm-primitives 21.0.1",
+ "revm-primitives 21.0.2",
  "ripemd",
  "rug",
  "secp256k1 0.31.1",
@@ -6725,9 +6411,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "21.0.1"
+version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536f30e24c3c2bf0d3d7d20fa9cf99b93040ed0f021fd9301c78cddb0dacda13"
+checksum = "29e161db429d465c09ba9cbff0df49e31049fe6b549e28eb0b7bd642fcbd4412"
 dependencies = [
  "alloy-primitives",
  "num_enum 0.7.4",
@@ -6749,13 +6435,13 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "8.1.0"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0b4873815e31cbc3e5b183b9128b86c09a487c027aaf8cc5cf4b9688878f9b"
+checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
 dependencies = [
  "bitflags 2.9.4",
- "revm-bytecode 7.1.0",
- "revm-primitives 21.0.1",
+ "revm-bytecode 7.1.1",
+ "revm-primitives 21.0.2",
  "serde",
 ]
 
@@ -7142,7 +6828,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7601,14 +7287,14 @@ dependencies = [
 [[package]]
 name = "sparsestate"
 version = "0.1.0"
-source = "git+https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.3.0#c927b843a6c6104c5cc1de069f626de07cb090e0"
+source = "git+https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.4.0#d4d8f968c183aedc23100c3a5634dee14c320757"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie 0.9.1",
  "mpt",
  "reth-errors",
- "reth-revm 1.8.2",
+ "reth-revm",
  "reth-stateless",
  "reth-trie-common",
 ]
@@ -7777,9 +7463,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b198d366dbec045acfcd97295eb653a7a2b40e4dc764ef1e79aafcad439d3c"
+checksum = "ff790eb176cc81bb8936aed0f7b9f14fc4670069a2d371b3e3b0ecce908b2cb3"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -7829,7 +7515,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8364,7 +8050,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/ere-guests/Cargo.toml
+++ b/ere-guests/Cargo.toml
@@ -148,28 +148,26 @@ openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", tag =
 openvm-keccak256 = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.1", default-features = false }
 openvm-revm-crypto = { git = "https://github.com/axiom-crypto/openvm-reth-benchmark.git", branch = "openvm-v1.4.1-reth-1.8.3", default-features = false }
 
-# branch is kw/zkevm-benchmark-workload-repo
-# NOTE: We are using a branch of a branch that has not yet been merged into master.
-reth-ethereum-primitives = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de", default-features = false }
-reth-primitives-traits = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de", default-features = false }
-reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de", default-features = false }
-reth-chainspec = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de", default-features = false }
-reth-errors = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de", default-features = false }
-reth-trie-common = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241", default-features = false }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241", default-features = false }
+reth-stateless = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241", default-features = false }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241", default-features = false }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241", default-features = false }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "cfde951976bfa9100a6d9f806e06fb539ae25241", default-features = false }
 
 # alloy
 alloy-primitives = { version = "1.4.1", default-features = false }
-alloy-consensus = { version = "1.0.41", default-features = false }
-alloy-eips = { version = "1.0.41", default-features = false }
-alloy-hardforks = { version = "0.4.3", default-features = false }
+alloy-consensus = { version = "1.1.2", default-features = false }
+alloy-eips = { version = "1.1.2", default-features = false }
+alloy-hardforks = { version = "0.4.5", default-features = false }
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-rlp = { version = "0.3.10", default-features = false }
 alloy-trie = { version = "0.9.1", default-features = false }
 
 # revm
-revm = { version = "31.0.0", default-features = false }
-revm-bytecode = { version = "7.1.0", default-features = false }
+revm = { version = "33.1.0", default-features = false }
+revm-bytecode = { version = "7.1.1", default-features = false }
 
 # ethrex
 ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "c68e76d6b569c60a667a1240a91e637bf2ea0d0b", package = "guest_program" }
@@ -196,7 +194,7 @@ k256 = { version = "0.13", default-features = false, features = [
     "serde",
     "pem",
 ] }
-sparsestate = { git = "https://github.com/eth-act/zkvm-ethereum-mpt.git", tag = "v0.3.0" }
+sparsestate = { git = "https://github.com/eth-act/zkvm-ethereum-mpt.git", tag = "v0.4.0" }
 
 [profile.release]
 lto = true
@@ -205,11 +203,5 @@ codegen-units = 1
 
 [profile.release.package.reth-airbender-stateless-validator]
 opt-level = "s"
-
-[patch."https://github.com/paradigmxyz/reth"]
-reth-revm = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-errors = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
-reth-trie-common = { git = "https://github.com/kevaundray/reth", rev = "2f94b4b8739b7d7dd83d5ca3567d73d7059120de" }
 
 [patch.crates-io]

--- a/ere-guests/stateless-validator/ethrex/risc0/Cargo.lock
+++ b/ere-guests/stateless-validator/ethrex/risc0/Cargo.lock
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.23.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527b47dc39850c6168002ddc1f7a2063e15d26137c1bb5330f6065a7524c1aa9"
+checksum = "01be36ba6f5e6e62563b369e03ca529eac46aea50677f84655084b4750816574"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e29d7eacf42f89c21d7f089916d0bdb4f36139a31698790e8837d2dbbd4b2c3"
+checksum = "2d9a33550fc21fd77a3f8b63e99969d17660eec8dcc50a95a80f7c9964f7680b"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -3841,8 +3841,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3861,8 +3861,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3879,8 +3879,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3889,8 +3889,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3902,8 +3902,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3914,8 +3914,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3924,8 +3924,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -3935,8 +3935,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3951,8 +3951,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -3963,8 +3963,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3980,8 +3980,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4001,8 +4001,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4014,8 +4014,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4030,8 +4030,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4042,8 +4042,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4069,8 +4069,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -4080,8 +4080,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -4092,8 +4092,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -4101,8 +4101,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -4124,13 +4124,12 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -4140,8 +4139,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4162,8 +4161,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4178,8 +4177,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4194,8 +4193,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4210,17 +4209,17 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "31.0.2"
+version = "33.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb67a5223602113cae59a305acde2d9936bc18f2478dda879a6124b267cebfb6"
+checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -4249,9 +4248,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "11.0.2"
+version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92850e150f4f99d46c05a20ad0cd09286a7ad4ee21866fffb87101de6e602231"
+checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -4265,9 +4264,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "12.0.1"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d701e2c2347d65216b066489ab22a0a8e1f7b2568256110d73a7d5eff3385c"
+checksum = "431c9a14e4ef1be41ae503708fd02d974f80ef1f2b6b23b5e402e8d854d1b225"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -4304,9 +4303,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "12.0.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45418ed95cfdf0cb19effdbb7633cf2144cab7fb0e6ffd6b0eb9117a50adff6"
+checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -4322,9 +4321,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "12.0.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99801eac7da06cc112df2244bd5a64024f4ef21240e923b26e73c4b4a0e5da6"
+checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
 dependencies = [
  "auto_impl",
  "either",
@@ -4338,9 +4337,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "29.0.1"
+version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22789ce92c5808c70185e3bc49732f987dc6fd907f77828c8d3470b2299c9c65"
+checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -4350,9 +4349,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "29.0.1"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968b124028960201abf6d6bf8e223f15fadebb4307df6b7dc9244a0aab5d2d05"
+checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",

--- a/ere-guests/stateless-validator/ethrex/sp1/Cargo.lock
+++ b/ere-guests/stateless-validator/ethrex/sp1/Cargo.lock
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.23.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527b47dc39850c6168002ddc1f7a2063e15d26137c1bb5330f6065a7524c1aa9"
+checksum = "01be36ba6f5e6e62563b369e03ca529eac46aea50677f84655084b4750816574"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e29d7eacf42f89c21d7f089916d0bdb4f36139a31698790e8837d2dbbd4b2c3"
+checksum = "2d9a33550fc21fd77a3f8b63e99969d17660eec8dcc50a95a80f7c9964f7680b"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -3609,8 +3609,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3629,8 +3629,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3647,8 +3647,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3657,8 +3657,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3670,8 +3670,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3682,8 +3682,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3692,8 +3692,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -3703,8 +3703,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3719,8 +3719,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -3731,8 +3731,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3748,8 +3748,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3769,8 +3769,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -3782,8 +3782,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3798,8 +3798,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3810,8 +3810,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3837,8 +3837,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -3848,8 +3848,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -3860,8 +3860,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -3869,8 +3869,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -3892,13 +3892,12 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -3908,8 +3907,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3930,8 +3929,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3946,8 +3945,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3962,8 +3961,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3978,17 +3977,17 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.8.3"
-source = "git+https://github.com/kevaundray/reth?rev=2f94b4b8739b7d7dd83d5ca3567d73d7059120de#2f94b4b8739b7d7dd83d5ca3567d73d7059120de"
+version = "1.9.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "31.0.2"
+version = "33.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb67a5223602113cae59a305acde2d9936bc18f2478dda879a6124b267cebfb6"
+checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -4017,9 +4016,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "11.0.2"
+version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92850e150f4f99d46c05a20ad0cd09286a7ad4ee21866fffb87101de6e602231"
+checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -4033,9 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "12.0.1"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d701e2c2347d65216b066489ab22a0a8e1f7b2568256110d73a7d5eff3385c"
+checksum = "431c9a14e4ef1be41ae503708fd02d974f80ef1f2b6b23b5e402e8d854d1b225"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -4072,9 +4071,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "12.0.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45418ed95cfdf0cb19effdbb7633cf2144cab7fb0e6ffd6b0eb9117a50adff6"
+checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -4090,9 +4089,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "12.0.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99801eac7da06cc112df2244bd5a64024f4ef21240e923b26e73c4b4a0e5da6"
+checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
 dependencies = [
  "auto_impl",
  "either",
@@ -4106,9 +4105,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "29.0.1"
+version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22789ce92c5808c70185e3bc49732f987dc6fd907f77828c8d3470b2299c9c65"
+checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -4118,9 +4117,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "29.0.1"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968b124028960201abf6d6bf8e223f15fadebb4307df6b7dc9244a0aab5d2d05"
+checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",


### PR DESCRIPTION
We finished upstreaming all the required changes to Reth, which means finally we can stop using our custom fork!