### PR TITLE
Bump EEST release

### DIFF
--- a/scripts/download-and-extract-fixtures.sh
+++ b/scripts/download-and-extract-fixtures.sh
@@ -3,7 +3,7 @@
 # download-and-extract-fixtures.sh
 #
 # Downloads execution spec test fixtures for zkevm.
-# By default, it fetches the benchmark@v0.0.6 release.
+# By default, it fetches the benchmark@v0.0.7 release.
 # You can optionally provide a tag as the first argument, or use 'latest' to explicitly fetch the latest release.
 # The second argument optionally sets the destination directory (default: ./zkevm-fixtures).
 #
@@ -11,7 +11,7 @@
 #   ./scripts/download-and-extract-fixtures.sh [TAG|latest] [DEST_DIR]
 #
 # Examples:
-#   # Download default release (benchmark@v0.0.6) to default directory
+#   # Download default release (benchmark@v0.0.7) to default directory
 #   ./scripts/download-and-extract-fixtures.sh
 #   # Download latest official release to default directory
 #   ./scripts/download-and-extract-fixtures.sh latest
@@ -27,7 +27,7 @@ set -euo pipefail
 
 REPO="ethereum/execution-spec-tests"
 ASSET_NAME="fixtures_benchmark.tar.gz"
-DEFAULT_TAG="benchmark%40v0.0.6"
+DEFAULT_TAG="benchmark%40v0.0.7"
 
 # Helper function to make authenticated GitHub API calls
 github_api_curl() {


### PR DESCRIPTION
This [release of EEST benchmarks](https://github.com/ethereum/execution-spec-tests/releases/tag/benchmark%40v0.0.7) has fillings for 1M, 5M, 10M, 30M, 60M, 100M, and 150M gas limits.

To generate fixtures for a specific gas limit, remember you can use:
```
$RAYON_NUM_THREADS=8 RUST_LOG=info cargo run --release -p witness-generator-cli -- tests --include Osaka --include _10M
```
or you can generate without gas limit `--include` flags and just delete the ones you want to exclude.