### PR TITLE
Add fixture name prefix filtering for benchmark runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ This decoupling provides several benefits:
     # Use custom input folder for stateless validator benchmarks
     cargo run --release -- --zkvms sp1 stateless-validator --execution-client reth --input-folder my-fixtures
 
+    # Run only fixtures whose names start with the provided prefixes
+    cargo run --release -- --zkvms sp1 stateless-validator --execution-client reth \
+        --input-folder my-fixtures \
+        --fixture test_sha256.py::test_sha256 \
+        --fixture test_memory.py::test_mcopy
+
     # Dump raw input files used in benchmarks (opt-in)
     cargo run --release -- --zkvms sp1 --dump-inputs my-inputs stateless-validator --execution-client reth
 
@@ -97,6 +103,7 @@ This decoupling provides several benefits:
     ```
 
     See the respective README files in each crate for detailed usage instructions.
+    The same prefix-based `--fixture` filter is also available on `block-encoding-length`.
 
 ### Dumping Input Files
 

--- a/crates/benchmark-runner/src/block_encoding_length_program.rs
+++ b/crates/benchmark-runner/src/block_encoding_length_program.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     guest_programs::{GenericGuestFixture, GuestFixture},
-    stateless_validator::{iter_benchmark_fixture_paths, load_benchmark_fixture},
+    stateless_validator::{benchmark_fixture_paths, load_benchmark_fixture},
 };
 use anyhow::{Context, Result};
 use ere_guests_block_encoding_length::guest::{
@@ -22,14 +22,15 @@ pub struct BlockEncodingLengthMetadata {
 /// Lazily generates inputs for the block encoding length guest program.
 pub fn block_encoding_length_input_iter(
     input_folder: &Path,
+    selected_fixtures: Option<&[String]>,
     loop_count: u16,
     format: BlockEncodingFormat,
-) -> impl Iterator<Item = Result<Box<dyn GuestFixture>>> {
-    block_encoding_length_input_iter_from_paths(
-        iter_benchmark_fixture_paths(input_folder),
+) -> Result<impl Iterator<Item = Result<Box<dyn GuestFixture>>>> {
+    Ok(block_encoding_length_input_iter_from_paths(
+        benchmark_fixture_paths(input_folder, selected_fixtures)?.into_iter(),
         loop_count,
         format,
-    )
+    ))
 }
 
 fn block_encoding_length_input_iter_from_paths<I>(

--- a/crates/benchmark-runner/src/stateless_validator.rs
+++ b/crates/benchmark-runner/src/stateless_validator.rs
@@ -1,7 +1,7 @@
 //! Stateless validator guest program.
 
 use crate::guest_programs::{GenericGuestFixture, GuestFixture};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use ere_guests_guest::Guest;
 use ere_guests_integration_tests::NoopPlatform;
 use ere_guests_stateless_validator_ethrex::guest::{
@@ -11,7 +11,10 @@ use ere_guests_stateless_validator_reth::guest::{
     StatelessValidatorRethGuest, StatelessValidatorRethInput,
 };
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 use strum::{AsRefStr, EnumString};
 use tracing::info;
 use walkdir::WalkDir;
@@ -55,6 +58,32 @@ pub fn iter_benchmark_fixture_paths(path: &Path) -> impl Iterator<Item = PathBuf
         .map(walkdir::DirEntry::into_path)
 }
 
+/// Resolves benchmark fixture file paths, optionally filtering by fixture name prefix.
+pub fn benchmark_fixture_paths(
+    input_folder: &Path,
+    selected_fixtures: Option<&[String]>,
+) -> Result<Vec<PathBuf>> {
+    let available_paths: Vec<_> = iter_benchmark_fixture_paths(input_folder).collect();
+    let Some(selected_fixtures) = selected_fixtures.filter(|fixtures| !fixtures.is_empty()) else {
+        return Ok(available_paths);
+    };
+
+    let fixture_prefixes = normalize_fixture_prefixes(selected_fixtures)?;
+    let mut resolved_paths = Vec::new();
+
+    for path in available_paths {
+        let fixture_name = fixture_name_from_path(&path)?;
+        if fixture_prefixes
+            .iter()
+            .any(|prefix| fixture_name.starts_with(prefix))
+        {
+            resolved_paths.push(path);
+        }
+    }
+
+    Ok(resolved_paths)
+}
+
 /// Reads and deserializes a single benchmark fixture file.
 pub fn load_benchmark_fixture(path: &Path) -> Result<StatelessValidationFixture> {
     let content = std::fs::read(path)?;
@@ -64,14 +93,15 @@ pub fn load_benchmark_fixture(path: &Path) -> Result<StatelessValidationFixture>
 /// Lazily prepares stateless validator inputs from a fixture folder.
 pub fn stateless_validator_input_iter(
     input_folder: &Path,
+    selected_fixtures: Option<&[String]>,
     el: ExecutionClient,
     existing_output_dir: Option<&Path>,
-) -> impl Iterator<Item = Result<Box<dyn GuestFixture>>> {
-    stateless_validator_input_iter_from_paths(
-        iter_benchmark_fixture_paths(input_folder),
+) -> Result<impl Iterator<Item = Result<Box<dyn GuestFixture>>>> {
+    Ok(stateless_validator_input_iter_from_paths(
+        benchmark_fixture_paths(input_folder, selected_fixtures)?.into_iter(),
         el,
         existing_output_dir.map(Path::to_path_buf),
-    )
+    ))
 }
 
 fn stateless_validator_input_iter_from_paths<I>(
@@ -114,6 +144,32 @@ fn fixture_name_from_path(path: &Path) -> Result<String> {
         .and_then(|stem| stem.to_str())
         .map(ToOwned::to_owned)
         .with_context(|| format!("Failed to derive fixture name from {}", path.display()))
+}
+
+fn normalize_fixture_prefixes(prefixes: &[String]) -> Result<Vec<String>> {
+    let mut normalized_prefixes = Vec::with_capacity(prefixes.len());
+    let mut seen_prefixes = HashSet::new();
+
+    for prefix in prefixes {
+        let normalized_prefix = normalize_fixture_prefix(prefix)?;
+        if seen_prefixes.insert(normalized_prefix.clone()) {
+            normalized_prefixes.push(normalized_prefix);
+        }
+    }
+
+    Ok(normalized_prefixes)
+}
+
+fn normalize_fixture_prefix(prefix: &str) -> Result<String> {
+    let normalized = prefix.trim();
+    if normalized.is_empty() {
+        bail!("Fixture prefix cannot be empty");
+    }
+
+    Ok(normalized
+        .strip_suffix(".json")
+        .unwrap_or(normalized)
+        .to_owned())
 }
 
 fn stateless_validator_input_from_fixture(

--- a/crates/ere-hosts/src/cli.rs
+++ b/crates/ere-hosts/src/cli.rs
@@ -84,6 +84,9 @@ pub enum GuestProgramCommand {
         /// Input folder for benchmark fixtures
         #[arg(short, long, default_value = "zkevm-fixtures-input")]
         input_folder: PathBuf,
+        /// Fixture name prefix to run. Repeat to select multiple prefixes.
+        #[arg(long, value_name = "PREFIX")]
+        fixture: Option<Vec<String>>,
         /// Execution client to benchmark
         #[arg(short, long)]
         execution_client: ExecutionClient,
@@ -96,6 +99,10 @@ pub enum GuestProgramCommand {
         /// Input folder for benchmark fixtures
         #[arg(short, long, default_value = "zkevm-fixtures-input")]
         input_folder: PathBuf,
+
+        /// Fixture name prefix to run. Repeat to select multiple prefixes.
+        #[arg(long, value_name = "PREFIX")]
+        fixture: Option<Vec<String>>,
 
         /// Number of times to loop the benchmark
         #[arg(long)]

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -97,6 +97,7 @@ async fn main() -> Result<()> {
     match cli.guest_program {
         GuestProgramCommand::StatelessValidator {
             input_folder,
+            fixture,
             execution_client,
         } => {
             let el: stateless_validator::ExecutionClient = execution_client.into();
@@ -134,9 +135,10 @@ async fn main() -> Result<()> {
                             .then(|| benchmark_output_dir(&zkvm.zkvm, &config));
                         let guest_io = stateless_validator::stateless_validator_input_iter(
                             input_folder.as_path(),
+                            fixture.as_deref(),
                             el,
                             existing_output_dir.as_deref(),
-                        )
+                        )?
                         .map(|input| input.context("Failed to get stateless validator input"));
                         run_benchmark_iter(zkvm, &config, guest_io)?;
                     }
@@ -172,6 +174,7 @@ async fn main() -> Result<()> {
         }
         GuestProgramCommand::BlockEncodingLength {
             input_folder,
+            fixture,
             loop_count,
             format,
         } => {
@@ -202,9 +205,10 @@ async fn main() -> Result<()> {
                         let guest_io =
                             block_encoding_length_program::block_encoding_length_input_iter(
                                 input_folder.as_path(),
+                                fixture.as_deref(),
                                 loop_count,
                                 format.clone().into(),
-                            )
+                            )?
                             .map(|input| {
                                 input.context("Failed to get block encoding length input")
                             });


### PR DESCRIPTION
This PR adds a (long due...) `--fixture` CLI flag (repeatable) to both `stateless-validator` and `block-encoding-length` subcommands, allowing users to run only fixtures whose names start with the given prefix(es).

Example:
```
cargo run --release -- --zkvms sp1 stateless-validator \
    --execution-client reth \
    --input-folder my-fixtures \
    --fixture test_sha256.py::test_sha256 \
    --fixture test_memory.py::test_mcopy
```