### PR TITLE
zisk: add modexp precompile

### DIFF
--- a/precompile-patches/zisk.toml
+++ b/precompile-patches/zisk.toml
@@ -4,3 +4,4 @@ sha2 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", tag =
 sha3 = { git = "https://github.com/0xPolygonHermez/zisk-patch-hashes.git", tag = "patch-sha3-0.10.8-zisk-0.13.0" }
 k256 = { git = "https://github.com/0xPolygonHermez/zisk-patch-elliptic-curves.git", tag = "patch-k256-0.13.4-zisk-0.13.0" }
 bn = { git = "https://github.com/0xPolygonHermez/zisk-patch-bn.git", tag = "patch-0.6.0-zisk-0.13.0", package = "substrate-bn" }
+aurora-engine-modexp = { git = "https://github.com/0xPolygonHermez/zisk-patch-modexp.git", tag = "patch-1.2.0-zisk-0.13.0" }


### PR DESCRIPTION
Include modexp precompile for Zisk.

When compiling the guest program there is an error:
```
2025-12-10T13:42:41.605888Z  INFO ere_hosts: Running stateless-validator benchmark for input folder: zkevm-fixtures-input
2025-12-10T13:42:41.849355Z  INFO benchmark_runner::runner: Running cargo zisk...
2025-12-10T13:42:42.264169Z  INFO benchmark_runner::runner: cargo zisk completed successfully
2025-12-10T13:42:42.472626Z  INFO ere_zisk::compiler::rust_rv64ima_customized: Compiling Rust ZisK program at /guest/stateless-validator/reth/zisk
2025-12-10T13:43:32.008946Z  INFO ere_zisk::compiler::rust_rv64ima_customized: Parsed program name: reth-zisk-stateless-validator
   Compiling lib-c v0.13.0 (https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.13.0#57c22a5e)
error: failed to run custom build command for `lib-c v0.13.0 (https://github.com/0xPolygonHermez/zisk.git?branch=pre-develop-0.13.0#57c22a5e)`

Caused by:
  process didn't exit successfully: `/guest/target/release/build/lib-c-3a96682f8d7c2529/build-script-build` (exit status: 101)
  --- stdout
  `/usr/local/cargo/git/checkouts/zisk-627550f4f7ac9ffb/57c22a5/lib-c/c/lib/libziskc.a` not found! Compiling...
  rm -rf build
  rm -rf lib
  mkdir -p build
  nasm -felf64 src/ffiasm/fec.asm -o build/fec.o

  --- stderr
  make: nasm: No such file or directory
  make: *** [Makefile:11: all] Error 127

  thread 'main' panicked at /usr/local/cargo/git/checkouts/zisk-627550f4f7ac9ffb/57c22a5/lib-c/build.rs:66:9:
  Command `make` failed with exit code Some(2)
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: Failed to compile program

Caused by:
    Command `RUSTC="/root/.zisk/toolchains/8S2tJKBrhi/bin/rustc" "cargo" "build" "--release" "--target" "riscv64ima-zisk-zkvm-elf" "--manifest-path" "/guest/stateless-validator/reth/zisk/Cargo.toml"` exit with exit status: 101
Error: Command `"docker" "run" "--rm" "--env" "RUST_LOG=info" "--volume" "/data/code-data/zkevm-benchmark-workload-two/ere-guests:/guest" "--volume" "/tmp/.tmpSFjRi2:/output" "ere-compiler-zisk:0.0.15-a75f8f4" "--compiler-kind" "rust-customized" "--guest-path" "/guest/stateless-validator/reth/zisk" "--output-path" "/output/program"` exit with exit status: 1
```

@han0110, I think this might be because we don't have `nasm` in the [Dockerfile.compiler](https://github.com/eth-act/ere/blob/master/docker/zisk/Dockerfile.compiler)? (i.e. we have it in the base image, but not the compiler one)