### PR TITLE
feat: update to ere@v0.11.0 and ere-guests@v0.11.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ zkevm-fixtures*
 zkevm-metrics*
 # zkevm dump
 zkevm-dump
+# zisk profiles
+zisk-profiles
 
 # vscode settings
 .vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,7 @@ dependencies = [
  "ere-util-tokio",
  "flate2",
  "guest",
+ "hex",
  "integration-tests",
  "rayon",
  "reqwest 0.12.28",
@@ -1881,7 +1882,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2520,8 +2521,8 @@ dependencies = [
 
 [[package]]
 name = "downloader"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.10.0#2d519d4f2cea92c654a1934f6cb0b0368d7fbef8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -2748,8 +2749,8 @@ dependencies = [
 
 [[package]]
 name = "ere-catalog"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-util-build",
  "serde",
@@ -2758,40 +2759,40 @@ dependencies = [
 
 [[package]]
 name = "ere-cluster-client-zisk"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
+ "bincode 2.0.1",
+ "ere-compiler-core",
  "ere-prover-core",
- "ere-util-tokio",
  "ere-verifier-zisk",
- "futures-util",
  "http",
  "prost",
  "prost-types",
+ "serde",
  "thiserror 2.0.18",
+ "tokio",
  "tonic",
  "tonic-prost",
- "tracing",
- "uuid",
 ]
 
 [[package]]
 name = "ere-codec"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-compiler-core"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ere-dockerized"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "anyhow",
  "ere-catalog",
@@ -2821,13 +2822,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-prover-core"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -2843,8 +2844,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-api"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "prost",
  "serde",
@@ -2853,8 +2854,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-client"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "bincode 2.0.1",
  "ere-prover-core",
@@ -2865,24 +2866,24 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "cargo_metadata 0.19.2",
 ]
 
 [[package]]
 name = "ere-util-tokio"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "ere-verifier-core"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "auto_impl",
  "ere-codec",
@@ -2891,8 +2892,8 @@ dependencies = [
 
 [[package]]
 name = "ere-verifier-zisk"
-version = "0.9.1"
-source = "git+https://github.com/eth-act/ere?tag=v0.9.1#a0ff5701d6328bb55126a59d7091b1777944c8b0"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "bincode 2.0.1",
  "bytemuck",
@@ -2901,8 +2902,8 @@ dependencies = [
  "proofman-util",
  "proofman-verifier",
  "serde",
- "serde-big-array",
  "thiserror 2.0.18",
+ "zisk-verifier",
 ]
 
 [[package]]
@@ -2944,8 +2945,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -2966,8 +2967,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2987,7 +2988,6 @@ dependencies = [
  "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
  "lru",
  "once_cell",
- "rayon",
  "rkyv",
  "rustc-hash",
  "serde",
@@ -2999,8 +2999,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3023,8 +3023,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3035,7 +3035,9 @@ dependencies = [
  "ethrex-vm",
  "hex",
  "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
  "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
  "rkyv",
  "serde",
  "serde_with",
@@ -3044,8 +3046,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3062,8 +3064,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -3071,7 +3073,6 @@ dependencies = [
  "ethrex-crypto",
  "ethrex-rlp",
  "malachite",
- "rayon",
  "rustc-hash",
  "serde",
  "strum 0.27.2",
@@ -3080,8 +3081,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -3096,8 +3097,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3138,8 +3139,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3148,8 +3149,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3187,8 +3188,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3209,8 +3210,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3228,8 +3229,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=81484becd285e2a1e178306d8c22f94a104f560b#81484becd285e2a1e178306d8c22f94a104f560b"
+version = "12.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -3238,7 +3239,6 @@ dependencies = [
  "ethrex-crypto",
  "ethrex-levm",
  "ethrex-rlp",
- "rayon",
  "rustc-hash",
  "serde",
  "thiserror 2.0.18",
@@ -3314,8 +3314,8 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fields"
-version = "0.16.1"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.16.1#971209423e8fa53fa32dc747744d68c65aafa6c7"
+version = "0.18.0"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -3700,8 +3700,8 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.10.0#2d519d4f2cea92c654a1934f6cb0b0368d7fbef8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
 dependencies = [
  "ere-codec",
  "ere-platform-core",
@@ -4088,7 +4088,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4378,8 +4378,8 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.10.0#2d519d4f2cea92c654a1934f6cb0b0368d7fbef8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
 dependencies = [
  "alloy-primitives",
  "ere-dockerized",
@@ -6164,11 +6164,10 @@ dependencies = [
 
 [[package]]
 name = "proofman-util"
-version = "0.16.1"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.16.1#971209423e8fa53fa32dc747744d68c65aafa6c7"
+version = "0.18.0"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
 dependencies = [
- "bincode 1.3.3",
- "bytemuck",
+ "bincode 2.0.1",
  "colored",
  "serde",
  "sysinfo 0.35.2",
@@ -6176,13 +6175,13 @@ dependencies = [
 
 [[package]]
 name = "proofman-verifier"
-version = "0.16.1"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.16.1#971209423e8fa53fa32dc747744d68c65aafa6c7"
+version = "0.18.0"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
 dependencies = [
- "bytemuck",
+ "bincode 2.0.1",
  "fields",
- "proofman-util",
- "rayon",
+ "num-traits",
+ "serde",
  "tracing",
 ]
 
@@ -9070,15 +9069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9442,8 +9432,8 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.10.0#2d519d4f2cea92c654a1934f6cb0b0368d7fbef8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9461,8 +9451,8 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator-ethrex"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.10.0#2d519d4f2cea92c654a1934f6cb0b0368d7fbef8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9484,8 +9474,8 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator-reth"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.10.0#2d519d4f2cea92c654a1934f6cb0b0368d7fbef8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9503,6 +9493,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-payload-validator",
  "reth-primitives-traits",
+ "revm",
  "serde",
  "serde_with",
  "sha2",
@@ -11596,6 +11587,14 @@ dependencies = [
  "alloy-rlp",
  "alloy-trie",
  "arrayvec",
+]
+
+[[package]]
+name = "zisk-verifier"
+version = "0.18.0"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.18.0#790f9e28a6d1d8575e38dc77f2af4966b8659722"
+dependencies = [
+ "proofman-verifier",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,16 +104,16 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 
 # ere
-ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.9.1" }
-ere-cluster-client-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.9.1" }
-ere-util-tokio = { git = "https://github.com/eth-act/ere", tag = "v0.9.1" }
+ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-cluster-client-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-util-tokio = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
 
 # ere-guests
-ere-guests-stateless-validator-reth = { git = "https://github.com/eth-act/ere-guests", tag = "v0.10.0", package = "stateless-validator-reth" }
-ere-guests-stateless-validator-ethrex = { git = "https://github.com/eth-act/ere-guests", tag = "v0.10.0", package = "stateless-validator-ethrex" }
-ere-guests-guest = { git = "https://github.com/eth-act/ere-guests", tag = "v0.10.0", package = "guest" }
-ere-guests-integration-tests = { git = "https://github.com/eth-act/ere-guests", tag = "v0.10.0", package = "integration-tests" }
-ere-guests-downloader = { git = "https://github.com/eth-act/ere-guests", tag = "v0.10.0", package = "downloader" }
+ere-guests-stateless-validator-reth = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "stateless-validator-reth" }
+ere-guests-stateless-validator-ethrex = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "stateless-validator-ethrex" }
+ere-guests-guest = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "guest" }
+ere-guests-integration-tests = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "integration-tests" }
+ere-guests-downloader = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "downloader" }
 
 reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.1.0" }
 reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.1.0" }
@@ -154,3 +154,4 @@ reqwest = { version = "0.12", default-features = false, features = [
 flate2 = "1.1"
 tar = "0.4"
 toml = "0.8"
+hex = "0.4"

--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -25,6 +25,7 @@ anyhow.workspace = true
 auto_impl.workspace = true
 ere-guests-downloader.workspace = true
 tempfile.workspace = true
+hex.workspace = true
 
 ere-guests-stateless-validator-ethrex = { "workspace" = true, features = [
     "host",

--- a/crates/benchmark-runner/src/guest_programs.rs
+++ b/crates/benchmark-runner/src/guest_programs.rs
@@ -60,7 +60,7 @@ where
     ) -> anyhow::Result<Self> {
         Ok(Self {
             name: name.as_ref().to_string(),
-            input: Input::new().with_prefixed_stdin(
+            input: Input::new().with_stdin(
                 input
                     .encode_to_vec()
                     .map_err(|e| anyhow::anyhow!("Failed to serialize guest input: {}", e))?,

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -1,7 +1,7 @@
 //! Runner for benchmark tests
 
 use anyhow::{anyhow, bail, Context, Result};
-use ere_cluster_client_zisk::{ZiskClusterClient, ZiskProgramVk, ZiskProof};
+use ere_cluster_client_zisk::{ZiskClusterClient, ZiskProof};
 use ere_dockerized::{
     codec::{Decode, Encode},
     zkVMKind, zkVMVerifier, DockerizedzkVM, DockerizedzkVMConfig, Elf, EncodedProof, Input,
@@ -31,13 +31,20 @@ const ERE_GUESTS_DOWNLOAD_VALUE: &str = env!("ERE_GUESTS_DOWNLOAD_VALUE");
 /// A zkVM instance bundled with ELF bytes (used for profiling).
 pub enum ZkVMInstance {
     /// Dockerized zkVM instance
-    Dockerized(DockerizedzkVM),
+    Dockerized {
+        /// zkVM instance
+        zkvm: DockerizedzkVM,
+        /// ELF of Zisk guest with feature `cycle-scope` enabled.
+        /// `Some` only if the guest is a Zisk guest.
+        profiling_elf: Option<Elf>,
+    },
     /// Remote Zisk proving cluster client.
     ZiskClusterClient {
-        /// ELF of the guest program.
-        elf: Elf,
         /// gRPC client connected to the remote Zisk cluster.
         client: ZiskClusterClient,
+        /// ELF of Zisk guest with feature `cycle-scope` enabled.
+        /// `Some` only if the guest is a Zisk guest.
+        profiling_elf: Option<Elf>,
     },
 }
 
@@ -45,7 +52,7 @@ impl ZkVMInstance {
     /// Returns the zkVM kind.
     pub fn zkvm_kind(&self) -> zkVMKind {
         match self {
-            Self::Dockerized(vm) => vm.zkvm_kind(),
+            Self::Dockerized { zkvm, .. } => zkvm.zkvm_kind(),
             Self::ZiskClusterClient { .. } => zkVMKind::Zisk,
         }
     }
@@ -53,7 +60,7 @@ impl ZkVMInstance {
     /// Returns the zkVM name.
     pub fn name(&self) -> &'static str {
         match self {
-            Self::Dockerized(vm) => vm.name(),
+            Self::Dockerized { zkvm, .. } => zkvm.name(),
             Self::ZiskClusterClient { client, .. } => client.verifier().name(),
         }
     }
@@ -61,23 +68,23 @@ impl ZkVMInstance {
     /// Returns the zkVM SDK version.
     pub fn sdk_version(&self) -> &'static str {
         match self {
-            Self::Dockerized(vm) => vm.sdk_version(),
+            Self::Dockerized { zkvm, .. } => zkvm.sdk_version(),
             Self::ZiskClusterClient { client, .. } => client.verifier().sdk_version(),
         }
     }
 
-    /// Returns the ELF.
-    fn elf(&self) -> &Elf {
+    /// Returns the ELF for Zisk profiling.
+    pub const fn profiling_elf(&self) -> Option<&Elf> {
         match self {
-            Self::Dockerized(vm) => vm.elf(),
-            Self::ZiskClusterClient { elf, .. } => elf,
+            Self::Dockerized { profiling_elf, .. }
+            | Self::ZiskClusterClient { profiling_elf, .. } => profiling_elf.as_ref(),
         }
     }
 
     /// Executes the guest program without proving.
     pub fn execute(&self, input: &Input) -> Result<(PublicValues, ProgramExecutionReport)> {
         match self {
-            Self::Dockerized(vm) => vm.execute(input),
+            Self::Dockerized { zkvm, .. } => zkvm.execute(input),
             Self::ZiskClusterClient { .. } => {
                 bail!("ZiskClusterClient does not support Action::Execute")
             }
@@ -90,10 +97,10 @@ impl ZkVMInstance {
         input: &Input,
     ) -> Result<(PublicValues, EncodedProof, ProgramProvingReport)> {
         match self {
-            Self::Dockerized(vm) => vm.prove(input),
+            Self::Dockerized { zkvm, .. } => zkvm.prove(input),
             Self::ZiskClusterClient { client, .. } => {
-                let (proof, proving_time) = block_on(client.prove(input))?;
-                let public_values = proof.public_values.into();
+                let (proof, proving_time) = block_on(client.prove(input, None))?;
+                let (_, public_values) = proof.program_vk_and_public_values()?;
                 let proof = proof.encode_to_vec()?;
                 Ok((
                     public_values,
@@ -107,10 +114,10 @@ impl ZkVMInstance {
     /// Verifies a proof and returns the public values it commits to.
     pub fn verify(&self, proof: &EncodedProof) -> Result<PublicValues> {
         match self {
-            Self::Dockerized(vm) => vm.verify(proof),
+            Self::Dockerized { zkvm, .. } => zkvm.verify(proof),
             Self::ZiskClusterClient { client, .. } => {
                 let proof = ZiskProof::decode_from_slice(&proof.0)?;
-                Ok(client.verify(&proof)?)
+                Ok(client.verifier().verify(&proof)?)
             }
         }
     }
@@ -119,15 +126,20 @@ impl ZkVMInstance {
 impl std::fmt::Debug for ZkVMInstance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Dockerized(vm) => f
+            Self::Dockerized { zkvm, .. } => f
                 .debug_struct("Dockerized")
-                .field("zkvm", &vm.name())
-                .field("elf", vm.elf())
+                .field("zkvm", &zkvm.name())
+                .field("sdk_version", &zkvm.sdk_version())
+                .field("program_vk", &hex::encode(&zkvm.program_vk().0))
                 .finish(),
-            Self::ZiskClusterClient { client, elf } => f
+            Self::ZiskClusterClient { client, .. } => f
                 .debug_struct("ZiskClusterClient")
                 .field("zkvm", &client.verifier().name())
-                .field("elf", elf)
+                .field("sdk_version", &client.verifier().sdk_version())
+                .field(
+                    "program_vk",
+                    &hex::encode(client.program_vk().encode_to_vec().expect("infallable")),
+                )
                 .finish(),
         }
     }
@@ -252,9 +264,12 @@ fn process_input(zkvm: &ZkVMInstance, io: impl GuestFixture, config: &RunConfig)
         Action::Execute => {
             // Run Zisk profiling if configured
             if let Some(profile_config) = &config.zisk_profile_config {
+                let Some(profiling_elf) = zkvm.profiling_elf() else {
+                    bail!("Zisk profiling configured but profiling ELF not found")
+                };
                 let outcome = run_profiling(
                     profile_config,
-                    zkvm.elf(),
+                    profiling_elf,
                     input.stdin(),
                     &fixture_name,
                     config.sub_folder.as_deref(),
@@ -383,20 +398,7 @@ pub async fn get_guest_zkvm_instances(
         let guest_name = format!("{}-{}", guest_name_prefix, zkvm.as_str());
         let compiled = load_compiled(&guest_name, bin_path).await?;
         let instance = match &resource {
-            ProverResource::Cluster(cfg) if *zkvm == zkVMKind::Zisk => {
-                let program_vk = ZiskProgramVk::decode_from_slice(&compiled.program_vk)
-                    .context("Failed to decode Zisk program vk")?;
-                let client = ZiskClusterClient::new(cfg, program_vk)
-                    .map_err(|e| anyhow!("Failed to connect to Zisk cluster: {e}"))?;
-                ZkVMInstance::ZiskClusterClient {
-                    elf: Elf(compiled.elf),
-                    client,
-                }
-            }
-            ProverResource::Cluster(_) => {
-                bail!("Cluster resource is only implemented for Zisk; got {zkvm}");
-            }
-            _ => {
+            ProverResource::Cpu | ProverResource::Gpu => {
                 let zkvm = DockerizedzkVM::new(
                     *zkvm,
                     Elf(compiled.elf),
@@ -404,8 +406,24 @@ pub async fn get_guest_zkvm_instances(
                     zkvm_config.clone(),
                 )
                 .with_context(|| format!("Failed to initialize DockerizedzkVM, kind {zkvm}"))?;
-                ZkVMInstance::Dockerized(zkvm)
+                ZkVMInstance::Dockerized {
+                    zkvm,
+                    profiling_elf: compiled.profiling_elf.map(Elf),
+                }
             }
+            ProverResource::Cluster(cfg) if *zkvm == zkVMKind::Zisk => {
+                let client = ZiskClusterClient::new(cfg, Elf(compiled.elf.clone()))
+                    .await
+                    .map_err(|e| anyhow!("Failed to connect to Zisk cluster: {e}"))?;
+                ZkVMInstance::ZiskClusterClient {
+                    client,
+                    profiling_elf: compiled.profiling_elf.map(Elf),
+                }
+            }
+            ProverResource::Cluster(_) => {
+                bail!("Cluster is only implemented for Zisk, got {zkvm}")
+            }
+            ProverResource::Network(_) => unreachable!(),
         };
         instances.push(instance);
     }
@@ -418,7 +436,12 @@ async fn load_compiled(guest_name: &str, bin_path: Option<&Path>) -> Result<Comp
             .with_context(|| format!("Failed to read ELF from path: {}", path.display()))?;
         let program_vk = fs::read(path.join(format!("{guest_name}.vk")))
             .with_context(|| format!("Failed to read program vk from path: {}", path.display()))?;
-        return Ok(CompiledGuest { elf, program_vk });
+        let profiling_elf = fs::read(path.join(format!("{guest_name}-profiling.elf"))).ok();
+        return Ok(CompiledGuest {
+            elf,
+            program_vk,
+            profiling_elf,
+        });
     }
 
     let downloader = guest_downloader().await?;

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -138,7 +138,7 @@ impl std::fmt::Debug for ZkVMInstance {
                 .field("sdk_version", &client.verifier().sdk_version())
                 .field(
                     "program_vk",
-                    &hex::encode(client.program_vk().encode_to_vec().expect("infallable")),
+                    &hex::encode(client.program_vk().encode_to_vec().expect("infallible")),
                 )
                 .finish(),
         }

--- a/crates/benchmark-runner/src/stateless_validator.rs
+++ b/crates/benchmark-runner/src/stateless_validator.rs
@@ -5,7 +5,8 @@ use anyhow::{bail, Context, Result};
 use ere_guests_guest::Guest;
 use ere_guests_integration_tests::NoopPlatform;
 use ere_guests_stateless_validator_ethrex::{
-    guest::StatelessValidatorEthrexGuest, host::build_eip8025_input,
+    guest::StatelessValidatorEthrexGuest,
+    host::{build_eip8025_input, Eip8025InputSource},
 };
 use ere_guests_stateless_validator_reth::guest::{
     StatelessValidatorRethGuest, StatelessValidatorRethInput,
@@ -188,8 +189,11 @@ fn ethrex_input_from_fixture(fixture: StatelessValidationFixture) -> Result<Box<
         stateless_input,
         success,
     } = fixture;
-    let input = build_eip8025_input(&stateless_input, success)
-        .context("Failed to create Ethrex stateless validator input")?;
+    let input = build_eip8025_input(Eip8025InputSource::Legacy {
+        stateless_input: &stateless_input,
+        valid_block: success,
+    })
+    .context("Failed to create Ethrex stateless validator input")?;
     let output = StatelessValidatorEthrexGuest::compute::<NoopPlatform>(input.clone());
     let metadata = BlockMetadata {
         block_used_gas: stateless_input.block.gas_used,

--- a/crates/benchmark-runner/src/zisk_profiling.rs
+++ b/crates/benchmark-runner/src/zisk_profiling.rs
@@ -250,7 +250,7 @@ fn remove_file_if_exists(path: &Path) -> Result<()> {
     }
 }
 
-/// Mirrors `ere-zisk` input preparation for direct `ziskemu` execution.
+/// Mirrors `ere-prover-zisk` input preparation for direct `ziskemu` execution.
 fn length_prefixed_and_padded(data: &[u8]) -> Vec<u8> {
     let len = (8 + data.len()).next_multiple_of(8);
     let mut buf = Vec::with_capacity(len);

--- a/scripts/analyze_zisk_profiles.py
+++ b/scripts/analyze_zisk_profiles.py
@@ -3,7 +3,7 @@
 Analyze Zisk profiling outputs and generate an aggregate summary report.
 
 Parses .prof files from ziskemu and produces a Markdown report with:
-- MARK_ID custom scope statistics (primary focus)
+- PROFILE TAGS custom scope statistics (primary focus)
 - Cost distribution breakdown (MAIN, OPCODES, PRECOMPILES, MEMORY)
 - Top opcodes by cost
 
@@ -37,6 +37,11 @@ class ProfileData:
     cost_distribution: Dict[str, int] = field(default_factory=dict)
     opcodes: Dict[str, Dict[str, int]] = field(default_factory=dict)
     mark_ids: Dict[str, Dict[str, int]] = field(default_factory=dict)
+
+
+# ziskemu's per-step MAIN cost constant. Used to derive per-scope MAIN cost from per-scope STEPS.
+# https://github.com/0xPolygonHermez/zisk/blob/v0.18.0/emulator/src/emu_costs.rs#L18
+MAIN_COST_PER_STEP = 68
 
 
 def parse_number(s: str) -> int:
@@ -94,6 +99,10 @@ def parse_profile(filepath: Path, verbose: bool = False) -> Optional[ProfileData
                 line = lines[i].strip()
                 if not line or line.startswith("TOTAL") or line.startswith("FROPS"):
                     break
+                # Skip VARIABLE which is a sub-total of MAIN+OPCODES+PRECOMPILES+MEMORY.
+                if line.startswith("VARIABLE"):
+                    i += 1
+                    continue
                 # Match lines like: BASE                         293,601,280   1.10%
                 match = re.match(r"^(\w+)\s+([\d,]+)\s+[\d.]+%$", line)
                 if match:
@@ -122,9 +131,10 @@ def parse_profile(filepath: Path, verbose: bool = False) -> Optional[ProfileData
                 line = lines[i].strip()
                 if not line or line.startswith("FROPS"):
                     break
-                # Match lines like: OP keccak                         44,347   5,681,205,476  21.20% #1
+                # Match lines like: OP keccak                         44,347   0.03%  5,681,205,476  21.20% #1
                 match = re.match(
-                    r"^OP\s+(\w+)\s+([\d,]+)\s+([\d,]+)\s+[\d.]+%", line
+                    r"^OP\s+(\w+)\s+([\d,]+)\s+[\d.]+%\s+([\d,]+)\s+[\d.]+%",
+                    line,
                 )
                 if match:
                     opcode = match.group(1)
@@ -134,37 +144,45 @@ def parse_profile(filepath: Path, verbose: bool = False) -> Optional[ProfileData
                 i += 1
             continue
 
-        # Parse MARK_ID section
-        if line.startswith("MARK_ID"):
+        # Parse PROFILE TAGS COST section.
+        if line.startswith("PROFILE TAGS COST"):
             i += 2  # Skip header line
             while i < len(lines):
                 line = lines[i].strip()
-                if not line or re.match(r"^[a-f0-9]{8}$", line):
+                if not line:
                     break
-                # Match MARK_ID lines
-                # RECOVER_BLOCK                     0          1       2,376,088   1.06%     384,171,246   1.43%     161,573,984      38,085,509     150,738,364      33,773,389
-                parts = line.split()
-                if len(parts) >= 11 and not parts[0].startswith("-"):
-                    try:
-                        name = parts[0].lower()
-                        # parts[1] = INDEX, parts[2] = COUNT, parts[3] = STEPS, parts[4] = STEPS%
-                        # parts[5] = TOTAL COST, parts[6] = %, parts[7] = MAIN COST, parts[8] = OPCODE COST
-                        # parts[9] = PRECOMPILE COST, parts[10] = MEMORY COST
-                        total_cost = parse_number(parts[5])
-                        main_cost = parse_number(parts[7])
-                        opcode_cost = parse_number(parts[8])
-                        precompile_cost = parse_number(parts[9])
-                        memory_cost = parse_number(parts[10])
+                # Match PROFILE TAGS COST lines (COST, % COST, CALLS, AVG, MIN, MAX, name):
+                # 28,506,826,487  94.81%          1  28,506,826,487  28,506,826,487  28,506,826,487 stf
+                match = re.match(
+                    r"^([\d,]+)\s+[\d.]+%\s+[\d,]+\s+[\d,]+\s+[\d,]+\s+[\d,]+\s+(\S+)\s*$",
+                    line,
+                )
+                if match:
+                    name = match.group(2).lower()
+                    cost = parse_number(match.group(1))
+                    entry = profile.mark_ids.setdefault(name, {})
+                    entry["total_cost"] = cost
+                i += 1
+            continue
 
-                        profile.mark_ids[name] = {
-                            "total_cost": total_cost,
-                            "main_cost": main_cost,
-                            "opcode_cost": opcode_cost,
-                            "precompile_cost": precompile_cost,
-                            "memory_cost": memory_cost,
-                        }
-                    except (IndexError, ValueError):
-                        pass
+        # Parse PROFILE TAGS STEPS section.
+        if line.startswith("PROFILE TAGS STEPS"):
+            i += 2  # Skip header line
+            while i < len(lines):
+                line = lines[i].strip()
+                if not line:
+                    break
+                # Match PROFILE TAGS STEPS lines (STEPS, % STEPS, CALLS, AVG, MIN, MAX, name):
+                # 225,526,731  95.12%          1     225,526,731     225,526,731     225,526,731 stf
+                match = re.match(
+                    r"^([\d,]+)\s+[\d.]+%\s+[\d,]+\s+[\d,]+\s+[\d,]+\s+[\d,]+\s+(\S+)\s*$",
+                    line,
+                )
+                if match:
+                    name = match.group(2).lower()
+                    steps = parse_number(match.group(1))
+                    entry = profile.mark_ids.setdefault(name, {})
+                    entry["steps"] = steps
                 i += 1
             continue
 
@@ -258,7 +276,7 @@ def aggregate_profiles(profiles: List[ProfileData]) -> Dict:
         stats["avg_count"] = statistics.mean(counts) if counts else 0
         result["opcodes"][opcode] = stats
 
-    # Aggregate MARK_IDs
+    # Aggregate PROFILE TAGS
     all_mark_ids = set()
     for p in profiles:
         all_mark_ids.update(p.mark_ids.keys())
@@ -267,15 +285,14 @@ def aggregate_profiles(profiles: List[ProfileData]) -> Dict:
         total_costs = [
             p.mark_ids.get(mark_id, {}).get("total_cost", 0) for p in profiles
         ]
-        main_costs = [p.mark_ids.get(mark_id, {}).get("main_cost", 0) for p in profiles]
-        opcode_costs = [
-            p.mark_ids.get(mark_id, {}).get("opcode_cost", 0) for p in profiles
-        ]
-        precompile_costs = [
-            p.mark_ids.get(mark_id, {}).get("precompile_cost", 0) for p in profiles
-        ]
-        memory_costs = [
-            p.mark_ids.get(mark_id, {}).get("memory_cost", 0) for p in profiles
+        steps = [p.mark_ids.get(mark_id, {}).get("steps", 0) for p in profiles]
+        # MAIN cost per scope is derived from steps. Rest is whatever the
+        # scope's total cost has on top of MAIN, i.e. the OPCODES +
+        # PRECOMPILES + MEMORY.
+        main_costs = [s * MAIN_COST_PER_STEP for s in steps]
+        rest_costs = [
+            max(total_cost - main_cost, 0)
+            for total_cost, main_cost in zip(total_costs, main_costs)
         ]
         percentages = [
             (p.mark_ids.get(mark_id, {}).get("total_cost", 0) / p.total_cost * 100)
@@ -286,10 +303,9 @@ def aggregate_profiles(profiles: List[ProfileData]) -> Dict:
 
         result["mark_ids"][mark_id] = {
             "total_cost": compute_statistics(total_costs),
+            "steps": compute_statistics(steps),
             "main_cost": compute_statistics(main_costs),
-            "opcode_cost": compute_statistics(opcode_costs),
-            "precompile_cost": compute_statistics(precompile_costs),
-            "memory_cost": compute_statistics(memory_costs),
+            "rest_cost": compute_statistics(rest_costs),
             "avg_pct": statistics.mean(percentages) if percentages else 0,
         }
 
@@ -319,8 +335,8 @@ def generate_markdown_report(
     lines.append(f"- **Std dev:** {format_number(total_cost_stats['std_dev'])}")
     lines.append("")
 
-    # MARK_ID Summary (primary focus)
-    lines.append("## Custom Scopes (MARK_ID)\n")
+    # PROFILE TAGS Summary (primary focus)
+    lines.append("## Custom Scopes (PROFILE TAGS)\n")
     lines.append(
         "| Scope | Avg Cost | Avg % | Median | Min | Max | Std Dev |"
     )
@@ -348,38 +364,25 @@ def generate_markdown_report(
 
     lines.append("")
 
-    # MARK_ID Cost Breakdown
-    lines.append("### Cost Breakdown by Scope\n")
-    lines.append("| Scope | Main | Opcodes | Precompiles | Memory |")
-    lines.append("|-------|------|---------|-------------|--------|")
+    # Cost Breakdown by Scope.
+    # MAIN per scope is derived from steps (steps * MAIN_COST_PER_STEP).
+    # Rest is the OPCODES + PRECOMPILES + MEMORY portion.
+    if any(data["steps"]["mean"] > 0 for _, data in sorted_mark_ids):
+        lines.append("### Cost Breakdown by Scope\n")
+        lines.append("| Scope | Main | Rest (Opcodes + Precompiles + Memory) |")
+        lines.append("|-------|------|---------------------------------------|")
 
-    for name, data in sorted_mark_ids:
-        main_pct = (
-            data["main_cost"]["mean"] / data["total_cost"]["mean"] * 100
-            if data["total_cost"]["mean"] > 0
-            else 0
-        )
-        opcode_pct = (
-            data["opcode_cost"]["mean"] / data["total_cost"]["mean"] * 100
-            if data["total_cost"]["mean"] > 0
-            else 0
-        )
-        precompile_pct = (
-            data["precompile_cost"]["mean"] / data["total_cost"]["mean"] * 100
-            if data["total_cost"]["mean"] > 0
-            else 0
-        )
-        memory_pct = (
-            data["memory_cost"]["mean"] / data["total_cost"]["mean"] * 100
-            if data["total_cost"]["mean"] > 0
-            else 0
-        )
-        lines.append(
-            f"| {name} | {format_percent(main_pct)} | {format_percent(opcode_pct)} | "
-            f"{format_percent(precompile_pct)} | {format_percent(memory_pct)} |"
-        )
+        for name, data in sorted_mark_ids:
+            total_mean = data["total_cost"]["mean"]
+            main_mean = data["main_cost"]["mean"]
+            rest_mean = data["rest_cost"]["mean"]
+            main_pct = main_mean / total_mean * 100 if total_mean > 0 else 0
+            rest_pct = rest_mean / total_mean * 100 if total_mean > 0 else 0
+            lines.append(
+                f"| {name} | {format_percent(main_pct)} | {format_percent(rest_pct)} |"
+            )
 
-    lines.append("")
+        lines.append("")
 
     # Cost Distribution Summary
     lines.append("## Cost Distribution\n")
@@ -447,7 +450,7 @@ def generate_scope_plot(
             k: v for k, v in mark_ids.items() if k.lower() not in ignore_zones
         }
     if not mark_ids:
-        print("Warning: No MARK_ID data to plot.", file=sys.stderr)
+        print("Warning: No PROFILE TAGS data to plot.", file=sys.stderr)
         return
 
     # Sort by mean total_cost descending


### PR DESCRIPTION
- ZisK gets updated to v0.18.0, and the profiling output of `ziskemu` change a bit, an sample `.prof` file can be found [here](https://gist.github.com/han0110/9b718ef5a44485a8d6ae725e836b4097#file-zisk_profile_rpc_block_24950000-prof), and a sample report generated can be found [here](https://gist.github.com/han0110/9b718ef5a44485a8d6ae725e836b4097#file-report-md). Note that the `Cost Breakdown by Scope` section now doesn't show `Opcodes | Precompiles | Memory` columns because `ziskemu` drop the support of that of profile tags (user defined cycle scope)
- `Platform` API is updated to be compatible with `zkvm-standard` so no longer need to do `with_prefixed_stdin`.