### PR TITLE
witness-generator-cli: add --genesis support for custom network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ This decoupling provides several benefits:
     # Or generate from RPC
     cargo run --release -- rpc --last-n-blocks 2 --rpc-url <your-rpc-url>
 
+    # Or generate from a custom/devnet RPC using a local genesis file
+    cargo run --release -- rpc --last-n-blocks 2 --rpc-url <your-rpc-url> \
+        --genesis /path/to/genesis.json
+
     # Or listen for new blocks continuously
     cargo run --release -- rpc --follow --rpc-url <your-rpc-url>
 

--- a/crates/witness-generator-cli/README.md
+++ b/crates/witness-generator-cli/README.md
@@ -47,6 +47,10 @@ cargo run -- tests --eest-fixtures-path /path/to/local/eest/fixtures
 # Generate from RPC (last 5 blocks)
 cargo run -- rpc --last-n-blocks 5 --rpc-url "https://mainnet.infura.io/v3/YOUR_KEY"
 
+# Generate from RPC using a custom/devnet genesis file
+cargo run -- rpc --last-n-blocks 5 --rpc-url "https://your-devnet-rpc" \
+  --genesis /data/code-data/devnets/bal-devnet-3-ethrex/metadata/el/genesis.json
+
 # Generate specific block from RPC
 cargo run -- rpc --block 20000000 --rpc-url "https://mainnet.infura.io/v3/YOUR_KEY"
 
@@ -89,6 +93,14 @@ When using `--follow`, the generator will:
 - Continue until interrupted with Ctrl+C
 - Handle network disconnections gracefully
 
+### RPC Custom Chain Config
+
+By default, the `rpc` subcommand only supports chain IDs with baked-in Reth chain configs. Use
+`--genesis <PATH>` to load a geth-style `genesis.json` for custom/devnet RPC endpoints.
+
+The CLI still validates `eth_chainId` against `genesis.config.chainId` and fails fast if they do
+not match.
+
 ## Command Line Options
 
 | Option | Description | Example |
@@ -105,6 +117,7 @@ When using `--follow`, the generator will:
 | `--follow` | Continuously stream new blocks | `--follow` |
 | `--rpc-url` | RPC endpoint URL | `--rpc-url "https://..."` |
 | `--rpc-header` | Custom RPC header | `--rpc-header "Auth=token"` |
+| `--genesis` | Custom geth-style genesis file for RPC chain config | `--genesis ./genesis.json` |
 | `--output-folder` | Custom output directory | `--output-folder my-fixtures` |
 
 ## Error Handling

--- a/crates/witness-generator-cli/src/main.rs
+++ b/crates/witness-generator-cli/src/main.rs
@@ -76,6 +76,10 @@ enum SourceCommand {
         /// Optional RPC headers to use (format: "Key:Value")
         #[arg(long)]
         rpc_header: Option<Vec<String>>,
+
+        /// Optional path to a geth-style genesis.json file for custom/devnet chain config
+        #[arg(long, value_name = "PATH")]
+        genesis: Option<PathBuf>,
     },
 }
 
@@ -146,6 +150,7 @@ async fn build_generator(source: SourceCommand) -> Result<Box<dyn FixtureGenerat
             block,
             rpc_url,
             rpc_header,
+            genesis,
             follow: listen,
         } => {
             let mut builder = RpcBlocksAndWitnessesBuilder::new(rpc_url);
@@ -155,6 +160,10 @@ async fn build_generator(source: SourceCommand) -> Result<Box<dyn FixtureGenerat
                     .try_into()
                     .context("Failed to parse RPC headers")?;
                 builder = builder.with_headers(headers);
+            }
+
+            if let Some(genesis) = genesis {
+                builder = builder.with_genesis(genesis);
             }
 
             if listen {

--- a/crates/witness-generator/src/lib.rs
+++ b/crates/witness-generator/src/lib.rs
@@ -103,6 +103,45 @@ pub enum WGError {
     #[error("unsupported chain ID: {0}")]
     UnsupportedChain(u64),
 
+    /// Genesis path does not exist
+    #[error("genesis path '{0}' does not exist")]
+    GenesisPathNotFound(String),
+
+    /// Genesis path is not a file
+    #[error("genesis path '{0}' is not a file")]
+    GenesisPathNotFile(String),
+
+    /// Failed to read a genesis file
+    #[error("failed to read genesis file at {path}: {source}")]
+    GenesisFileReadError {
+        /// Path to the genesis file
+        path: String,
+        /// Underlying I/O error
+        source: std::io::Error,
+    },
+
+    /// Failed to deserialize a genesis file
+    #[error("failed to deserialize genesis file at {path}: {source}")]
+    GenesisDeserializationError {
+        /// Path to the genesis file
+        path: String,
+        /// Underlying deserialization error
+        source: serde_json::Error,
+    },
+
+    /// RPC chain ID does not match the provided genesis file
+    #[error(
+        "genesis chain ID mismatch for '{path}': genesis={genesis_chain_id}, rpc={rpc_chain_id}"
+    )]
+    GenesisChainIdMismatch {
+        /// Path to the genesis file
+        path: String,
+        /// Chain ID from the genesis file
+        genesis_chain_id: u64,
+        /// Chain ID reported by the RPC endpoint
+        rpc_chain_id: u64,
+    },
+
     /// Live polling not supported in generate method
     #[error("live polling is not supported in generate method. Use generate_to_path instead.")]
     LivePollingNotSupported,

--- a/crates/witness-generator/src/rpc_generator.rs
+++ b/crates/witness-generator/src/rpc_generator.rs
@@ -2,7 +2,7 @@
 
 use crate::{Fixture, FixtureGenerator, Result, StatelessValidationFixture, WGError};
 use alloy_eips::BlockNumberOrTag;
-use alloy_genesis::ChainConfig;
+use alloy_genesis::{ChainConfig, Genesis};
 use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction, TransactionRequest};
 use async_trait::async_trait;
 use http::{HeaderName, HeaderValue};
@@ -14,7 +14,10 @@ use reth_chainspec::{Chain, HOLESKY, HOODI, NamedChain, SEPOLIA, mainnet_chain_c
 use reth_ethereum_primitives::TransactionSigned;
 use reth_rpc_api::{DebugApiClient, EthApiClient};
 use stateless::StatelessInput;
-use std::{path::Path, str::FromStr};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 use tokio_util::sync::CancellationToken;
 
 /// Builder for configuring an RPC client that fetches blocks and witnesses.
@@ -25,6 +28,7 @@ pub struct RpcBlocksAndWitnessesBuilder {
     last_n_blocks: Option<usize>,
     block: Option<u64>,
     stop: Option<CancellationToken>,
+    genesis: Option<PathBuf>,
 }
 
 impl RpcBlocksAndWitnessesBuilder {
@@ -45,6 +49,15 @@ impl RpcBlocksAndWitnessesBuilder {
     /// * `headers` - HTTP headers to include in RPC requests
     pub fn with_headers(mut self, headers: HeaderMap) -> Self {
         self.header_map = headers;
+        self
+    }
+
+    /// Sets the path to a geth-style `genesis.json` file used to derive the chain config.
+    ///
+    /// # Arguments
+    /// * `path` - Path to the genesis file
+    pub fn with_genesis(mut self, path: PathBuf) -> Self {
+        self.genesis = Some(path);
         self
     }
 
@@ -75,6 +88,40 @@ impl RpcBlocksAndWitnessesBuilder {
         self
     }
 
+    fn load_chain_config_from_genesis(path: &Path) -> Result<ChainConfig> {
+        if !path.exists() {
+            return Err(WGError::GenesisPathNotFound(path.display().to_string()));
+        }
+        if !path.is_file() {
+            return Err(WGError::GenesisPathNotFile(path.display().to_string()));
+        }
+
+        let contents =
+            std::fs::read_to_string(path).map_err(|e| WGError::GenesisFileReadError {
+                path: path.display().to_string(),
+                source: e,
+            })?;
+        let genesis: Genesis =
+            serde_json::from_str(&contents).map_err(|e| WGError::GenesisDeserializationError {
+                path: path.display().to_string(),
+                source: e,
+            })?;
+
+        Ok(genesis.config)
+    }
+
+    fn chain_config_from_chain_id(chain_id: u64) -> Result<ChainConfig> {
+        let chain = Chain::from_id(chain_id);
+
+        match chain.named() {
+            Some(NamedChain::Mainnet) => Ok(mainnet_chain_config()),
+            Some(NamedChain::Sepolia) => Ok(SEPOLIA.genesis.config.clone()),
+            Some(NamedChain::Hoodi) => Ok(HOODI.genesis.config.clone()),
+            Some(NamedChain::Holesky) => Ok(HOLESKY.genesis.config.clone()),
+            _ => Err(WGError::UnsupportedChain(chain_id)),
+        }
+    }
+
     /// Builds the configured `RpcBlocksAndWitnesses`.
     pub async fn build(self) -> Result<RpcFixtureGenerator> {
         let client = HttpClientBuilder::default()
@@ -88,16 +135,20 @@ impl RpcBlocksAndWitnessesBuilder {
             .map_err(|e| WGError::RpcError(e.to_string()))?
             .ok_or(WGError::ChainIdFetchError)?;
 
-        let chain = Chain::from_id(chain_id.to());
+        let rpc_chain_id: u64 = chain_id.to();
 
-        let chain_config = match chain.named() {
-            Some(NamedChain::Mainnet) => mainnet_chain_config(),
-            Some(NamedChain::Sepolia) => SEPOLIA.genesis.config.clone(),
-            Some(NamedChain::Hoodi) => HOODI.genesis.config.clone(),
-            Some(NamedChain::Holesky) => HOLESKY.genesis.config.clone(),
-            _ => {
-                return Err(WGError::UnsupportedChain(chain_id.to()));
+        let chain_config = if let Some(genesis_path) = self.genesis.as_deref() {
+            let chain_config = Self::load_chain_config_from_genesis(genesis_path)?;
+            if chain_config.chain_id != rpc_chain_id {
+                return Err(WGError::GenesisChainIdMismatch {
+                    path: genesis_path.display().to_string(),
+                    genesis_chain_id: chain_config.chain_id,
+                    rpc_chain_id,
+                });
             }
+            chain_config
+        } else {
+            Self::chain_config_from_chain_id(rpc_chain_id)?
         };
 
         Ok(RpcFixtureGenerator {


### PR DESCRIPTION
This PR adds custom genesis support to the RPC fixture generation flow:
- add a `--genesis <PATH>` flag to `witness-generator-cli rpc`
- load chain config from a geth-style `genesis.json` when the flag is provided
- keep the existing built-in chain config flow for supported networks when `--genesis` is not set
- validate `eth_chainId` from the RPC endpoint against `genesis.config.chainId`

The current RPC generator only supports networks with baked-in chain configs. That works for mainnet and a few known testnets, but it blocks fixture generation from custom or devnet RPC endpoints.

With this change, users can point the CLI at a local genesis file and generate fixtures from custom chains without losing chain ID validation.

