### PR TITLE
Support Zisk profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1423,6 +1423,7 @@ dependencies = [
  "stateless-validator-ethrex",
  "stateless-validator-reth",
  "strum 0.26.3",
+ "tempfile",
  "toml",
  "tracing",
  "walkdir",
@@ -2358,7 +2359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.113",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2569,7 +2570,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2959,7 +2960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4169,7 +4170,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5413,7 +5414,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6432,7 +6433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.113",
@@ -6445,7 +6446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.113",
@@ -6534,7 +6535,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -6571,9 +6572,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8836,7 +8837,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9845,7 +9846,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10860,7 +10861,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -20,6 +20,7 @@ strum.workspace = true
 anyhow.workspace = true
 auto_impl.workspace = true
 ere-guests-downloader.workspace = true
+tempfile.workspace = true
 
 ere-guests-block-encoding-length = { "workspace" = true, features = ["host"] }
 ere-guests-stateless-validator-ethrex = { "workspace" = true, features = [

--- a/crates/benchmark-runner/build.rs
+++ b/crates/benchmark-runner/build.rs
@@ -32,6 +32,7 @@ fn main() {
 
     let reth_version = find_el_version(packages, "stateless-validator-reth", RETH_DEP_PREFIX);
     let ethrex_version = find_el_version(packages, "stateless-validator-ethrex", ETHREX_DEP_PREFIX);
+    let ere_tag = find_ere_tag(packages);
 
     println!(
         "cargo:rustc-env=RETH_EL_VERSION={}",
@@ -44,6 +45,13 @@ fn main() {
         "cargo:rustc-env=ETHREX_EL_VERSION={}",
         ethrex_version.unwrap_or_else(|| {
             println!("cargo:warning=Could not determine ethrex version from Cargo.lock");
+            "unknown".to_string()
+        })
+    );
+    println!(
+        "cargo:rustc-env=ERE_TAG={}",
+        ere_tag.unwrap_or_else(|| {
+            println!("cargo:warning=Could not determine ERE tag from Cargo.lock");
             "unknown".to_string()
         })
     );
@@ -97,4 +105,14 @@ fn extract_tag_from_source(source: &str) -> Option<String> {
 fn extract_short_hash_from_source(source: &str) -> Option<String> {
     let hash = source.split('#').nth(1)?;
     Some(hash[..7.min(hash.len())].to_string())
+}
+
+/// Finds the ERE tag (short commit hash) from the `ere-platform-trait` package source.
+fn find_ere_tag(packages: &[toml::Value]) -> Option<String> {
+    let pkg = packages
+        .iter()
+        .find(|p| p.get("name").and_then(|n| n.as_str()) == Some("ere-platform-trait"))?;
+
+    let source = pkg.get("source").and_then(|s| s.as_str())?;
+    extract_short_hash_from_source(source)
 }

--- a/crates/benchmark-runner/build.rs
+++ b/crates/benchmark-runner/build.rs
@@ -32,7 +32,6 @@ fn main() {
 
     let reth_version = find_el_version(packages, "stateless-validator-reth", RETH_DEP_PREFIX);
     let ethrex_version = find_el_version(packages, "stateless-validator-ethrex", ETHREX_DEP_PREFIX);
-    let ere_tag = find_ere_tag(packages);
 
     println!(
         "cargo:rustc-env=RETH_EL_VERSION={}",
@@ -45,13 +44,6 @@ fn main() {
         "cargo:rustc-env=ETHREX_EL_VERSION={}",
         ethrex_version.unwrap_or_else(|| {
             println!("cargo:warning=Could not determine ethrex version from Cargo.lock");
-            "unknown".to_string()
-        })
-    );
-    println!(
-        "cargo:rustc-env=ERE_TAG={}",
-        ere_tag.unwrap_or_else(|| {
-            println!("cargo:warning=Could not determine ERE tag from Cargo.lock");
             "unknown".to_string()
         })
     );
@@ -105,14 +97,4 @@ fn extract_tag_from_source(source: &str) -> Option<String> {
 fn extract_short_hash_from_source(source: &str) -> Option<String> {
     let hash = source.split('#').nth(1)?;
     Some(hash[..7.min(hash.len())].to_string())
-}
-
-/// Finds the ERE tag (short commit hash) from the `ere-platform-trait` package source.
-fn find_ere_tag(packages: &[toml::Value]) -> Option<String> {
-    let pkg = packages
-        .iter()
-        .find(|p| p.get("name").and_then(|n| n.as_str()) == Some("ere-platform-trait"))?;
-
-    let source = pkg.get("source").and_then(|s| s.as_str())?;
-    extract_short_hash_from_source(source)
 }

--- a/crates/benchmark-runner/src/lib.rs
+++ b/crates/benchmark-runner/src/lib.rs
@@ -7,5 +7,6 @@ pub mod guest_programs;
 pub mod block_encoding_length_program;
 pub mod empty_program;
 pub mod stateless_validator;
+pub mod zisk_profiling;
 
 pub mod runner;

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -13,9 +13,29 @@ use ere_zkvm_interface::{zkVM, ProofKind, ProverResourceType};
 use zkevm_metrics::{BenchmarkRun, CrashInfo, ExecutionMetrics, HardwareInfo, ProvingMetrics};
 
 use crate::guest_programs::{GuestFixture, OutputVerifierResult};
+use crate::zisk_profiling::run_profiling;
+
+pub use crate::zisk_profiling::ProfileConfig;
 
 /// Default version tag for guest programs
 const DEFAULT_GUEST_VERSION: &str = "v0.5.0";
+
+/// A zkVM instance bundled with ELF bytes (used for profiling).
+pub struct ZkVMInstance {
+    /// The dockerized zkVM instance
+    pub zkvm: DockerizedzkVM,
+    /// Raw ELF bytes of the guest program
+    pub elf: Vec<u8>,
+}
+
+impl std::fmt::Debug for ZkVMInstance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZkVMInstance")
+            .field("zkvm", &self.zkvm.name())
+            .field("elf_len", &self.elf.len())
+            .finish()
+    }
+}
 
 /// Holds the configuration for running benchmarks
 #[derive(Debug, Clone)]
@@ -30,6 +50,8 @@ pub struct RunConfig {
     pub force_rerun: bool,
     /// Optional folder to dump input files
     pub dump_inputs_folder: Option<PathBuf>,
+    /// Optional Zisk profiling configuration
+    pub zisk_profile_config: Option<ProfileConfig>,
 }
 
 /// Action specifies whether we should prove or execute
@@ -43,26 +65,37 @@ pub enum Action {
 
 /// Executes benchmarks for a given guest program type and zkVM
 pub fn run_benchmark(
-    ere_zkvm: &DockerizedzkVM,
+    instance: &ZkVMInstance,
     config: &RunConfig,
     inputs: impl IntoParallelIterator<Item: GuestFixture> + IntoIterator<Item: GuestFixture>,
 ) -> Result<()> {
     HardwareInfo::detect().to_path(config.output_folder.join("hardware.json"))?;
+
+    let zisk_elf = config
+        .zisk_profile_config
+        .is_some()
+        .then_some(instance.elf.as_slice());
+    let zkvm = &instance.zkvm;
     match config.action {
         Action::Execute => inputs
             .into_par_iter()
-            .try_for_each(|input| process_input(ere_zkvm, input, config))?,
+            .try_for_each(|input| process_input(zkvm, input, config, zisk_elf))?,
 
         Action::Prove => inputs
             .into_iter()
-            .try_for_each(|input| process_input(ere_zkvm, input, config))?,
+            .try_for_each(|input| process_input(zkvm, input, config, zisk_elf))?,
     }
 
     Ok(())
 }
 
 /// Processes a single input through the zkVM
-fn process_input(zkvm: &DockerizedzkVM, io: impl GuestFixture, config: &RunConfig) -> Result<()> {
+fn process_input(
+    zkvm: &DockerizedzkVM,
+    io: impl GuestFixture,
+    config: &RunConfig,
+    zisk_elf: Option<&[u8]>,
+) -> Result<()> {
     let zkvm_name = format!("{}-v{}", zkvm.name(), zkvm.sdk_version());
     let out_path = config
         .output_folder
@@ -89,6 +122,17 @@ fn process_input(zkvm: &DockerizedzkVM, io: impl GuestFixture, config: &RunConfi
     info!("Running {}", io.name());
     let (execution, proving) = match config.action {
         Action::Execute => {
+            // Run Zisk profiling if configured
+            if let (Some(profile_config), Some(elf)) = (&config.zisk_profile_config, zisk_elf) {
+                run_profiling(
+                    profile_config,
+                    elf,
+                    input.stdin(),
+                    &io.name(),
+                    config.sub_folder.as_deref(),
+                )?;
+            }
+
             let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm.execute(&input)));
             let execution = match run {
                 Ok(Ok((public_values, report))) => {
@@ -170,45 +214,50 @@ pub async fn get_el_zkvm_instances(
     zkvms: &[zkVMKind],
     resource: ProverResourceType,
     bin_path: Option<&Path>,
-) -> Result<Vec<DockerizedzkVM>> {
-    let artifact_name_prefix = format!("stateless-validator-{el}");
-    get_guest_zkvm_instances(&artifact_name_prefix, zkvms, resource, bin_path).await
+) -> Result<Vec<ZkVMInstance>> {
+    let guest_name_prefix = format!("stateless-validator-{el}");
+    get_guest_zkvm_instances(&guest_name_prefix, zkvms, resource, bin_path).await
 }
 
 /// Creates the requested guest program zkVMs ere instances.
 pub async fn get_guest_zkvm_instances(
-    artifact_name_prefix: &str,
+    guest_name_prefix: &str,
     zkvms: &[zkVMKind],
     resource: ProverResourceType,
     bin_path: Option<&Path>,
-) -> Result<Vec<DockerizedzkVM>> {
+) -> Result<Vec<ZkVMInstance>> {
     let mut instances = Vec::new();
     for zkvm in zkvms {
-        let artifact_name = format!("{}-{}", artifact_name_prefix, zkvm.as_str());
-        let program = load_program(&artifact_name, bin_path).await?;
+        let guest_name = format!("{}-{}", guest_name_prefix, zkvm.as_str());
+        let (program, elf) = load_program(&guest_name, bin_path).await?;
         let zkvm = DockerizedzkVM::new(*zkvm, program, resource.clone())
             .with_context(|| format!("Failed to initialize DockerizedzkVM, kind {zkvm}"))?;
-        instances.push(zkvm);
+        instances.push(ZkVMInstance { zkvm, elf });
     }
     Ok(instances)
 }
 
-async fn load_program(artifact_name: &str, bin_path: Option<&Path>) -> Result<SerializedProgram> {
+async fn load_program(
+    guest_name: &str,
+    bin_path: Option<&Path>,
+) -> Result<(SerializedProgram, Vec<u8>)> {
     if let Some(path) = bin_path {
-        let bytes = fs::read(path.join(artifact_name))
+        let bytes = fs::read(path.join(guest_name))
             .with_context(|| format!("Failed to read program from path: {}", path.display()))?;
-        return Ok(SerializedProgram(bytes));
+        let elf = fs::read(path.join(format!("{guest_name}.elf")))
+            .with_context(|| format!("Failed to read ELF from path: {}", path.display()))?;
+        return Ok((SerializedProgram(bytes), elf));
     }
 
     let downloader = Downloader::from_tag(DEFAULT_GUEST_VERSION)
         .await
         .context("Failed to create guest program downloader")?;
     let compiled = downloader
-        .download(artifact_name)
+        .download(guest_name)
         .await
-        .with_context(|| format!("Failed to download guest program: {artifact_name}"))?;
+        .with_context(|| format!("Failed to download guest program: {guest_name}"))?;
 
-    Ok(SerializedProgram(compiled.program))
+    Ok((SerializedProgram(compiled.program), compiled.elf))
 }
 
 /// Dumps the raw input bytes to disk

--- a/crates/benchmark-runner/src/stateless_validator.rs
+++ b/crates/benchmark-runner/src/stateless_validator.rs
@@ -11,6 +11,7 @@ use ere_guests_stateless_validator_ethrex::guest::{
 use ere_guests_stateless_validator_reth::guest::{
     StatelessValidatorRethGuest, StatelessValidatorRethInput,
 };
+use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -92,7 +93,7 @@ pub fn reth_inputs_from_fixture(
     fixtures: &[StatelessValidationFixture],
 ) -> Result<Vec<Box<dyn GuestFixture>>> {
     fixtures
-        .iter()
+        .par_iter()
         .map(|bw| {
             info!(
                 "Preparing Reth stateless validator input for fixture {}",

--- a/crates/benchmark-runner/src/zisk_profiling.rs
+++ b/crates/benchmark-runner/src/zisk_profiling.rs
@@ -18,7 +18,7 @@ pub struct ProfileConfig {
 
 impl ProfileConfig {
     /// Creates a new `ProfileConfig`, using the build-time ERE tag or an explicit override.
-    pub fn new(output_folder: PathBuf) -> Self {
+    pub const fn new(output_folder: PathBuf) -> Self {
         Self { output_folder }
     }
 }

--- a/crates/benchmark-runner/src/zisk_profiling.rs
+++ b/crates/benchmark-runner/src/zisk_profiling.rs
@@ -7,7 +7,7 @@ use std::{env, fs};
 use tracing::info;
 
 /// ERE commit hash extracted from `Cargo.lock` at build time.
-const DEFAULT_ERE_TAG: &str = env!("ERE_TAG");
+const DEFAULT_ERE_TAG: &str = ere_dockerized::DOCKER_IMAGE_TAG;
 
 /// Configuration for Zisk profiling.
 #[derive(Debug, Clone)]
@@ -17,7 +17,7 @@ pub struct ProfileConfig {
 }
 
 impl ProfileConfig {
-    /// Creates a new `ProfileConfig`, using the build-time ERE tag or an explicit override.
+    /// Creates a new `ProfileConfig`.
     pub const fn new(output_folder: PathBuf) -> Self {
         Self { output_folder }
     }

--- a/crates/benchmark-runner/src/zisk_profiling.rs
+++ b/crates/benchmark-runner/src/zisk_profiling.rs
@@ -1,0 +1,126 @@
+//! Zisk profiling support for benchmark runs
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use std::process::Command;
+use std::{env, fs};
+use tracing::info;
+
+/// Configuration for Zisk profiling.
+#[derive(Debug, Clone)]
+pub struct ProfileConfig {
+    /// Output folder for Zisk profile results
+    pub output_folder: PathBuf,
+    /// ERE tag for docker image
+    pub ere_tag: String,
+}
+
+impl ProfileConfig {
+    /// Creates a new `ZiskProfileConfig` by computing the ERE tag from cargo tree
+    pub fn new(output_folder: PathBuf) -> Result<Self> {
+        let ere_tag = compute_ere_tag()?;
+        Ok(Self {
+            output_folder,
+            ere_tag,
+        })
+    }
+}
+
+/// Computes the ERE tag by parsing `cargo tree -p ere-platform-trait` output
+fn compute_ere_tag() -> Result<String> {
+    let output = Command::new("cargo")
+        .args(["tree", "-p", "ere-platform-trait"])
+        .output()
+        .context("Failed to execute cargo tree")?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "cargo tree failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let first_line = stdout.lines().next().context("No output from cargo tree")?;
+
+    let commit = first_line
+        .find('#')
+        .map(|i| &first_line[i + 1..])
+        .and_then(|s| s.get(..7))
+        .context("Failed to extract commit hash from cargo tree output")?;
+
+    Ok(commit.to_string())
+}
+
+/// Runs Zisk profiling for a single fixture.
+pub fn run_profiling(
+    config: &ProfileConfig,
+    elf: &[u8],
+    stdin: &[u8],
+    fixture_name: &str,
+    sub_folder: Option<&str>,
+) -> Result<()> {
+    info!("Running Zisk profiling for {}", fixture_name);
+
+    let temp_dir = tempfile::tempdir().context("Failed to create temp directory for profiling")?;
+    let temp_path = temp_dir.path();
+
+    let input_path = temp_path.join("input.bin");
+    let elf_path = temp_path.join("program.elf");
+    fs::write(&input_path, stdin)
+        .with_context(|| format!("Failed to write input.bin to {}", input_path.display()))?;
+    fs::write(&elf_path, elf)
+        .with_context(|| format!("Failed to write program.elf to {}", elf_path.display()))?;
+
+    let docker_image = match env::var("ERE_IMAGE_REGISTRY") {
+        Ok(registry) => format!("{}/ere-server-zisk:{}", registry, config.ere_tag),
+        Err(_) => format!("ere-server-zisk:{}", config.ere_tag),
+    };
+    let volume_mount = format!("{}:/data", temp_path.display());
+
+    let output = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "-v",
+            &volume_mount,
+            "--entrypoint",
+            "ziskemu",
+            &docker_image,
+            "-X",
+            "-S",
+            "-D",
+            "-e",
+            "/data/program.elf",
+            "-i",
+            "/data/input.bin",
+        ])
+        .output()
+        .context("Failed to execute docker command for Zisk profiling")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "Zisk profiling failed for fixture '{}': docker command exited with code {}\nstderr: {}",
+            fixture_name,
+            output.status.code().unwrap_or(-1),
+            stderr
+        );
+    }
+
+    let profile_dir = config.output_folder.join(sub_folder.unwrap_or(""));
+    fs::create_dir_all(&profile_dir).with_context(|| {
+        format!(
+            "Failed to create profile directory: {}",
+            profile_dir.display()
+        )
+    })?;
+
+    let profile_path = profile_dir.join(format!("zisk_profile_{}.prof", fixture_name));
+    fs::write(&profile_path, &output.stdout)
+        .with_context(|| format!("Failed to write profile to {}", profile_path.display()))?;
+
+    info!("Saved Zisk profile to {}", profile_path.display());
+
+    Ok(())
+}

--- a/crates/ere-hosts/src/cli.rs
+++ b/crates/ere-hosts/src/cli.rs
@@ -45,6 +45,14 @@ pub struct Cli {
     /// from the latest ere-guests release.
     #[arg(long)]
     pub bin_path: Option<PathBuf>,
+
+    /// Enable Zisk profiling (requires --zkvms zisk, --action execute)
+    #[arg(long, default_value_t = false)]
+    pub zisk_profile: bool,
+
+    /// Output folder for Zisk profile results
+    #[arg(long, default_value = "zisk-profiles")]
+    pub zisk_profile_output: PathBuf,
 }
 
 /// Subcommands for different guest programs

--- a/crates/ere-hosts/src/cli.rs
+++ b/crates/ere-hosts/src/cli.rs
@@ -47,7 +47,7 @@ pub struct Cli {
     pub bin_path: Option<PathBuf>,
 
     /// Enable Zisk profiling (requires --zkvms zisk, --action execute)
-    #[arg(long, default_value_t = false)]
+    #[arg(long)]
     pub zisk_profile: bool,
 
     /// Output folder for Zisk profile results

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -53,11 +53,9 @@ async fn main() -> Result<()> {
         resource, action
     );
 
-    let zisk_profile_config = if cli.zisk_profile {
-        Some(ProfileConfig::new(cli.zisk_profile_output.clone())?)
-    } else {
-        None
-    };
+    let zisk_profile_config = cli
+        .zisk_profile
+        .then(|| ProfileConfig::new(cli.zisk_profile_output.clone()));
 
     let bin_path = cli.bin_path.as_deref();
     let config_base = RunConfig {

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -32,7 +32,10 @@ async fn main() -> Result<()> {
 
     if cli.zisk_profile {
         if !matches!(cli.action, cli::BenchmarkAction::Execute) {
-            bail!("--zisk-profile requires --action execute, but got {:?}", cli.action);
+            bail!(
+                "--zisk-profile requires --action execute, but got {:?}",
+                cli.action
+            );
         }
         if cli.zkvms.len() != 1 || cli.zkvms[0] != zkVMKind::Zisk {
             let zkvm_names: Vec<_> = cli.zkvms.iter().map(|z| z.as_str()).collect();

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -2,12 +2,16 @@
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use benchmark_runner::{
     block_encoding_length_program, empty_program,
-    runner::{Action, RunConfig, get_el_zkvm_instances, get_guest_zkvm_instances, run_benchmark},
+    runner::{
+        Action, ProfileConfig, RunConfig, get_el_zkvm_instances, get_guest_zkvm_instances,
+        run_benchmark,
+    },
     stateless_validator::{self},
 };
+use ere_dockerized::zkVMKind;
 
 use clap::Parser;
 use ere_zkvm_interface::ProverResourceType;
@@ -26,12 +30,31 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
+    if cli.zisk_profile {
+        if !matches!(cli.action, cli::BenchmarkAction::Execute) {
+            bail!("--zisk-profile requires --action execute, but got {:?}", cli.action);
+        }
+        if cli.zkvms.len() != 1 || cli.zkvms[0] != zkVMKind::Zisk {
+            let zkvm_names: Vec<_> = cli.zkvms.iter().map(|z| z.as_str()).collect();
+            bail!(
+                "--zisk-profile requires --zkvms zisk only, but got: {}",
+                zkvm_names.join(", ")
+            );
+        }
+    }
+
     let resource: ProverResourceType = cli.resource.into();
     let action: Action = cli.action.into();
     info!(
         "Running benchmarks with resource={:?} and action={:?}",
         resource, action
     );
+
+    let zisk_profile_config = if cli.zisk_profile {
+        Some(ProfileConfig::new(cli.zisk_profile_output.clone())?)
+    } else {
+        None
+    };
 
     let bin_path = cli.bin_path.as_deref();
     let config_base = RunConfig {
@@ -40,6 +63,7 @@ async fn main() -> Result<()> {
         action,
         force_rerun: cli.force_rerun,
         dump_inputs_folder: cli.dump_inputs,
+        zisk_profile_config,
     };
 
     match cli.guest_program {

--- a/scripts/analyze_zisk_profiles.py
+++ b/scripts/analyze_zisk_profiles.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""
+Analyze Zisk profiling outputs and generate an aggregate summary report.
+
+Parses .prof files from ziskemu and produces a Markdown report with:
+- MARK_ID custom scope statistics (primary focus)
+- Cost distribution breakdown (MAIN, OPCODES, PRECOMPILES, MEMORY)
+- Top opcodes by cost
+
+Usage:
+    python3 scripts/analyze_zisk_profiles.py zisk-profiles/reth/
+    python3 scripts/analyze_zisk_profiles.py zisk-profiles/reth/ --output report.md
+    python3 scripts/analyze_zisk_profiles.py zisk-profiles/reth/ --verbose
+
+Options:
+    --output, -o FILE   Write report to FILE instead of stdout
+    --verbose, -v       Show parsing progress (file count, each file being parsed,
+                        success count).
+"""
+
+import argparse
+import re
+import statistics
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class ProfileData:
+    """Data extracted from a single .prof file."""
+
+    filename: str
+    block_id: str
+    total_cost: int = 0
+    cost_distribution: Dict[str, int] = field(default_factory=dict)
+    opcodes: Dict[str, Dict[str, int]] = field(default_factory=dict)
+    mark_ids: Dict[str, Dict[str, int]] = field(default_factory=dict)
+
+
+def parse_number(s: str) -> int:
+    """Parse a number string, removing commas."""
+    return int(s.replace(",", ""))
+
+
+def format_number(n: float) -> str:
+    """Format a number in human-readable form (e.g., 5.7B, 959M, 12.8K)."""
+    abs_n = abs(n)
+    if abs_n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}B"
+    elif abs_n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    elif abs_n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    else:
+        return f"{n:.0f}"
+
+
+def format_percent(p: float) -> str:
+    """Format a percentage value."""
+    return f"{p:.1f}%"
+
+
+def extract_block_id(filename: str) -> str:
+    """Extract block ID from filename like 'zisk_profile_rpc_block_23326233.prof'."""
+    match = re.search(r"block_(\d+)", filename)
+    return match.group(1) if match else filename
+
+
+def parse_profile(filepath: Path, verbose: bool = False) -> Optional[ProfileData]:
+    """Parse a single .prof file and extract relevant data."""
+    try:
+        content = filepath.read_text()
+    except Exception as e:
+        if verbose:
+            print(f"Warning: Could not read {filepath}: {e}", file=sys.stderr)
+        return None
+
+    profile = ProfileData(
+        filename=filepath.name, block_id=extract_block_id(filepath.name)
+    )
+
+    lines = content.split("\n")
+    i = 0
+
+    while i < len(lines):
+        line = lines[i].strip()
+
+        # Parse COST DISTRIBUTION section
+        if line.startswith("COST DISTRIBUTION"):
+            i += 2  # Skip header line
+            while i < len(lines):
+                line = lines[i].strip()
+                if not line or line.startswith("TOTAL") or line.startswith("FROPS"):
+                    break
+                # Match lines like: BASE                         293,601,280   1.10%
+                match = re.match(r"^(\w+)\s+([\d,]+)\s+[\d.]+%$", line)
+                if match:
+                    category = match.group(1)
+                    cost = parse_number(match.group(2))
+                    profile.cost_distribution[category] = cost
+                i += 1
+
+            # Get total cost from TOTAL line
+            while i < len(lines):
+                line = lines[i].strip()
+                if line.startswith("TOTAL"):
+                    match = re.match(r"^TOTAL\s+([\d,]+)", line)
+                    if match:
+                        profile.total_cost = parse_number(match.group(1))
+                    break
+                if line.startswith("FROPS"):
+                    break
+                i += 1
+            continue
+
+        # Parse COST BY OPCODE section
+        if line.startswith("COST BY OPCODE"):
+            i += 2  # Skip header line
+            while i < len(lines):
+                line = lines[i].strip()
+                if not line or line.startswith("FROPS"):
+                    break
+                # Match lines like: OP keccak                         44,347   5,681,205,476  21.20% #1
+                match = re.match(
+                    r"^OP\s+(\w+)\s+([\d,]+)\s+([\d,]+)\s+[\d.]+%", line
+                )
+                if match:
+                    opcode = match.group(1)
+                    count = parse_number(match.group(2))
+                    cost = parse_number(match.group(3))
+                    profile.opcodes[opcode] = {"count": count, "cost": cost}
+                i += 1
+            continue
+
+        # Parse MARK_ID section
+        if line.startswith("MARK_ID"):
+            i += 2  # Skip header line
+            while i < len(lines):
+                line = lines[i].strip()
+                if not line or re.match(r"^[a-f0-9]{8}$", line):
+                    break
+                # Match MARK_ID lines
+                # RECOVER_BLOCK                     0          1       2,376,088   1.06%     384,171,246   1.43%     161,573,984      38,085,509     150,738,364      33,773,389
+                parts = line.split()
+                if len(parts) >= 11 and not parts[0].startswith("-"):
+                    try:
+                        name = parts[0]
+                        # parts[1] = INDEX, parts[2] = COUNT, parts[3] = STEPS, parts[4] = STEPS%
+                        # parts[5] = TOTAL COST, parts[6] = %, parts[7] = MAIN COST, parts[8] = OPCODE COST
+                        # parts[9] = PRECOMPILE COST, parts[10] = MEMORY COST
+                        total_cost = parse_number(parts[5])
+                        main_cost = parse_number(parts[7])
+                        opcode_cost = parse_number(parts[8])
+                        precompile_cost = parse_number(parts[9])
+                        memory_cost = parse_number(parts[10])
+
+                        profile.mark_ids[name] = {
+                            "total_cost": total_cost,
+                            "main_cost": main_cost,
+                            "opcode_cost": opcode_cost,
+                            "precompile_cost": precompile_cost,
+                            "memory_cost": memory_cost,
+                        }
+                    except (IndexError, ValueError):
+                        pass
+                i += 1
+            continue
+
+        i += 1
+
+    return profile
+
+
+def compute_statistics(values: List[float]) -> Dict[str, float]:
+    """Compute statistics for a list of values."""
+    if not values:
+        return {
+            "count": 0,
+            "sum": 0,
+            "mean": 0,
+            "median": 0,
+            "min": 0,
+            "max": 0,
+            "std_dev": 0,
+        }
+
+    result = {
+        "count": len(values),
+        "sum": sum(values),
+        "mean": statistics.mean(values),
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
+        "std_dev": statistics.stdev(values) if len(values) > 1 else 0,
+    }
+    return result
+
+
+def aggregate_profiles(profiles: List[ProfileData]) -> Dict:
+    """Aggregate data across all profiles."""
+    result = {
+        "count": len(profiles),
+        "block_ids": [p.block_id for p in profiles],
+        "total_costs": [p.total_cost for p in profiles],
+        "cost_distribution": {},
+        "opcodes": {},
+        "mark_ids": {},
+    }
+
+    # Aggregate cost distribution
+    all_categories = set()
+    for p in profiles:
+        all_categories.update(p.cost_distribution.keys())
+
+    for category in all_categories:
+        values = [p.cost_distribution.get(category, 0) for p in profiles]
+        percentages = [
+            (p.cost_distribution.get(category, 0) / p.total_cost * 100)
+            if p.total_cost > 0
+            else 0
+            for p in profiles
+        ]
+        stats = compute_statistics(values)
+        stats["avg_pct"] = statistics.mean(percentages) if percentages else 0
+        result["cost_distribution"][category] = stats
+
+    # Aggregate opcodes
+    all_opcodes = set()
+    for p in profiles:
+        all_opcodes.update(p.opcodes.keys())
+
+    for opcode in all_opcodes:
+        costs = [p.opcodes.get(opcode, {}).get("cost", 0) for p in profiles]
+        counts = [p.opcodes.get(opcode, {}).get("count", 0) for p in profiles]
+        percentages = [
+            (p.opcodes.get(opcode, {}).get("cost", 0) / p.total_cost * 100)
+            if p.total_cost > 0
+            else 0
+            for p in profiles
+        ]
+        stats = compute_statistics(costs)
+        stats["avg_pct"] = statistics.mean(percentages) if percentages else 0
+        stats["avg_count"] = statistics.mean(counts) if counts else 0
+        result["opcodes"][opcode] = stats
+
+    # Aggregate MARK_IDs
+    all_mark_ids = set()
+    for p in profiles:
+        all_mark_ids.update(p.mark_ids.keys())
+
+    for mark_id in all_mark_ids:
+        total_costs = [
+            p.mark_ids.get(mark_id, {}).get("total_cost", 0) for p in profiles
+        ]
+        main_costs = [p.mark_ids.get(mark_id, {}).get("main_cost", 0) for p in profiles]
+        opcode_costs = [
+            p.mark_ids.get(mark_id, {}).get("opcode_cost", 0) for p in profiles
+        ]
+        precompile_costs = [
+            p.mark_ids.get(mark_id, {}).get("precompile_cost", 0) for p in profiles
+        ]
+        memory_costs = [
+            p.mark_ids.get(mark_id, {}).get("memory_cost", 0) for p in profiles
+        ]
+        percentages = [
+            (p.mark_ids.get(mark_id, {}).get("total_cost", 0) / p.total_cost * 100)
+            if p.total_cost > 0
+            else 0
+            for p in profiles
+        ]
+
+        result["mark_ids"][mark_id] = {
+            "total_cost": compute_statistics(total_costs),
+            "main_cost": compute_statistics(main_costs),
+            "opcode_cost": compute_statistics(opcode_costs),
+            "precompile_cost": compute_statistics(precompile_costs),
+            "memory_cost": compute_statistics(memory_costs),
+            "avg_pct": statistics.mean(percentages) if percentages else 0,
+        }
+
+    return result
+
+
+def generate_markdown_report(aggregated: Dict, directory: str) -> str:
+    """Generate a Markdown report from aggregated data."""
+    lines = []
+
+    # Header
+    lines.append("# Zisk Profile Summary\n")
+    lines.append(f"- **Profiles analyzed:** {aggregated['count']}")
+    lines.append(f"- **Directory:** `{directory}`")
+
+    block_ids = sorted(aggregated["block_ids"], key=lambda x: int(x) if x.isdigit() else 0)
+    if block_ids:
+        lines.append(f"- **Block range:** {block_ids[0]} - {block_ids[-1]}")
+
+    total_cost_stats = compute_statistics(aggregated["total_costs"])
+    lines.append(f"- **Total cost (sum):** {format_number(total_cost_stats['sum'])}")
+    lines.append(f"- **Avg cost per profile:** {format_number(total_cost_stats['mean'])}")
+    lines.append("")
+
+    # MARK_ID Summary (primary focus)
+    lines.append("## Custom Scopes (MARK_ID)\n")
+    lines.append(
+        "| Scope | Avg Cost | Avg % | Median | Min | Max | Std Dev |"
+    )
+    lines.append("|-------|----------|-------|--------|-----|-----|---------|")
+
+    # Sort by average cost descending
+    sorted_mark_ids = sorted(
+        aggregated["mark_ids"].items(),
+        key=lambda x: x[1]["total_cost"]["mean"],
+        reverse=True,
+    )
+
+    for name, data in sorted_mark_ids:
+        stats = data["total_cost"]
+        lines.append(
+            f"| {name} | {format_number(stats['mean'])} | {format_percent(data['avg_pct'])} | "
+            f"{format_number(stats['median'])} | {format_number(stats['min'])} | "
+            f"{format_number(stats['max'])} | {format_number(stats['std_dev'])} |"
+        )
+
+    lines.append("")
+
+    # MARK_ID Cost Breakdown
+    lines.append("### Cost Breakdown by Scope\n")
+    lines.append("| Scope | Main | Opcodes | Precompiles | Memory |")
+    lines.append("|-------|------|---------|-------------|--------|")
+
+    for name, data in sorted_mark_ids:
+        main_pct = (
+            data["main_cost"]["mean"] / data["total_cost"]["mean"] * 100
+            if data["total_cost"]["mean"] > 0
+            else 0
+        )
+        opcode_pct = (
+            data["opcode_cost"]["mean"] / data["total_cost"]["mean"] * 100
+            if data["total_cost"]["mean"] > 0
+            else 0
+        )
+        precompile_pct = (
+            data["precompile_cost"]["mean"] / data["total_cost"]["mean"] * 100
+            if data["total_cost"]["mean"] > 0
+            else 0
+        )
+        memory_pct = (
+            data["memory_cost"]["mean"] / data["total_cost"]["mean"] * 100
+            if data["total_cost"]["mean"] > 0
+            else 0
+        )
+        lines.append(
+            f"| {name} | {format_percent(main_pct)} | {format_percent(opcode_pct)} | "
+            f"{format_percent(precompile_pct)} | {format_percent(memory_pct)} |"
+        )
+
+    lines.append("")
+
+    # Cost Distribution Summary
+    lines.append("## Cost Distribution\n")
+    lines.append("| Category | Avg Cost | Avg % | Median | Min | Max |")
+    lines.append("|----------|----------|-------|--------|-----|-----|")
+
+    # Sort by average cost descending
+    sorted_categories = sorted(
+        aggregated["cost_distribution"].items(),
+        key=lambda x: x[1]["mean"],
+        reverse=True,
+    )
+
+    for category, stats in sorted_categories:
+        lines.append(
+            f"| {category} | {format_number(stats['mean'])} | {format_percent(stats['avg_pct'])} | "
+            f"{format_number(stats['median'])} | {format_number(stats['min'])} | "
+            f"{format_number(stats['max'])} |"
+        )
+
+    lines.append("")
+
+    # Top 10 Opcodes by Cost
+    lines.append("## Top 10 Opcodes by Cost\n")
+    lines.append("| Opcode | Avg Cost | Avg % | Avg Count | Median Cost |")
+    lines.append("|--------|----------|-------|-----------|-------------|")
+
+    sorted_opcodes = sorted(
+        aggregated["opcodes"].items(), key=lambda x: x[1]["mean"], reverse=True
+    )[:10]
+
+    for opcode, stats in sorted_opcodes:
+        lines.append(
+            f"| {opcode} | {format_number(stats['mean'])} | {format_percent(stats['avg_pct'])} | "
+            f"{format_number(stats['avg_count'])} | {format_number(stats['median'])} |"
+        )
+
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze Zisk profiling outputs and generate an aggregate summary.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "directory",
+        type=str,
+        help="Directory containing .prof files to analyze",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        help="Output file path (default: stdout)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show verbose output during parsing",
+    )
+
+    args = parser.parse_args()
+
+    directory = Path(args.directory)
+    if not directory.exists():
+        print(f"Error: Directory does not exist: {directory}", file=sys.stderr)
+        sys.exit(1)
+
+    if not directory.is_dir():
+        print(f"Error: Not a directory: {directory}", file=sys.stderr)
+        sys.exit(1)
+
+    prof_files = list(directory.glob("*.prof"))
+    if not prof_files:
+        print(f"Error: No .prof files found in {directory}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.verbose:
+        print(f"Found {len(prof_files)} profile files", file=sys.stderr)
+
+    # Parse all profiles
+    profiles = []
+    for filepath in sorted(prof_files):
+        if args.verbose:
+            print(f"Parsing {filepath.name}...", file=sys.stderr)
+        profile = parse_profile(filepath, args.verbose)
+        if profile:
+            profiles.append(profile)
+
+    if not profiles:
+        print("Error: All profiles failed to parse", file=sys.stderr)
+        sys.exit(2)
+
+    if args.verbose:
+        print(f"Successfully parsed {len(profiles)} profiles", file=sys.stderr)
+
+    # Aggregate and generate report
+    aggregated = aggregate_profiles(profiles)
+    report = generate_markdown_report(aggregated, str(directory))
+
+    # Output
+    if args.output:
+        output_path = Path(args.output)
+        output_path.write_text(report)
+        print(f"Report written to {output_path}", file=sys.stderr)
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a feature to dump Zisk profiles when running in `execute` mode.

If the `--zisk-profile` flag is added when using `--action execute`, it will dump `ziskemu` profiles of all executed fixtures in an output folder (`zisk-profiles` by default or can be overridden by `--zisk-profile-output`).

```
> tree zisk-profiles               
zisk-profiles
└── ethrex-v9.0.0
    ├── zisk_profile_rpc_block_23533518.prof
    ├── zisk_profile_rpc_block_23533705.prof
    ├── zisk_profile_rpc_block_23533763.prof
    ├── zisk_profile_rpc_block_23533796.prof
...
```

I also added a Python script that can read this output folder and provide some summary about all the fixture runs regarding costs (e.g. avg, min, max, etc.), and also a plot to have an easier visual on this. I'll soon share a HackMD doc with results from 500 mainnet blocks.

