### PR TITLE
feat: add support for EEST blockchain test fixtures

### DIFF
--- a/crates/benchmark-runner/src/stateless_validator.rs
+++ b/crates/benchmark-runner/src/stateless_validator.rs
@@ -1,25 +1,16 @@
 //! Stateless validator guest program.
 
-use crate::guest_programs::{GenericGuestFixture, GuestFixture};
-use anyhow::{bail, Context, Result};
-use ere_guests_guest::Guest;
-use ere_guests_integration_tests::NoopPlatform;
-use ere_guests_stateless_validator_ethrex::{
-    guest::StatelessValidatorEthrexGuest,
-    host::{build_eip8025_input, Eip8025InputSource},
-};
-use ere_guests_stateless_validator_reth::guest::{
-    StatelessValidatorRethGuest, StatelessValidatorRethInput,
-};
+mod eest;
+mod fixtures;
+mod inputs;
+
+use crate::guest_programs::GuestFixture;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashSet,
-    path::{Path, PathBuf},
-};
+use std::path::Path;
 use strum::{AsRefStr, EnumString};
-use tracing::info;
-use walkdir::WalkDir;
-use witness_generator::StatelessValidationFixture;
+
+pub use fixtures::{benchmark_fixture_paths, iter_benchmark_fixture_paths, load_benchmark_fixture};
 
 /// Execution client variants.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, AsRefStr)]
@@ -49,48 +40,6 @@ impl ExecutionClient {
     }
 }
 
-/// Lazily walks a fixture folder and yields each fixture file path.
-pub fn iter_benchmark_fixture_paths(path: &Path) -> impl Iterator<Item = PathBuf> {
-    WalkDir::new(path)
-        .min_depth(1)
-        .into_iter()
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.file_type().is_file())
-        .map(walkdir::DirEntry::into_path)
-}
-
-/// Resolves benchmark fixture file paths, optionally filtering by fixture name prefix.
-pub fn benchmark_fixture_paths(
-    input_folder: &Path,
-    selected_fixtures: Option<&[String]>,
-) -> Result<Vec<PathBuf>> {
-    let available_paths: Vec<_> = iter_benchmark_fixture_paths(input_folder).collect();
-    let Some(selected_fixtures) = selected_fixtures.filter(|fixtures| !fixtures.is_empty()) else {
-        return Ok(available_paths);
-    };
-
-    let fixture_prefixes = normalize_fixture_prefixes(selected_fixtures)?;
-    let mut resolved_paths = Vec::new();
-
-    for path in available_paths {
-        let fixture_name = fixture_name_from_path(&path)?;
-        if fixture_prefixes
-            .iter()
-            .any(|prefix| fixture_name.starts_with(prefix))
-        {
-            resolved_paths.push(path);
-        }
-    }
-
-    Ok(resolved_paths)
-}
-
-/// Reads and deserializes a single benchmark fixture file.
-pub fn load_benchmark_fixture(path: &Path) -> Result<StatelessValidationFixture> {
-    let content = std::fs::read(path)?;
-    serde_json::from_slice(&content).with_context(|| format!("Failed to parse {}", path.display()))
-}
-
 /// Lazily prepares stateless validator inputs from a fixture folder.
 pub fn stateless_validator_input_iter(
     input_folder: &Path,
@@ -98,139 +47,10 @@ pub fn stateless_validator_input_iter(
     el: ExecutionClient,
     existing_output_dir: Option<&Path>,
 ) -> Result<impl Iterator<Item = Result<Box<dyn GuestFixture>>>> {
-    Ok(stateless_validator_input_iter_from_paths(
-        benchmark_fixture_paths(input_folder, selected_fixtures)?.into_iter(),
+    fixtures::stateless_validator_input_iter(
+        input_folder,
+        selected_fixtures,
         el,
-        existing_output_dir.map(Path::to_path_buf),
-    ))
-}
-
-fn stateless_validator_input_iter_from_paths<I>(
-    paths: I,
-    el: ExecutionClient,
-    existing_output_dir: Option<PathBuf>,
-) -> impl Iterator<Item = Result<Box<dyn GuestFixture>>>
-where
-    I: Iterator<Item = PathBuf>,
-{
-    paths.filter_map(move |path| {
-        match skip_existing_fixture_output(&path, existing_output_dir.as_deref()) {
-            Ok(true) => None,
-            Ok(false) => Some(
-                load_benchmark_fixture(&path)
-                    .and_then(|fixture| stateless_validator_input_from_fixture(fixture, el)),
-            ),
-            Err(err) => Some(Err(err)),
-        }
-    })
-}
-
-fn skip_existing_fixture_output(path: &Path, existing_output_dir: Option<&Path>) -> Result<bool> {
-    let Some(existing_output_dir) = existing_output_dir else {
-        return Ok(false);
-    };
-
-    let fixture_name = fixture_name_from_path(path)?;
-    let output_path = existing_output_dir.join(format!("{fixture_name}.json"));
-    if output_path.exists() {
-        info!("Skipping {fixture_name} (already exists)");
-        return Ok(true);
-    }
-
-    Ok(false)
-}
-
-fn fixture_name_from_path(path: &Path) -> Result<String> {
-    path.file_stem()
-        .and_then(|stem| stem.to_str())
-        .map(ToOwned::to_owned)
-        .with_context(|| format!("Failed to derive fixture name from {}", path.display()))
-}
-
-fn normalize_fixture_prefixes(prefixes: &[String]) -> Result<Vec<String>> {
-    let mut normalized_prefixes = Vec::with_capacity(prefixes.len());
-    let mut seen_prefixes = HashSet::new();
-
-    for prefix in prefixes {
-        let normalized_prefix = normalize_fixture_prefix(prefix)?;
-        if seen_prefixes.insert(normalized_prefix.clone()) {
-            normalized_prefixes.push(normalized_prefix);
-        }
-    }
-
-    Ok(normalized_prefixes)
-}
-
-fn normalize_fixture_prefix(prefix: &str) -> Result<String> {
-    let normalized = prefix.trim();
-    if normalized.is_empty() {
-        bail!("Fixture prefix cannot be empty");
-    }
-
-    Ok(normalized
-        .strip_suffix(".json")
-        .unwrap_or(normalized)
-        .to_owned())
-}
-
-fn stateless_validator_input_from_fixture(
-    fixture: StatelessValidationFixture,
-    el: ExecutionClient,
-) -> Result<Box<dyn GuestFixture>> {
-    match el {
-        ExecutionClient::Reth => reth_input_from_fixture(fixture),
-        ExecutionClient::Ethrex => ethrex_input_from_fixture(fixture),
-    }
-}
-
-fn ethrex_input_from_fixture(fixture: StatelessValidationFixture) -> Result<Box<dyn GuestFixture>> {
-    let StatelessValidationFixture {
-        name,
-        stateless_input,
-        success,
-    } = fixture;
-    let input = build_eip8025_input(Eip8025InputSource::Legacy {
-        stateless_input: &stateless_input,
-        valid_block: success,
-    })
-    .context("Failed to create Ethrex stateless validator input")?;
-    let output = StatelessValidatorEthrexGuest::compute::<NoopPlatform>(input.clone());
-    let metadata = BlockMetadata {
-        block_used_gas: stateless_input.block.gas_used,
-    };
-
-    Ok(
-        GenericGuestFixture::<BlockMetadata>::new::<StatelessValidatorEthrexGuest>(
-            name, input, output, metadata,
-        )?
-        .output_sha256()
-        .into_boxed(),
-    )
-}
-
-fn reth_input_from_fixture(fixture: StatelessValidationFixture) -> Result<Box<dyn GuestFixture>> {
-    let StatelessValidationFixture {
-        name,
-        stateless_input,
-        success,
-    } = fixture;
-    info!(
-        "Preparing Reth stateless validator input for fixture {}",
-        name
-    );
-    let input = StatelessValidatorRethInput::new(&stateless_input, success)
-        .context("Failed to create Reth stateless validator input")?;
-
-    let output = StatelessValidatorRethGuest::compute::<NoopPlatform>(input.clone());
-    let metadata = BlockMetadata {
-        block_used_gas: stateless_input.block.gas_used,
-    };
-
-    Ok(
-        GenericGuestFixture::<BlockMetadata>::new::<StatelessValidatorRethGuest>(
-            name, input, output, metadata,
-        )?
-        .output_sha256()
-        .into_boxed(),
+        existing_output_dir,
     )
 }

--- a/crates/benchmark-runner/src/stateless_validator/eest.rs
+++ b/crates/benchmark-runner/src/stateless_validator/eest.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::{collections::BTreeMap, path::Path};
+use tracing::info;
 
 const EEST_SAFE_NAME_MAX_LEN: usize = 80;
 
@@ -62,7 +63,7 @@ pub(crate) fn load_eest_benchmark_fixtures(
     let cases: BTreeMap<String, EestBlockchainTest> =
         serde_json::from_value(value).with_context(|| {
             format!(
-                "Fixture {} is neither a legacy benchmark fixture nor an EEST blockchain test",
+                "Failed to parse fixture {} as an EEST blockchain test",
                 path.display()
             )
         })?;
@@ -76,6 +77,9 @@ pub(crate) fn load_eest_benchmark_fixtures(
 
         for (block_index, block) in case.blocks.into_iter().enumerate() {
             let Some(input_hex) = block.stateless_input_bytes else {
+                info!(
+                    "Skipping EEST test {test_name} block {block_index} from {source_path}: missing statelessInputBytes"
+                );
                 continue;
             };
             let stateless_input_bytes = decode_hex_bytes("statelessInputBytes", &input_hex)
@@ -85,6 +89,9 @@ pub(crate) fn load_eest_benchmark_fixtures(
                     )
                 })?;
             if stateless_input_bytes.is_empty() {
+                info!(
+                    "Skipping EEST test {test_name} block {block_index} from {source_path}: empty statelessInputBytes"
+                );
                 continue;
             }
 

--- a/crates/benchmark-runner/src/stateless_validator/eest.rs
+++ b/crates/benchmark-runner/src/stateless_validator/eest.rs
@@ -1,10 +1,12 @@
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
-use std::{collections::BTreeMap, path::Path};
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::Path,
+};
 use tracing::info;
 
-const EEST_SAFE_NAME_MAX_LEN: usize = 80;
+const EEST_SAFE_FILE_STEM_MAX_LEN: usize = 220;
 
 #[derive(Debug, Clone)]
 pub(crate) struct EestStatelessFixture {
@@ -70,6 +72,7 @@ pub(crate) fn load_eest_benchmark_fixtures(
 
     let source_path = relative_source_path(path, input_root);
     let mut fixtures = Vec::new();
+    let mut fixture_names = HashSet::new();
 
     for (test_name, case) in cases {
         let chain_id = parse_json_u64(&case.config.chainid)
@@ -129,7 +132,7 @@ pub(crate) fn load_eest_benchmark_fixtures(
             })?;
 
             fixtures.push(EestStatelessFixture {
-                name: eest_fixture_name(&source_path, &test_name, block_index),
+                name: unique_eest_fixture_name(&test_name, block_index, &mut fixture_names),
                 original_test_name: test_name.clone(),
                 source_path: source_path.clone(),
                 block_index,
@@ -198,13 +201,34 @@ fn normalize_path_string(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
-fn eest_fixture_name(source_path: &str, test_name: &str, block_index: usize) -> String {
-    let sanitized = sanitize_fixture_name(test_name);
-    let hash_input = format!("{source_path}\0{test_name}\0{block_index}");
-    let digest = Sha256::digest(hash_input.as_bytes());
-    let hash = hex_lower(&digest[..6]);
+fn unique_eest_fixture_name(
+    test_name: &str,
+    block_index: usize,
+    fixture_names: &mut HashSet<String>,
+) -> String {
+    let base = eest_fixture_name(test_name, block_index);
+    let mut index = 1;
 
-    format!("eest__{sanitized}__block{block_index}__{hash}")
+    loop {
+        let suffix = if index == 1 {
+            String::new()
+        } else {
+            format!("__{index}")
+        };
+        let candidate = truncate_fixture_name(&base, &suffix);
+
+        if fixture_names.insert(candidate.clone()) {
+            return candidate;
+        }
+
+        index += 1;
+    }
+}
+
+fn eest_fixture_name(test_name: &str, block_index: usize) -> String {
+    let sanitized = sanitize_fixture_name(test_name);
+
+    format!("eest__{sanitized}__block{block_index}")
 }
 
 fn sanitize_fixture_name(value: &str) -> String {
@@ -222,9 +246,7 @@ fn sanitize_fixture_name(value: &str) -> String {
             '_'
         };
 
-        if sanitized.len() < EEST_SAFE_NAME_MAX_LEN {
-            sanitized.push(next);
-        }
+        sanitized.push(next);
     }
 
     let sanitized = sanitized.trim_matches('_');
@@ -235,14 +257,14 @@ fn sanitize_fixture_name(value: &str) -> String {
     sanitized.to_string()
 }
 
-fn hex_lower(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push(HEX[(byte >> 4) as usize] as char);
-        out.push(HEX[(byte & 0x0f) as usize] as char);
+fn truncate_fixture_name(base: &str, suffix: &str) -> String {
+    let base_max_len = EEST_SAFE_FILE_STEM_MAX_LEN.saturating_sub(suffix.len());
+    if base.len() <= base_max_len {
+        return format!("{base}{suffix}");
     }
-    out
+
+    let truncated = base[..base_max_len].trim_end_matches('_');
+    format!("{truncated}{suffix}")
 }
 
 #[cfg(test)]
@@ -270,7 +292,13 @@ mod tests {
             .iter()
             .map(|fixture| fixture.name.clone())
             .collect();
-        assert_ne!(names[0], names[1]);
+        assert_eq!(
+            names,
+            vec![
+                "eest__tests_foo_py_test_same_name_a__block0".to_string(),
+                "eest__tests_foo_py_test_same_name_a__block0__2".to_string(),
+            ]
+        );
         assert!(names.iter().all(|name| name.starts_with("eest__")));
         assert!(names.iter().all(|name| !name.contains('/')));
         assert!(names.iter().all(|name| !name.contains(':')));
@@ -292,6 +320,31 @@ mod tests {
         assert_eq!(fixture.block_used_gas, Some(16));
 
         Ok(())
+    }
+
+    #[test]
+    fn eest_fixture_name_preserves_full_sanitized_name_when_it_fits() {
+        let name = eest_fixture_name(
+            "tests/amsterdam/eip8025_optional_proofs/test_witness_state_writes.py::test_witness_state_sstore_into_empty_storage_omits_post_state_nodes[fork_Amsterdam-blockchain_test]",
+            0,
+        );
+
+        assert_eq!(
+            name,
+            "eest__tests_amsterdam_eip8025_optional_proofs_test_witness_state_writes_py_test_witness_state_sstore_into_empty_storage_omits_post_state_nodes_fork_Amsterdam-blockchain_test__block0"
+        );
+    }
+
+    #[test]
+    fn eest_fixture_name_truncates_only_when_it_exceeds_safe_file_stem_limit() {
+        let test_name = format!("tests/foo.py::test_{}", "a".repeat(300));
+        let name = eest_fixture_name(&test_name, 0);
+        let truncated = truncate_fixture_name(&name, "");
+
+        assert!(name.len() > EEST_SAFE_FILE_STEM_MAX_LEN);
+        assert_eq!(truncated.len(), EEST_SAFE_FILE_STEM_MAX_LEN);
+        assert!(truncated.starts_with("eest__tests_foo_py_test_"));
+        assert!(!truncated.ends_with('_'));
     }
 
     #[test]

--- a/crates/benchmark-runner/src/stateless_validator/eest.rs
+++ b/crates/benchmark-runner/src/stateless_validator/eest.rs
@@ -145,7 +145,7 @@ fn decode_hex_bytes(field_name: &str, value: &str) -> Result<Vec<u8>> {
         .or_else(|| value.strip_prefix("0X"))
         .unwrap_or(value);
 
-    if hex.len() % 2 != 0 {
+    if !hex.len().is_multiple_of(2) {
         bail!("{field_name} must contain an even number of hex digits");
     }
 

--- a/crates/benchmark-runner/src/stateless_validator/eest.rs
+++ b/crates/benchmark-runner/src/stateless_validator/eest.rs
@@ -1,0 +1,352 @@
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::{collections::BTreeMap, path::Path};
+
+const EEST_SAFE_NAME_MAX_LEN: usize = 80;
+
+#[derive(Debug, Clone)]
+pub(crate) struct EestStatelessFixture {
+    pub(crate) name: String,
+    pub(crate) original_test_name: String,
+    pub(crate) source_path: String,
+    pub(crate) block_index: usize,
+    pub(crate) network: String,
+    pub(crate) chain_id: u64,
+    pub(crate) block_number: Option<u64>,
+    pub(crate) block_used_gas: Option<u64>,
+    pub(crate) stateless_input_bytes: Vec<u8>,
+    pub(crate) stateless_output_bytes: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EestBlockchainTest {
+    network: String,
+    config: EestConfig,
+    blocks: Vec<EestBlock>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EestConfig {
+    chainid: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EestBlock {
+    #[serde(default)]
+    stateless_input_bytes: Option<String>,
+    #[serde(default)]
+    stateless_output_bytes: Option<String>,
+    #[serde(default)]
+    block_header: Option<EestBlockHeader>,
+    #[serde(default, rename = "blocknumber")]
+    block_number: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EestBlockHeader {
+    #[serde(default)]
+    number: Option<String>,
+    #[serde(default)]
+    gas_used: Option<String>,
+}
+
+pub(crate) fn load_eest_benchmark_fixtures(
+    value: serde_json::Value,
+    path: &Path,
+    input_root: &Path,
+) -> Result<Vec<EestStatelessFixture>> {
+    let cases: BTreeMap<String, EestBlockchainTest> =
+        serde_json::from_value(value).with_context(|| {
+            format!(
+                "Fixture {} is neither a legacy benchmark fixture nor an EEST blockchain test",
+                path.display()
+            )
+        })?;
+
+    let source_path = relative_source_path(path, input_root);
+    let mut fixtures = Vec::new();
+
+    for (test_name, case) in cases {
+        let chain_id = parse_json_u64(&case.config.chainid)
+            .with_context(|| format!("Failed to parse chainid for EEST test {test_name}"))?;
+
+        for (block_index, block) in case.blocks.into_iter().enumerate() {
+            let Some(input_hex) = block.stateless_input_bytes else {
+                continue;
+            };
+            let stateless_input_bytes = decode_hex_bytes("statelessInputBytes", &input_hex)
+                .with_context(|| {
+                    format!(
+                        "Failed to decode statelessInputBytes for EEST test {test_name} block {block_index}"
+                    )
+                })?;
+            if stateless_input_bytes.is_empty() {
+                continue;
+            }
+
+            let output_hex = block.stateless_output_bytes.with_context(|| {
+                format!(
+                    "EEST test {test_name} block {block_index} has statelessInputBytes but no statelessOutputBytes"
+                )
+            })?;
+            let stateless_output_bytes = decode_hex_bytes("statelessOutputBytes", &output_hex)
+                .with_context(|| {
+                    format!(
+                        "Failed to decode statelessOutputBytes for EEST test {test_name} block {block_index}"
+                    )
+                })?;
+            let block_number = parse_optional_json_u64(
+                block
+                    .block_header
+                    .as_ref()
+                    .and_then(|header| header.number.as_deref())
+                    .or(block.block_number.as_deref()),
+            )
+            .with_context(|| {
+                format!(
+                    "Failed to parse block number for EEST test {test_name} block {block_index}"
+                )
+            })?;
+            let block_used_gas = parse_optional_json_u64(
+                block
+                    .block_header
+                    .as_ref()
+                    .and_then(|header| header.gas_used.as_deref()),
+            )
+            .with_context(|| {
+                format!("Failed to parse gas used for EEST test {test_name} block {block_index}")
+            })?;
+
+            fixtures.push(EestStatelessFixture {
+                name: eest_fixture_name(&source_path, &test_name, block_index),
+                original_test_name: test_name.clone(),
+                source_path: source_path.clone(),
+                block_index,
+                network: case.network.clone(),
+                chain_id,
+                block_number,
+                block_used_gas,
+                stateless_input_bytes,
+                stateless_output_bytes,
+            });
+        }
+    }
+
+    Ok(fixtures)
+}
+
+fn decode_hex_bytes(field_name: &str, value: &str) -> Result<Vec<u8>> {
+    let hex = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .unwrap_or(value);
+
+    if hex.len() % 2 != 0 {
+        bail!("{field_name} must contain an even number of hex digits");
+    }
+
+    (0..hex.len())
+        .step_by(2)
+        .map(|index| {
+            u8::from_str_radix(&hex[index..index + 2], 16)
+                .with_context(|| format!("{field_name} contains invalid hex at byte {index}"))
+        })
+        .collect()
+}
+
+fn parse_optional_json_u64(value: Option<&str>) -> Result<Option<u64>> {
+    value.map(parse_json_u64).transpose()
+}
+
+fn parse_json_u64(value: &str) -> Result<u64> {
+    let value = value.trim();
+    if let Some(hex) = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+    {
+        return u64::from_str_radix(hex, 16)
+            .with_context(|| format!("failed to parse hex u64 value {value}"));
+    }
+
+    value
+        .parse()
+        .with_context(|| format!("failed to parse decimal u64 value {value}"))
+}
+
+fn relative_source_path(path: &Path, input_root: &Path) -> String {
+    let relative = path
+        .strip_prefix(input_root)
+        .ok()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or(path);
+
+    normalize_path_string(relative)
+}
+
+fn normalize_path_string(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn eest_fixture_name(source_path: &str, test_name: &str, block_index: usize) -> String {
+    let sanitized = sanitize_fixture_name(test_name);
+    let hash_input = format!("{source_path}\0{test_name}\0{block_index}");
+    let digest = Sha256::digest(hash_input.as_bytes());
+    let hash = hex_lower(&digest[..6]);
+
+    format!("eest__{sanitized}__block{block_index}__{hash}")
+}
+
+fn sanitize_fixture_name(value: &str) -> String {
+    let mut sanitized = String::new();
+    let mut last_was_separator = false;
+
+    for ch in value.chars() {
+        let next = if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+            last_was_separator = false;
+            ch
+        } else if last_was_separator {
+            continue;
+        } else {
+            last_was_separator = true;
+            '_'
+        };
+
+        if sanitized.len() < EEST_SAFE_NAME_MAX_LEN {
+            sanitized.push(next);
+        }
+    }
+
+    let sanitized = sanitized.trim_matches('_');
+    if sanitized.is_empty() {
+        return "fixture".to_string();
+    }
+
+    sanitized.to_string()
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn load_eest_fixture_flattens_blocks_and_preserves_raw_guest_io() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let fixture_path = dir
+            .path()
+            .join("blockchain_tests/for_amsterdam/compute/mcopy.json");
+        fs::create_dir_all(fixture_path.parent().unwrap())?;
+        fs::write(&fixture_path, sample_eest_fixture())?;
+
+        let fixtures = load_eest_benchmark_fixtures(
+            serde_json::from_str(sample_eest_fixture())?,
+            &fixture_path,
+            dir.path(),
+        )?;
+        assert_eq!(fixtures.len(), 2);
+
+        let names: Vec<_> = fixtures
+            .iter()
+            .map(|fixture| fixture.name.clone())
+            .collect();
+        assert_ne!(names[0], names[1]);
+        assert!(names.iter().all(|name| name.starts_with("eest__")));
+        assert!(names.iter().all(|name| !name.contains('/')));
+        assert!(names.iter().all(|name| !name.contains(':')));
+        assert!(names.iter().all(|name| !name.contains('[')));
+
+        let fixture = fixtures
+            .iter()
+            .find(|fixture| fixture.original_test_name == "tests/foo.py::test_same[name/a]")
+            .unwrap();
+        assert_eq!(fixture.stateless_input_bytes, [0x00, 0x01, 0x02]);
+        assert_eq!(fixture.stateless_output_bytes, [0xaa, 0xbb]);
+        assert_eq!(
+            fixture.source_path,
+            "blockchain_tests/for_amsterdam/compute/mcopy.json"
+        );
+        assert_eq!(fixture.block_index, 0);
+        assert_eq!(fixture.chain_id, 1);
+        assert_eq!(fixture.block_number, Some(1));
+        assert_eq!(fixture.block_used_gas, Some(16));
+
+        Ok(())
+    }
+
+    #[test]
+    fn eest_block_with_input_requires_output() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let fixture_path = dir.path().join("missing-output.json");
+        fs::write(
+            &fixture_path,
+            r#"{
+                "tests/foo.py::test_missing_output": {
+                    "network": "Amsterdam",
+                    "config": {"chainid": "0x01"},
+                    "blocks": [{"statelessInputBytes": "0x0102"}]
+                }
+            }"#,
+        )?;
+
+        let err = load_eest_benchmark_fixtures(
+            serde_json::from_str(&fs::read_to_string(&fixture_path)?)?,
+            &fixture_path,
+            dir.path(),
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("has statelessInputBytes but no statelessOutputBytes"));
+
+        Ok(())
+    }
+
+    pub(crate) fn sample_eest_fixture() -> &'static str {
+        r#"{
+            "tests/foo.py::test_same[name/a]": {
+                "network": "Amsterdam",
+                "config": {"chainid": "0x01"},
+                "blocks": [
+                    {
+                        "statelessInputBytes": "0x000102",
+                        "statelessOutputBytes": "0xaabb",
+                        "blockHeader": {"number": "0x01", "gasUsed": "0x10"}
+                    },
+                    {
+                        "blockHeader": {"number": "0x02", "gasUsed": "0x20"}
+                    },
+                    {
+                        "statelessInputBytes": "0x",
+                        "statelessOutputBytes": "0xcc"
+                    }
+                ]
+            },
+            "tests/foo.py::test_same[name?a]": {
+                "network": "Amsterdam",
+                "config": {"chainid": "0x01"},
+                "blocks": [
+                    {
+                        "statelessInputBytes": "0x0f",
+                        "statelessOutputBytes": "0xdead",
+                        "blocknumber": "0x03",
+                        "blockHeader": {"gasUsed": "0x30"}
+                    }
+                ]
+            }
+        }"#
+    }
+}

--- a/crates/benchmark-runner/src/stateless_validator/fixtures.rs
+++ b/crates/benchmark-runner/src/stateless_validator/fixtures.rs
@@ -15,6 +15,8 @@ use tracing::info;
 use walkdir::WalkDir;
 use witness_generator::StatelessValidationFixture;
 
+const EEST_BLOCKCHAIN_TESTS_DIR: &str = "blockchain_tests";
+
 #[derive(Debug, Clone)]
 pub(crate) enum BenchmarkFixture {
     Legacy(Box<StatelessValidationFixture>),
@@ -61,7 +63,19 @@ pub fn benchmark_fixture_paths(
     input_folder: &Path,
     _selected_fixtures: Option<&[String]>,
 ) -> Result<Vec<PathBuf>> {
-    Ok(iter_benchmark_fixture_paths(input_folder).collect())
+    let fixture_root =
+        eest_blockchain_tests_root(input_folder).unwrap_or_else(|| input_folder.to_path_buf());
+
+    Ok(iter_benchmark_fixture_paths(&fixture_root).collect())
+}
+
+fn eest_blockchain_tests_root(input_folder: &Path) -> Option<PathBuf> {
+    if input_folder.is_file() {
+        return None;
+    }
+
+    let blockchain_tests = input_folder.join(EEST_BLOCKCHAIN_TESTS_DIR);
+    blockchain_tests.is_dir().then_some(blockchain_tests)
 }
 
 /// Reads and deserializes a single legacy benchmark fixture file.
@@ -272,6 +286,26 @@ mod tests {
 
         let paths: Vec<_> = iter_benchmark_fixture_paths(dir.path()).collect();
         assert_eq!(paths, vec![dir.path().join("fixture.json")]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn benchmark_fixture_paths_prefers_eest_blockchain_tests_subdir() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let included_path = dir
+            .path()
+            .join("blockchain_tests/for_amsterdam/included.json");
+        let engine_path = dir
+            .path()
+            .join("blockchain_tests_engine/for_amsterdam/ignored.json");
+        fs::create_dir_all(included_path.parent().unwrap())?;
+        fs::create_dir_all(engine_path.parent().unwrap())?;
+        fs::write(&included_path, "{}")?;
+        fs::write(&engine_path, "{}")?;
+
+        let paths = benchmark_fixture_paths(dir.path(), None)?;
+        assert_eq!(paths, vec![included_path]);
 
         Ok(())
     }

--- a/crates/benchmark-runner/src/stateless_validator/fixtures.rs
+++ b/crates/benchmark-runner/src/stateless_validator/fixtures.rs
@@ -17,7 +17,7 @@ use witness_generator::StatelessValidationFixture;
 
 #[derive(Debug, Clone)]
 pub(crate) enum BenchmarkFixture {
-    Legacy(StatelessValidationFixture),
+    Legacy(Box<StatelessValidationFixture>),
     Eest(EestStatelessFixture),
 }
 
@@ -143,7 +143,7 @@ fn load_benchmark_fixtures(path: &Path, input_root: &Path) -> Result<Vec<Benchma
     if value.get("stateless_input").is_some() {
         let fixture = serde_json::from_value(value)
             .with_context(|| format!("Failed to parse legacy fixture {}", path.display()))?;
-        return Ok(vec![BenchmarkFixture::Legacy(fixture)]);
+        return Ok(vec![BenchmarkFixture::Legacy(Box::new(fixture))]);
     }
 
     load_eest_benchmark_fixtures(value, path, input_root)

--- a/crates/benchmark-runner/src/stateless_validator/fixtures.rs
+++ b/crates/benchmark-runner/src/stateless_validator/fixtures.rs
@@ -61,11 +61,8 @@ pub fn iter_benchmark_fixture_paths(path: &Path) -> impl Iterator<Item = PathBuf
         .map(walkdir::DirEntry::into_path)
 }
 
-/// Resolves benchmark fixture file paths.
-pub fn benchmark_fixture_paths(
-    input_folder: &Path,
-    _selected_fixtures: Option<&[String]>,
-) -> Result<Vec<PathBuf>> {
+/// Resolves benchmark fixture JSON paths.
+pub fn benchmark_fixture_paths(input_folder: &Path) -> Result<Vec<PathBuf>> {
     let fixture_root = benchmark_fixture_root(input_folder)?;
     Ok(iter_benchmark_fixture_paths(&fixture_root).collect())
 }
@@ -83,7 +80,8 @@ fn benchmark_fixture_root(input_folder: &Path) -> Result<PathBuf> {
     if looks_like_eest_fixture_bundle(input_folder) {
         bail!(
             "EEST fixture bundle {} does not contain required {}/ directory; \
-             stateless-validator supports EEST blockchain_test fixtures",
+             stateless-validator supports EEST blockchain_test fixtures, \
+             not blockchain_test_engine-only fixtures",
             input_folder.display(),
             EEST_BLOCKCHAIN_TESTS_DIR
         );
@@ -131,7 +129,7 @@ pub(super) fn stateless_validator_input_iter(
         .transpose()?;
 
     Ok(stateless_validator_input_iter_from_paths(
-        benchmark_fixture_paths(input_folder, None)?.into_iter(),
+        benchmark_fixture_paths(input_folder)?.into_iter(),
         input_folder.to_path_buf(),
         fixture_prefixes,
         el,
@@ -339,7 +337,7 @@ mod tests {
         fs::write(&included_path, "{}")?;
         fs::write(&engine_path, "{}")?;
 
-        let paths = benchmark_fixture_paths(dir.path(), None)?;
+        let paths = benchmark_fixture_paths(dir.path())?;
         assert_eq!(paths, vec![included_path]);
 
         Ok(())
@@ -354,7 +352,7 @@ mod tests {
         fs::create_dir_all(engine_path.parent().unwrap())?;
         fs::write(&engine_path, "{}")?;
 
-        let err = benchmark_fixture_paths(dir.path(), None).unwrap_err();
+        let err = benchmark_fixture_paths(dir.path()).unwrap_err();
         let message = err.to_string();
         assert!(message.contains("blockchain_tests"));
         assert!(message.contains("blockchain_test_engine-only"));

--- a/crates/benchmark-runner/src/stateless_validator/fixtures.rs
+++ b/crates/benchmark-runner/src/stateless_validator/fixtures.rs
@@ -1,0 +1,306 @@
+use crate::{
+    guest_programs::GuestFixture,
+    stateless_validator::{
+        eest::{load_eest_benchmark_fixtures, EestStatelessFixture},
+        inputs::stateless_validator_input_from_fixture,
+        ExecutionClient,
+    },
+};
+use anyhow::{bail, Context, Result};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+use tracing::info;
+use walkdir::WalkDir;
+use witness_generator::StatelessValidationFixture;
+
+#[derive(Debug, Clone)]
+pub(crate) enum BenchmarkFixture {
+    Legacy(StatelessValidationFixture),
+    Eest(EestStatelessFixture),
+}
+
+impl BenchmarkFixture {
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            Self::Legacy(fixture) => &fixture.name,
+            Self::Eest(fixture) => &fixture.name,
+        }
+    }
+
+    fn original_eest_test_name(&self) -> Option<&str> {
+        match self {
+            Self::Legacy(_) => None,
+            Self::Eest(fixture) => Some(&fixture.original_test_name),
+        }
+    }
+}
+
+/// Lazily walks a fixture folder and yields each fixture file path.
+pub fn iter_benchmark_fixture_paths(path: &Path) -> impl Iterator<Item = PathBuf> {
+    let min_depth = if path.is_file() { 0 } else { 1 };
+
+    WalkDir::new(path)
+        .min_depth(min_depth)
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_file())
+        .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
+        .filter(|entry| {
+            !entry
+                .path()
+                .components()
+                .any(|component| component.as_os_str() == ".meta")
+        })
+        .map(walkdir::DirEntry::into_path)
+}
+
+/// Resolves benchmark fixture file paths.
+pub fn benchmark_fixture_paths(
+    input_folder: &Path,
+    _selected_fixtures: Option<&[String]>,
+) -> Result<Vec<PathBuf>> {
+    Ok(iter_benchmark_fixture_paths(input_folder).collect())
+}
+
+/// Reads and deserializes a single legacy benchmark fixture file.
+pub fn load_benchmark_fixture(path: &Path) -> Result<StatelessValidationFixture> {
+    let content = std::fs::read(path)?;
+    serde_json::from_slice(&content).with_context(|| format!("Failed to parse {}", path.display()))
+}
+
+pub(super) fn stateless_validator_input_iter(
+    input_folder: &Path,
+    selected_fixtures: Option<&[String]>,
+    el: ExecutionClient,
+    existing_output_dir: Option<&Path>,
+) -> Result<impl Iterator<Item = Result<Box<dyn GuestFixture>>>> {
+    let fixture_prefixes = selected_fixtures
+        .filter(|fixtures| !fixtures.is_empty())
+        .map(normalize_fixture_prefixes)
+        .transpose()?;
+
+    Ok(stateless_validator_input_iter_from_paths(
+        benchmark_fixture_paths(input_folder, None)?.into_iter(),
+        input_folder.to_path_buf(),
+        fixture_prefixes,
+        el,
+        existing_output_dir.map(Path::to_path_buf),
+    ))
+}
+
+fn stateless_validator_input_iter_from_paths<I>(
+    paths: I,
+    input_root: PathBuf,
+    fixture_prefixes: Option<Vec<String>>,
+    el: ExecutionClient,
+    existing_output_dir: Option<PathBuf>,
+) -> impl Iterator<Item = Result<Box<dyn GuestFixture>>>
+where
+    I: Iterator<Item = PathBuf>,
+{
+    paths.flat_map(move |path| {
+        let results: Vec<_> = match load_benchmark_fixtures(&path, &input_root) {
+            Ok(fixtures) => fixtures
+                .into_iter()
+                .filter(|fixture| fixture_matches_prefixes(fixture, fixture_prefixes.as_deref()))
+                .filter_map(|fixture| {
+                    match skip_existing_fixture_output(
+                        fixture.name(),
+                        existing_output_dir.as_deref(),
+                    ) {
+                        Ok(true) => None,
+                        Ok(false) => Some(stateless_validator_input_from_fixture(fixture, el)),
+                        Err(err) => Some(Err(err)),
+                    }
+                })
+                .collect(),
+            Err(err) => vec![Err(err)],
+        };
+        results
+    })
+}
+
+fn fixture_matches_prefixes(fixture: &BenchmarkFixture, prefixes: Option<&[String]>) -> bool {
+    let Some(prefixes) = prefixes else {
+        return true;
+    };
+
+    prefixes.iter().any(|prefix| {
+        fixture.name().starts_with(prefix)
+            || fixture
+                .original_eest_test_name()
+                .is_some_and(|name| name.starts_with(prefix))
+    })
+}
+
+fn load_benchmark_fixtures(path: &Path, input_root: &Path) -> Result<Vec<BenchmarkFixture>> {
+    let content = std::fs::read(path)?;
+    let value: serde_json::Value = serde_json::from_slice(&content)
+        .with_context(|| format!("Failed to parse {}", path.display()))?;
+
+    if value.get("stateless_input").is_some() {
+        let fixture = serde_json::from_value(value)
+            .with_context(|| format!("Failed to parse legacy fixture {}", path.display()))?;
+        return Ok(vec![BenchmarkFixture::Legacy(fixture)]);
+    }
+
+    load_eest_benchmark_fixtures(value, path, input_root)
+        .map(|fixtures| fixtures.into_iter().map(BenchmarkFixture::Eest).collect())
+}
+
+fn skip_existing_fixture_output(
+    fixture_name: &str,
+    existing_output_dir: Option<&Path>,
+) -> Result<bool> {
+    let Some(existing_output_dir) = existing_output_dir else {
+        return Ok(false);
+    };
+
+    let output_path = existing_output_dir.join(format!("{fixture_name}.json"));
+    if output_path.exists() {
+        info!("Skipping {fixture_name} (already exists)");
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+fn normalize_fixture_prefixes(prefixes: &[String]) -> Result<Vec<String>> {
+    let mut normalized_prefixes = Vec::with_capacity(prefixes.len());
+    let mut seen_prefixes = HashSet::new();
+
+    for prefix in prefixes {
+        let normalized_prefix = normalize_fixture_prefix(prefix)?;
+        if seen_prefixes.insert(normalized_prefix.clone()) {
+            normalized_prefixes.push(normalized_prefix);
+        }
+    }
+
+    Ok(normalized_prefixes)
+}
+
+fn normalize_fixture_prefix(prefix: &str) -> Result<String> {
+    let normalized = prefix.trim();
+    if normalized.is_empty() {
+        bail!("Fixture prefix cannot be empty");
+    }
+
+    Ok(normalized
+        .strip_suffix(".json")
+        .unwrap_or(normalized)
+        .to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+    use std::fs;
+
+    #[test]
+    fn fixture_prefix_matching_accepts_safe_and_original_eest_names() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let fixture_path = dir.path().join("mcopy.json");
+        fs::write(&fixture_path, sample_eest_fixture())?;
+        let fixtures = load_benchmark_fixtures(&fixture_path, dir.path())?;
+        let fixture = fixtures
+            .iter()
+            .find(|fixture| {
+                fixture.original_eest_test_name() == Some("tests/foo.py::test_same[name?a]")
+            })
+            .unwrap();
+
+        let safe_prefix = normalize_fixture_prefixes(&[format!("{}.json", fixture.name())])?;
+        assert!(fixture_matches_prefixes(fixture, Some(&safe_prefix)));
+
+        let original_prefix =
+            normalize_fixture_prefixes(&["tests/foo.py::test_same[name?a]".to_string()])?;
+        assert!(fixture_matches_prefixes(fixture, Some(&original_prefix)));
+
+        let non_matching_prefix = normalize_fixture_prefixes(&["other_test".to_string()])?;
+        assert!(!fixture_matches_prefixes(
+            fixture,
+            Some(&non_matching_prefix)
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn eest_fixture_iter_yields_raw_input_and_hashed_output() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let fixture_path = dir.path().join("mcopy.json");
+        fs::write(&fixture_path, sample_eest_fixture())?;
+
+        let selected = vec!["tests/foo.py::test_same[name/a]".to_string()];
+        let mut fixtures = stateless_validator_input_iter(
+            dir.path(),
+            Some(&selected),
+            ExecutionClient::Reth,
+            None,
+        )?;
+        let guest_fixture = fixtures.next().unwrap()?;
+        assert!(fixtures.next().is_none());
+
+        let input = guest_fixture.input()?;
+        assert_eq!(input.stdin(), [0x00, 0x01, 0x02]);
+        assert_eq!(
+            guest_fixture.expected_public_values()?,
+            Sha256::digest([0xaa, 0xbb]).to_vec()
+        );
+
+        let metadata = guest_fixture.metadata();
+        assert_eq!(metadata["fixture_format"], "eest");
+        assert_eq!(
+            metadata["original_test_name"],
+            "tests/foo.py::test_same[name/a]"
+        );
+        assert_eq!(metadata["block_used_gas"].as_u64(), Some(16));
+
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_path_discovery_skips_meta_and_non_json_files() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join(".meta"))?;
+        fs::write(dir.path().join(".meta/index.json"), "{}")?;
+        fs::write(dir.path().join("ignored.txt"), "not json")?;
+        fs::write(dir.path().join("fixture.json"), "{}")?;
+
+        let paths: Vec<_> = iter_benchmark_fixture_paths(dir.path()).collect();
+        assert_eq!(paths, vec![dir.path().join("fixture.json")]);
+
+        Ok(())
+    }
+
+    fn sample_eest_fixture() -> &'static str {
+        r#"{
+            "tests/foo.py::test_same[name/a]": {
+                "network": "Amsterdam",
+                "config": {"chainid": "0x01"},
+                "blocks": [
+                    {
+                        "statelessInputBytes": "0x000102",
+                        "statelessOutputBytes": "0xaabb",
+                        "blockHeader": {"number": "0x01", "gasUsed": "0x10"}
+                    }
+                ]
+            },
+            "tests/foo.py::test_same[name?a]": {
+                "network": "Amsterdam",
+                "config": {"chainid": "0x01"},
+                "blocks": [
+                    {
+                        "statelessInputBytes": "0x0f",
+                        "statelessOutputBytes": "0xdead",
+                        "blocknumber": "0x03",
+                        "blockHeader": {"gasUsed": "0x30"}
+                    }
+                ]
+            }
+        }"#
+    }
+}

--- a/crates/benchmark-runner/src/stateless_validator/fixtures.rs
+++ b/crates/benchmark-runner/src/stateless_validator/fixtures.rs
@@ -16,6 +16,9 @@ use walkdir::WalkDir;
 use witness_generator::StatelessValidationFixture;
 
 const EEST_BLOCKCHAIN_TESTS_DIR: &str = "blockchain_tests";
+const EEST_BLOCKCHAIN_TESTS_ENGINE_DIR: &str = "blockchain_tests_engine";
+const EEST_BLOCKCHAIN_TESTS_ENGINE_X_DIR: &str = "blockchain_tests_engine_x";
+const EEST_BLOCKCHAIN_TESTS_SYNC_DIR: &str = "blockchain_tests_sync";
 
 #[derive(Debug, Clone)]
 pub(crate) enum BenchmarkFixture {
@@ -63,19 +66,51 @@ pub fn benchmark_fixture_paths(
     input_folder: &Path,
     _selected_fixtures: Option<&[String]>,
 ) -> Result<Vec<PathBuf>> {
-    let fixture_root =
-        eest_blockchain_tests_root(input_folder).unwrap_or_else(|| input_folder.to_path_buf());
-
+    let fixture_root = benchmark_fixture_root(input_folder)?;
     Ok(iter_benchmark_fixture_paths(&fixture_root).collect())
 }
 
-fn eest_blockchain_tests_root(input_folder: &Path) -> Option<PathBuf> {
+fn benchmark_fixture_root(input_folder: &Path) -> Result<PathBuf> {
     if input_folder.is_file() {
-        return None;
+        return Ok(input_folder.to_path_buf());
     }
 
     let blockchain_tests = input_folder.join(EEST_BLOCKCHAIN_TESTS_DIR);
-    blockchain_tests.is_dir().then_some(blockchain_tests)
+    if blockchain_tests.is_dir() {
+        return Ok(blockchain_tests);
+    }
+
+    if looks_like_eest_fixture_bundle(input_folder) {
+        bail!(
+            "EEST fixture bundle {} does not contain required {}/ directory; \
+             stateless-validator supports EEST blockchain_test fixtures",
+            input_folder.display(),
+            EEST_BLOCKCHAIN_TESTS_DIR
+        );
+    }
+
+    Ok(input_folder.to_path_buf())
+}
+
+fn looks_like_eest_fixture_bundle(input_folder: &Path) -> bool {
+    input_folder.join(EEST_BLOCKCHAIN_TESTS_ENGINE_DIR).is_dir()
+        || input_folder
+            .join(EEST_BLOCKCHAIN_TESTS_ENGINE_X_DIR)
+            .is_dir()
+        || input_folder.join(EEST_BLOCKCHAIN_TESTS_SYNC_DIR).is_dir()
+        || eest_fixture_index_has_formats(input_folder)
+}
+
+fn eest_fixture_index_has_formats(input_folder: &Path) -> bool {
+    let index_path = input_folder.join(".meta").join("index.json");
+    let Ok(content) = std::fs::read(index_path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&content) else {
+        return false;
+    };
+
+    value.get("fixture_formats").is_some()
 }
 
 /// Reads and deserializes a single legacy benchmark fixture file.
@@ -306,6 +341,23 @@ mod tests {
 
         let paths = benchmark_fixture_paths(dir.path(), None)?;
         assert_eq!(paths, vec![included_path]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn benchmark_fixture_paths_rejects_engine_only_eest_bundle() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let engine_path = dir
+            .path()
+            .join("blockchain_tests_engine/for_amsterdam/ignored.json");
+        fs::create_dir_all(engine_path.parent().unwrap())?;
+        fs::write(&engine_path, "{}")?;
+
+        let err = benchmark_fixture_paths(dir.path(), None).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("blockchain_tests"));
+        assert!(message.contains("blockchain_test_engine-only"));
 
         Ok(())
     }

--- a/crates/benchmark-runner/src/stateless_validator/inputs.rs
+++ b/crates/benchmark-runner/src/stateless_validator/inputs.rs
@@ -38,8 +38,8 @@ pub(crate) fn stateless_validator_input_from_fixture(
 ) -> Result<Box<dyn GuestFixture>> {
     match fixture {
         BenchmarkFixture::Legacy(fixture) => match el {
-            ExecutionClient::Reth => reth_input_from_fixture(fixture),
-            ExecutionClient::Ethrex => ethrex_input_from_fixture(fixture),
+            ExecutionClient::Reth => reth_input_from_fixture(*fixture),
+            ExecutionClient::Ethrex => ethrex_input_from_fixture(*fixture),
         },
         BenchmarkFixture::Eest(fixture) => raw_eest_input_from_fixture(fixture),
     }

--- a/crates/benchmark-runner/src/stateless_validator/inputs.rs
+++ b/crates/benchmark-runner/src/stateless_validator/inputs.rs
@@ -1,0 +1,120 @@
+use crate::{
+    guest_programs::{GenericGuestFixture, GuestFixture},
+    stateless_validator::{
+        eest::EestStatelessFixture, fixtures::BenchmarkFixture, BlockMetadata, ExecutionClient,
+    },
+};
+use anyhow::{Context, Result};
+use ere_dockerized::Input;
+use ere_guests_guest::Guest;
+use ere_guests_integration_tests::NoopPlatform;
+use ere_guests_stateless_validator_ethrex::{
+    guest::StatelessValidatorEthrexGuest,
+    host::{build_eip8025_input, Eip8025InputSource},
+};
+use ere_guests_stateless_validator_reth::guest::{
+    StatelessValidatorRethGuest, StatelessValidatorRethInput,
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tracing::info;
+use witness_generator::StatelessValidationFixture;
+
+#[derive(Debug, Clone, Serialize)]
+struct EestBlockMetadata {
+    fixture_format: &'static str,
+    original_test_name: String,
+    source_path: String,
+    block_index: usize,
+    network: String,
+    chain_id: u64,
+    block_number: Option<u64>,
+    block_used_gas: Option<u64>,
+}
+
+pub(crate) fn stateless_validator_input_from_fixture(
+    fixture: BenchmarkFixture,
+    el: ExecutionClient,
+) -> Result<Box<dyn GuestFixture>> {
+    match fixture {
+        BenchmarkFixture::Legacy(fixture) => match el {
+            ExecutionClient::Reth => reth_input_from_fixture(fixture),
+            ExecutionClient::Ethrex => ethrex_input_from_fixture(fixture),
+        },
+        BenchmarkFixture::Eest(fixture) => raw_eest_input_from_fixture(fixture),
+    }
+}
+
+fn raw_eest_input_from_fixture(fixture: EestStatelessFixture) -> Result<Box<dyn GuestFixture>> {
+    let metadata = EestBlockMetadata {
+        fixture_format: "eest",
+        original_test_name: fixture.original_test_name,
+        source_path: fixture.source_path,
+        block_index: fixture.block_index,
+        network: fixture.network,
+        chain_id: fixture.chain_id,
+        block_number: fixture.block_number,
+        block_used_gas: fixture.block_used_gas,
+    };
+    let expected_public_values = Sha256::digest(fixture.stateless_output_bytes).to_vec();
+
+    Ok(GenericGuestFixture::<EestBlockMetadata> {
+        name: fixture.name,
+        input: Input::new().with_stdin(fixture.stateless_input_bytes),
+        expected_public_values,
+        metadata,
+    }
+    .into_boxed())
+}
+
+fn ethrex_input_from_fixture(fixture: StatelessValidationFixture) -> Result<Box<dyn GuestFixture>> {
+    let StatelessValidationFixture {
+        name,
+        stateless_input,
+        success,
+    } = fixture;
+    let input = build_eip8025_input(Eip8025InputSource::Legacy {
+        stateless_input: &stateless_input,
+        valid_block: success,
+    })
+    .context("Failed to create Ethrex stateless validator input")?;
+    let output = StatelessValidatorEthrexGuest::compute::<NoopPlatform>(input.clone());
+    let metadata = BlockMetadata {
+        block_used_gas: stateless_input.block.gas_used,
+    };
+
+    Ok(
+        GenericGuestFixture::<BlockMetadata>::new::<StatelessValidatorEthrexGuest>(
+            name, input, output, metadata,
+        )?
+        .output_sha256()
+        .into_boxed(),
+    )
+}
+
+fn reth_input_from_fixture(fixture: StatelessValidationFixture) -> Result<Box<dyn GuestFixture>> {
+    let StatelessValidationFixture {
+        name,
+        stateless_input,
+        success,
+    } = fixture;
+    info!(
+        "Preparing Reth stateless validator input for fixture {}",
+        name
+    );
+    let input = StatelessValidatorRethInput::new(&stateless_input, success)
+        .context("Failed to create Reth stateless validator input")?;
+
+    let output = StatelessValidatorRethGuest::compute::<NoopPlatform>(input.clone());
+    let metadata = BlockMetadata {
+        block_used_gas: stateless_input.block.gas_used,
+    };
+
+    Ok(
+        GenericGuestFixture::<BlockMetadata>::new::<StatelessValidatorRethGuest>(
+            name, input, output, metadata,
+        )?
+        .output_sha256()
+        .into_boxed(),
+    )
+}

--- a/docs/benchmark-execution.md
+++ b/docs/benchmark-execution.md
@@ -16,6 +16,7 @@ Prerequisites:
 
 - Docker is required because zkVM hosts are managed through `ere-dockerized`.
 - Fixture JSON files are expected in `zkevm-fixtures-input/` unless `--input-folder` is provided.
+- `stateless-validator` accepts both generated repo fixtures and EEST `blockchain_tests` fixtures that contain `statelessInputBytes` and `statelessOutputBytes`.
 
 ## Common Benchmark Commands
 
@@ -45,6 +46,14 @@ Use a custom fixture folder:
 cargo run -p ere-hosts --release -- --zkvms sp1 \
     stateless-validator --execution-client reth \
     --input-folder my-fixtures
+```
+
+Run directly from an EEST fixture checkout:
+
+```bash
+cargo run -p ere-hosts --release -- --zkvms sp1 \
+    stateless-validator --execution-client reth \
+    --input-folder /data/code-data/execution-specs/fixtures
 ```
 
 Filter the selected fixtures by prefix:
@@ -84,6 +93,8 @@ cargo run -p ere-hosts --release -- --zkvms sp1 \
 - Metrics output folder default: `zkevm-metrics/`
 - Verification proof folder default: `zkevm-fixtures-proofs/`
 - Zisk profile output folder default: `zisk-profiles/`
+
+Generated repo fixtures are converted into the selected execution client's guest input format before execution. EEST fixtures are different: `ere-hosts` extracts each block's `statelessInputBytes` and sends those bytes directly to the selected guest program without EL-specific host conversion. The expected public values are the SHA-256 digest of the fixture's `statelessOutputBytes`, matching the current stateless validator guest binaries.
 
 Proofs are only saved when `--save-proofs <PATH>` is provided.
 
@@ -141,4 +152,5 @@ When `--proofs-url` is used, the archive is downloaded, extracted to a temporary
 - Docker availability issues will block benchmark execution.
 - `--save-proofs` is only valid with `--action prove`.
 - `--proofs-url` is only valid with `--action verify`.
+- Direct EEST fixture runs may produce normal benchmark crash reports until the selected EL guest binary can decode canonical EEST stateless input bytes.
 - Local offline failures may come from guest downloads, RPC access, or proof archive downloads rather than from a compile regression.

--- a/docs/benchmark-execution.md
+++ b/docs/benchmark-execution.md
@@ -56,6 +56,9 @@ cargo run -p ere-hosts --release -- --zkvms sp1 \
     --input-folder /data/code-data/execution-specs/fixtures
 ```
 
+When an input folder contains an EEST `blockchain_tests/` subdirectory, only that
+subtree is used for stateless-validator inputs.
+
 Filter the selected fixtures by prefix:
 
 ```bash

--- a/docs/fixture-generation.md
+++ b/docs/fixture-generation.md
@@ -16,6 +16,8 @@ Override the default output folder with `-o, --output-folder <PATH>` when needed
 
 ## EEST Fixtures
 
+`ere-hosts` can consume new EEST `blockchain_tests` fixtures directly when their blocks include `statelessInputBytes` and `statelessOutputBytes`. Use `witness-generator-cli tests` only when you need the legacy generated fixture shape.
+
 Generate fixtures from execution-spec benchmark fixtures:
 
 ```bash


### PR DESCRIPTION
This PR:
- Adds support in `ere-hosts` to directly consume EEST tests new format from `execution-specs@projects/zkevm`. It is the usual fixture format, but for each block contains `statelessInputBytes` and `statelessOutputBytes`.
- The runner automatically can detect both workload fixture formats: current one (now called `Legacy`, and new one `Eest`). i.e. this is not a breaking change.
- If `Eest` fixtures are detected, we directly use `stateless{Input|Output}Bytes` for the guest program run (i.e. running EEST fixtures can be done directly without a previously required `witness-generator-cli`).
- The `zkevm-metrics` metadata for an EEST run contains more details to easily map to original EEST file.

Example run output in `zkevm-metrics`:
```
{
  "name": "eest__tests_amsterdam_eip8025_optional_proofs_test_witness_state_writes_py_test_witness_state_reverted_sstore_still_contains_storage_proof_fork_Amsterdam-blockchain_test__block0",
  "timestamp_completed": "2026-05-21T17:48:02.645237188Z",
  "metadata": {
    "block_index": 0,
    "block_number": 1,
    "block_used_gas": 26012,
    "chain_id": 1,
    "fixture_format": "eest",
    "network": "Amsterdam",
    "original_test_name": "tests/amsterdam/eip8025_optional_proofs/test_witness_state_writes.py::test_witness_state_reverted_sstore_still_contains_storage_proof[fork_Amsterdam-blockchain_test]",
    "source_path": "blockchain_tests/for_amsterdam/amsterdam/eip8025_optional_proofs/witness_state_writes/witness_state_reverted_sstore_still_contains_storage_proof.json"
  },
  "execution": {
    "crashed": {
      "reason": "zkVM method error: Emulator panicked: Mem::read() section not found for addr: 0=0 with width: 8"
    }
  }
}
```
