### PR TITLE
feat: add zisk cluster benchmark support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,9 @@ dependencies = [
  "anyhow",
  "auto_impl",
  "downloader",
- "ere-dockerized",
+ "ere-cluster-client-zisk",
+ "ere-dockerized 0.8.1",
+ "ere-util-tokio 0.8.1",
  "flate2",
  "guest",
  "integration-tests",
@@ -1872,6 +1874,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "combine"
@@ -2740,15 +2751,49 @@ name = "ere-catalog"
 version = "0.8.0"
 source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-util-build",
+ "ere-util-build 0.8.0",
  "serde",
  "strum 0.27.2",
+]
+
+[[package]]
+name = "ere-catalog"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
+dependencies = [
+ "ere-util-build 0.8.1",
+ "serde",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "ere-cluster-client-zisk"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
+dependencies = [
+ "ere-prover-core 0.8.1",
+ "ere-util-tokio 0.8.1",
+ "ere-verifier-zisk",
+ "futures-util",
+ "http",
+ "prost",
+ "prost-types",
+ "thiserror 2.0.18",
+ "tonic",
+ "tonic-prost",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "ere-codec"
 version = "0.8.0"
 source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
+name = "ere-codec"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
 
 [[package]]
 name = "ere-compiler-core"
@@ -2759,16 +2804,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ere-compiler-core"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ere-dockerized"
 version = "0.8.0"
 source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
  "anyhow",
- "ere-catalog",
- "ere-compiler-core",
- "ere-prover-core",
- "ere-server-client",
- "ere-util-tokio",
+ "ere-catalog 0.8.0",
+ "ere-compiler-core 0.8.0",
+ "ere-prover-core 0.8.0",
+ "ere-server-client 0.8.0",
+ "ere-util-tokio 0.8.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "ere-dockerized"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
+dependencies = [
+ "anyhow",
+ "ere-catalog 0.8.1",
+ "ere-compiler-core 0.8.1",
+ "ere-prover-core 0.8.1",
+ "ere-server-client 0.8.1",
+ "ere-util-tokio 0.8.1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2782,7 +2852,7 @@ dependencies = [
  "anyhow",
  "benchmark-runner",
  "clap",
- "ere-dockerized",
+ "ere-dockerized 0.8.1",
  "humantime",
  "tokio",
  "tracing",
@@ -2803,8 +2873,25 @@ dependencies = [
  "auto_impl",
  "bincode 2.0.1",
  "clap",
- "ere-codec",
- "ere-verifier-core",
+ "ere-codec 0.8.0",
+ "ere-verifier-core 0.8.0",
+ "indexmap 2.14.0",
+ "serde",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ere-prover-core"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
+dependencies = [
+ "anyhow",
+ "auto_impl",
+ "bincode 2.0.1",
+ "clap",
+ "ere-codec 0.8.1",
+ "ere-verifier-core 0.8.1",
  "indexmap 2.14.0",
  "serde",
  "strum 0.27.2",
@@ -2822,13 +2909,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ere-server-api"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
+dependencies = [
+ "prost",
+ "serde",
+ "twirp",
+]
+
+[[package]]
 name = "ere-server-client"
 version = "0.8.0"
 source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
  "bincode 2.0.1",
- "ere-prover-core",
- "ere-server-api",
+ "ere-prover-core 0.8.0",
+ "ere-server-api 0.8.0",
+ "thiserror 2.0.18",
+ "twirp",
+]
+
+[[package]]
+name = "ere-server-client"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
+dependencies = [
+ "bincode 2.0.1",
+ "ere-prover-core 0.8.1",
+ "ere-server-api 0.8.1",
  "thiserror 2.0.18",
  "twirp",
 ]
@@ -2842,9 +2951,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ere-util-build"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
+dependencies = [
+ "cargo_metadata 0.19.2",
+]
+
+[[package]]
 name = "ere-util-tokio"
 version = "0.8.0"
 source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "ere-util-tokio"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
 dependencies = [
  "tokio",
 ]
@@ -2855,8 +2980,34 @@ version = "0.8.0"
 source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
  "auto_impl",
- "ere-codec",
+ "ere-codec 0.8.0",
  "serde",
+]
+
+[[package]]
+name = "ere-verifier-core"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
+dependencies = [
+ "auto_impl",
+ "ere-codec 0.8.1",
+ "serde",
+]
+
+[[package]]
+name = "ere-verifier-zisk"
+version = "0.8.1"
+source = "git+https://github.com/eth-act/ere?rev=44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b#44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b"
+dependencies = [
+ "bincode 2.0.1",
+ "bytemuck",
+ "ere-util-build 0.8.1",
+ "ere-verifier-core 0.8.1",
+ "proofman-util",
+ "proofman-verifier",
+ "serde",
+ "serde-big-array",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3260,6 +3411,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "fields"
+version = "0.16.1"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.16.1#971209423e8fa53fa32dc747744d68c65aafa6c7"
+dependencies = [
+ "cfg-if",
+ "num-bigint",
+ "paste",
+ "serde",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,7 +3801,7 @@ name = "guest"
 version = "0.9.0"
 source = "git+https://github.com/eth-act/ere-guests?rev=a58aa0d7f2c0a813d666eabc9fd94036a21d87b5#a58aa0d7f2c0a813d666eabc9fd94036a21d87b5"
 dependencies = [
- "ere-codec",
+ "ere-codec 0.8.0",
  "ere-platform-core",
  "sha2",
 ]
@@ -4318,7 +4480,7 @@ version = "0.9.0"
 source = "git+https://github.com/eth-act/ere-guests?rev=a58aa0d7f2c0a813d666eabc9fd94036a21d87b5#a58aa0d7f2c0a813d666eabc9fd94036a21d87b5"
 dependencies = [
  "alloy-primitives",
- "ere-dockerized",
+ "ere-dockerized 0.8.0",
  "flate2",
  "guest",
  "rayon",
@@ -6062,6 +6224,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proofman-util"
+version = "0.16.1"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.16.1#971209423e8fa53fa32dc747744d68c65aafa6c7"
+dependencies = [
+ "bincode 1.3.3",
+ "bytemuck",
+ "colored",
+ "serde",
+ "sysinfo 0.35.2",
+]
+
+[[package]]
+name = "proofman-verifier"
+version = "0.16.1"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.16.1#971209423e8fa53fa32dc747744d68c65aafa6c7"
+dependencies = [
+ "bytemuck",
+ "fields",
+ "proofman-util",
+ "rayon",
+ "tracing",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6122,6 +6308,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -8936,6 +9131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9305,7 +9509,7 @@ dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
  "anyhow",
- "ere-codec",
+ "ere-codec 0.8.0",
  "ere-platform-core",
  "libssz",
  "libssz-derive",
@@ -9328,7 +9532,7 @@ dependencies = [
  "alloy-rlp",
  "anyhow",
  "bytes",
- "ere-prover-core",
+ "ere-prover-core 0.8.0",
  "ethrex-common",
  "ethrex-crypto",
  "ethrex-guest-program",
@@ -9356,7 +9560,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "anyhow",
  "bincode 2.0.1",
- "ere-prover-core",
+ "ere-prover-core 0.8.0",
  "guest",
  "once_cell",
  "reth-chainspec",
@@ -9506,6 +9710,20 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -9914,8 +10132,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
+ "axum",
  "base64",
  "bytes",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -9924,6 +10144,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,9 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 
 # ere
-ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }
+ere-dockerized = { git = "https://github.com/eth-act/ere", rev = "44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b" }
+ere-cluster-client-zisk = { git = "https://github.com/eth-act/ere", rev = "44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b" }
+ere-util-tokio = { git = "https://github.com/eth-act/ere", rev = "44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b" }
 
 # ere-guests
 ere-guests-stateless-validator-reth = { git = "https://github.com/eth-act/ere-guests", rev = "a58aa0d7f2c0a813d666eabc9fd94036a21d87b5", package = "stateless-validator-reth" }

--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -8,6 +8,8 @@ rust-version.workspace = true
 witness-generator.workspace = true
 zkevm-metrics.workspace = true
 ere-dockerized.workspace = true
+ere-cluster-client-zisk.workspace = true
+ere-util-tokio.workspace = true
 
 rayon.workspace = true
 tracing.workspace = true

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -1,10 +1,14 @@
 //! Runner for benchmark tests
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
+use ere_cluster_client_zisk::{ZiskClusterClient, ZiskProgramVk, ZiskProof};
 use ere_dockerized::{
-    zkVMKind, DockerizedzkVM, DockerizedzkVMConfig, Elf, EncodedProof, ProverResource,
+    codec::{Decode, Encode},
+    zkVMKind, zkVMVerifier, DockerizedzkVM, DockerizedzkVMConfig, Elf, EncodedProof, Input,
+    ProgramExecutionReport, ProgramProvingReport, ProverResource, PublicValues,
 };
-use ere_guests_downloader::Downloader;
+use ere_guests_downloader::{CompiledGuest, Downloader};
+use ere_util_tokio::block_on;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -25,23 +29,107 @@ const ERE_GUESTS_DOWNLOAD_KIND: &str = env!("ERE_GUESTS_DOWNLOAD_KIND");
 const ERE_GUESTS_DOWNLOAD_VALUE: &str = env!("ERE_GUESTS_DOWNLOAD_VALUE");
 
 /// A zkVM instance bundled with ELF bytes (used for profiling).
-pub struct ZkVMInstance {
-    /// The dockerized zkVM instance
-    pub zkvm: DockerizedzkVM,
+pub enum ZkVMInstance {
+    /// Dockerized zkVM instance
+    Dockerized(DockerizedzkVM),
+    /// Remote Zisk proving cluster client.
+    ZiskClusterClient {
+        /// ELF of the guest program.
+        elf: Elf,
+        /// gRPC client connected to the remote Zisk cluster.
+        client: ZiskClusterClient,
+    },
 }
 
 impl ZkVMInstance {
+    /// Returns the zkVM kind.
+    pub fn zkvm_kind(&self) -> zkVMKind {
+        match self {
+            Self::Dockerized(vm) => vm.zkvm_kind(),
+            Self::ZiskClusterClient { .. } => zkVMKind::Zisk,
+        }
+    }
+
+    /// Returns the zkVM name.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Dockerized(vm) => vm.name(),
+            Self::ZiskClusterClient { client, .. } => client.verifier().name(),
+        }
+    }
+
+    /// Returns the zkVM SDK version.
+    pub fn sdk_version(&self) -> &'static str {
+        match self {
+            Self::Dockerized(vm) => vm.sdk_version(),
+            Self::ZiskClusterClient { client, .. } => client.verifier().sdk_version(),
+        }
+    }
+
+    /// Returns the ELF.
     fn elf(&self) -> &Elf {
-        self.zkvm.elf()
+        match self {
+            Self::Dockerized(vm) => vm.elf(),
+            Self::ZiskClusterClient { elf, .. } => elf,
+        }
+    }
+
+    /// Executes the guest program without proving.
+    pub fn execute(&self, input: &Input) -> Result<(PublicValues, ProgramExecutionReport)> {
+        match self {
+            Self::Dockerized(vm) => vm.execute(input),
+            Self::ZiskClusterClient { .. } => {
+                bail!("ZiskClusterClient does not support Action::Execute")
+            }
+        }
+    }
+
+    /// Generates a proof for the guest program with the given input.
+    pub fn prove(
+        &self,
+        input: &Input,
+    ) -> Result<(PublicValues, EncodedProof, ProgramProvingReport)> {
+        match self {
+            Self::Dockerized(vm) => vm.prove(input),
+            Self::ZiskClusterClient { client, .. } => {
+                let (proof, proving_time) = block_on(client.prove(input))?;
+                let public_values = proof.public_values.into();
+                let proof = proof.encode_to_vec()?;
+                Ok((
+                    public_values,
+                    EncodedProof(proof),
+                    ProgramProvingReport::new(proving_time),
+                ))
+            }
+        }
+    }
+
+    /// Verifies a proof and returns the public values it commits to.
+    pub fn verify(&self, proof: &EncodedProof) -> Result<PublicValues> {
+        match self {
+            Self::Dockerized(vm) => vm.verify(proof),
+            Self::ZiskClusterClient { client, .. } => {
+                let proof = ZiskProof::decode_from_slice(&proof.0)?;
+                Ok(client.verify(&proof)?)
+            }
+        }
     }
 }
 
 impl std::fmt::Debug for ZkVMInstance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ZkVMInstance")
-            .field("zkvm", &self.zkvm.name())
-            .field("elf_len", &self.elf().len())
-            .finish()
+        match self {
+            Self::Dockerized(vm) => f
+                .debug_struct("Dockerized")
+                .field("zkvm", &vm.name())
+                .field("elf", vm.elf())
+                .finish(),
+            Self::ZiskClusterClient { client, elf } => f
+                .debug_struct("ZiskClusterClient")
+                .field("zkvm", &client.verifier().name())
+                .field("elf", elf)
+                .finish(),
+        }
     }
 }
 
@@ -82,17 +170,15 @@ where
 {
     HardwareInfo::detect().to_path(config.output_folder.join("hardware.json"))?;
 
-    let zkvm = &instance.zkvm;
-    let elf = &instance.elf();
     match config.action {
         Action::Execute => inputs.par_bridge().try_for_each(|input| {
             let input = input?;
-            process_input(zkvm, input, config, elf)
+            process_input(instance, input, config)
         })?,
 
         Action::Prove => inputs.into_iter().try_for_each(|input| {
             let input = input?;
-            process_input(zkvm, input, config, elf)
+            process_input(instance, input, config)
         })?,
 
         Action::Verify => {
@@ -105,7 +191,7 @@ where
     Ok(())
 }
 
-fn benchmark_zkvm_name(zkvm: &DockerizedzkVM) -> String {
+fn benchmark_zkvm_name(zkvm: &ZkVMInstance) -> String {
     format!("{}-v{}", zkvm.name(), zkvm.sdk_version())
 }
 
@@ -125,13 +211,13 @@ fn benchmark_output_path_for_name(
 }
 
 /// Returns the output directory for a given zkVM benchmark run.
-pub fn benchmark_output_dir(zkvm: &DockerizedzkVM, config: &RunConfig) -> PathBuf {
+pub fn benchmark_output_dir(zkvm: &ZkVMInstance, config: &RunConfig) -> PathBuf {
     benchmark_output_dir_for_name(config, &benchmark_zkvm_name(zkvm))
 }
 
 /// Returns the output path for a given fixture within a zkVM benchmark run.
 pub fn benchmark_output_path(
-    zkvm: &DockerizedzkVM,
+    zkvm: &ZkVMInstance,
     config: &RunConfig,
     fixture_name: &str,
 ) -> PathBuf {
@@ -139,12 +225,7 @@ pub fn benchmark_output_path(
 }
 
 /// Processes a single input through the zkVM
-fn process_input(
-    zkvm: &DockerizedzkVM,
-    io: impl GuestFixture,
-    config: &RunConfig,
-    elf: &[u8],
-) -> Result<()> {
+fn process_input(zkvm: &ZkVMInstance, io: impl GuestFixture, config: &RunConfig) -> Result<()> {
     let zkvm_name = benchmark_zkvm_name(zkvm);
     let fixture_name = io.name();
     let out_path = benchmark_output_path_for_name(config, &zkvm_name, &fixture_name);
@@ -173,7 +254,7 @@ fn process_input(
             if let Some(profile_config) = &config.zisk_profile_config {
                 let outcome = run_profiling(
                     profile_config,
-                    elf,
+                    zkvm.elf(),
                     input.stdin(),
                     &fixture_name,
                     config.sub_folder.as_deref(),
@@ -300,27 +381,51 @@ pub async fn get_guest_zkvm_instances(
     let mut instances = Vec::new();
     for zkvm in zkvms {
         let guest_name = format!("{}-{}", guest_name_prefix, zkvm.as_str());
-        let elf = load_elf(&guest_name, bin_path).await?;
-        let zkvm = DockerizedzkVM::new(*zkvm, Elf(elf), resource.clone(), zkvm_config.clone())
-            .with_context(|| format!("Failed to initialize DockerizedzkVM, kind {zkvm}"))?;
-        instances.push(ZkVMInstance { zkvm });
+        let compiled = load_compiled(&guest_name, bin_path).await?;
+        let instance = match &resource {
+            ProverResource::Cluster(cfg) if *zkvm == zkVMKind::Zisk => {
+                let program_vk = ZiskProgramVk::decode_from_slice(&compiled.program_vk)
+                    .context("Failed to decode Zisk program vk")?;
+                let client = ZiskClusterClient::new(cfg, program_vk)
+                    .map_err(|e| anyhow!("Failed to connect to Zisk cluster: {e}"))?;
+                ZkVMInstance::ZiskClusterClient {
+                    elf: Elf(compiled.elf),
+                    client,
+                }
+            }
+            ProverResource::Cluster(_) => {
+                bail!("Cluster resource is only implemented for Zisk; got {zkvm}");
+            }
+            _ => {
+                let zkvm = DockerizedzkVM::new(
+                    *zkvm,
+                    Elf(compiled.elf),
+                    resource.clone(),
+                    zkvm_config.clone(),
+                )
+                .with_context(|| format!("Failed to initialize DockerizedzkVM, kind {zkvm}"))?;
+                ZkVMInstance::Dockerized(zkvm)
+            }
+        };
+        instances.push(instance);
     }
     Ok(instances)
 }
 
-async fn load_elf(guest_name: &str, bin_path: Option<&Path>) -> Result<Vec<u8>> {
+async fn load_compiled(guest_name: &str, bin_path: Option<&Path>) -> Result<CompiledGuest> {
     if let Some(path) = bin_path {
-        return fs::read(path.join(format!("{guest_name}.elf")))
-            .with_context(|| format!("Failed to read ELF from path: {}", path.display()));
+        let elf = fs::read(path.join(format!("{guest_name}.elf")))
+            .with_context(|| format!("Failed to read ELF from path: {}", path.display()))?;
+        let program_vk = fs::read(path.join(format!("{guest_name}.vk")))
+            .with_context(|| format!("Failed to read program vk from path: {}", path.display()))?;
+        return Ok(CompiledGuest { elf, program_vk });
     }
 
     let downloader = guest_downloader().await?;
-    let compiled = downloader
+    downloader
         .download(guest_name)
         .await
-        .with_context(|| format!("Failed to download guest program: {guest_name}"))?;
-
-    Ok(compiled.elf)
+        .with_context(|| format!("Failed to download guest program: {guest_name}"))
 }
 
 async fn guest_downloader() -> Result<Downloader> {

--- a/crates/benchmark-runner/src/verification.rs
+++ b/crates/benchmark-runner/src/verification.rs
@@ -1,18 +1,18 @@
 //! Proof verification from disk or remote URL
 
 use anyhow::{anyhow, Context, Result};
-use ere_dockerized::{DockerizedzkVM, EncodedProof};
+use ere_dockerized::EncodedProof;
 use std::fs;
 use std::panic;
 use std::path::{Path, PathBuf};
 use tracing::info;
 use zkevm_metrics::{BenchmarkRun, CrashInfo, HardwareInfo, VerificationMetrics};
 
-use crate::runner::{get_panic_msg, RunConfig};
+use crate::runner::{get_panic_msg, RunConfig, ZkVMInstance};
 
 /// Loads proof artifacts from disk and verifies them using the given zkVM.
 pub fn run_verify_from_disk(
-    zkvm: &DockerizedzkVM,
+    zkvm: &ZkVMInstance,
     config: &RunConfig,
     proofs_folder: &Path,
 ) -> Result<()> {

--- a/crates/ere-hosts/src/cli.rs
+++ b/crates/ere-hosts/src/cli.rs
@@ -2,7 +2,7 @@
 
 use benchmark_runner::{runner::Action, stateless_validator};
 use clap::{Parser, Subcommand, ValueEnum};
-use ere_dockerized::{ProverResource, zkVMKind};
+use ere_dockerized::{ProverResource, RemoteProverConfig, zkVMKind};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -16,6 +16,10 @@ pub struct Cli {
     /// Resource type for proving
     #[arg(short, long, value_enum, default_value = "cpu")]
     pub resource: Resource,
+
+    /// Endpoint URL of the proving cluster (required when --resource cluster)
+    #[arg(long, required_if_eq("resource", "cluster"))]
+    pub cluster_endpoint: Option<String>,
 
     /// Action to perform
     #[arg(short, long, value_enum, default_value = "execute")]
@@ -121,6 +125,8 @@ pub enum Resource {
     Cpu,
     /// GPU resource
     Gpu,
+    /// Proving cluster (requires --cluster-endpoint)
+    Cluster,
 }
 
 /// Benchmark actions
@@ -138,11 +144,19 @@ fn parse_duration(value: &str) -> Result<Duration, String> {
     humantime::parse_duration(value).map_err(|err| err.to_string())
 }
 
-impl From<Resource> for ProverResource {
-    fn from(resource: Resource) -> Self {
-        match resource {
-            Resource::Cpu => Self::Cpu,
-            Resource::Gpu => Self::Gpu,
+impl Cli {
+    /// Build the Ere [`ProverResource`] from parsed CLI args.
+    pub fn prover_resource(&self) -> ProverResource {
+        match self.resource {
+            Resource::Cpu => ProverResource::Cpu,
+            Resource::Gpu => ProverResource::Gpu,
+            Resource::Cluster => ProverResource::Cluster(RemoteProverConfig {
+                endpoint: self
+                    .cluster_endpoint
+                    .clone()
+                    .expect("clap required_if_eq should guarantee cluster_endpoint set"),
+                api_key: None,
+            }),
         }
     }
 }

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    let resource: ProverResource = cli.resource.into();
+    let resource: ProverResource = cli.prover_resource();
     let action: Action = cli.action.into();
     let zkvm_config = build_zkvm_config(action, cli.timeout);
     info!(
@@ -71,6 +71,21 @@ async fn main() -> Result<()> {
     // Validate: --proofs-url is only valid with --action verify
     if cli.proofs_url.is_some() && !matches!(action, Action::Verify) {
         anyhow::bail!("--proofs-url is only valid with --action verify");
+    }
+
+    // Validate: --cluster-endpoint is only valid with --resource cluster
+    if cli.cluster_endpoint.is_some() && !matches!(cli.resource, cli::Resource::Cluster) {
+        anyhow::bail!("--cluster-endpoint is only valid with --resource cluster");
+    }
+
+    // Validate: --resource cluster currently only supports zisk zkVM and not support --action execute
+    if matches!(cli.resource, cli::Resource::Cluster) {
+        if cli.zkvms.iter().any(|z| *z != zkVMKind::Zisk) {
+            anyhow::bail!("--resource cluster is only implemented for --zkvms zisk");
+        }
+        if matches!(action, Action::Execute) {
+            anyhow::bail!("--resource cluster is not implemented for --action execute");
+        }
     }
 
     // Resolve proofs source: download from URL or use local folder.
@@ -121,7 +136,7 @@ async fn main() -> Result<()> {
             match action {
                 Action::Verify => {
                     for instance in &zkvms {
-                        run_verify_from_disk(&instance.zkvm, &config, &proofs_folder)?;
+                        run_verify_from_disk(instance, &config, &proofs_folder)?;
                     }
                 }
                 _ => {
@@ -130,8 +145,8 @@ async fn main() -> Result<()> {
                         input_folder.display()
                     );
                     for zkvm in &zkvms {
-                        let existing_output_dir = (!config.force_rerun)
-                            .then(|| benchmark_output_dir(&zkvm.zkvm, &config));
+                        let existing_output_dir =
+                            (!config.force_rerun).then(|| benchmark_output_dir(zkvm, &config));
                         let guest_io = stateless_validator::stateless_validator_input_iter(
                             input_folder.as_path(),
                             fixture.as_deref(),
@@ -159,7 +174,7 @@ async fn main() -> Result<()> {
             match action {
                 Action::Verify => {
                     for instance in &zkvms {
-                        run_verify_from_disk(&instance.zkvm, &config_base, &proofs_folder)?;
+                        run_verify_from_disk(instance, &config_base, &proofs_folder)?;
                     }
                 }
                 _ => {


### PR DESCRIPTION
- Bump `ere` to `44e91ed7c0bd5398d55eb4ce43594ac0f161dd2b`
- Add dep `ere-cluster-client-zisk` so we can use `ZiskClusterClient` to do the proving benchmark
  Although `DockerizedzkVM` also supports `ProverResource::Cluster`, but it requires additional configuration for the container to get access to the actual cluster (extra hosts), so this PR integrates the client directly to avoid that.
- Make the `ZkVMInstance` an enum, and `Dockerized` variant works as is. For `ZiskClusterClient` it supports `prove` and `verify` (by integrating the verifier directly in the cluster client crate), but it doesn't support `execute`
