### PR TITLE
feat: add output matching metrics for execution and proving processes

### DIFF
--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -569,6 +569,23 @@ fn public_output_matched(
     }
 }
 
+fn normalize_expected_public_values(
+    zkvm_kind: zkVMKind,
+    mut expected_public_values: Vec<u8>,
+) -> Vec<u8> {
+    if matches!(zkvm_kind, zkVMKind::Airbender | zkVMKind::OpenVM)
+        && expected_public_values.len() < 32
+    {
+        expected_public_values.resize(32, 0);
+    }
+
+    if matches!(zkvm_kind, zkVMKind::Zisk) && expected_public_values.len() < 256 {
+        expected_public_values.resize(256, 0);
+    }
+
+    expected_public_values
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -656,21 +673,4 @@ mod tests {
 
         Ok(())
     }
-}
-
-fn normalize_expected_public_values(
-    zkvm_kind: zkVMKind,
-    mut expected_public_values: Vec<u8>,
-) -> Vec<u8> {
-    if matches!(zkvm_kind, zkVMKind::Airbender | zkVMKind::OpenVM)
-        && expected_public_values.len() < 32
-    {
-        expected_public_values.resize(32, 0);
-    }
-
-    if matches!(zkvm_kind, zkVMKind::Zisk) && expected_public_values.len() < 256 {
-        expected_public_values.resize(256, 0);
-    }
-
-    expected_public_values
 }

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -285,10 +285,12 @@ fn process_input(zkvm: &ZkVMInstance, io: impl GuestFixture, config: &RunConfig)
             let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm.execute(&input)));
             let execution = match run {
                 Ok(Ok((public_values, report))) => {
-                    verify_public_output(zkvm.zkvm_kind(), &io, &public_values)
-                        .context("Failed to verify public output from execution")?;
+                    let output_matched =
+                        public_output_matched(zkvm.zkvm_kind(), &io, &public_values)
+                            .context("Failed to compare public output from execution")?;
 
                     ExecutionMetrics::Success {
+                        output_matched,
                         total_num_cycles: report.total_num_cycles,
                         region_cycles: report.region_cycles.into_iter().collect(),
                         execution_duration: report.execution_duration,
@@ -307,8 +309,9 @@ fn process_input(zkvm: &ZkVMInstance, io: impl GuestFixture, config: &RunConfig)
             let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm.prove(&input)));
             let proving = match run {
                 Ok(Ok((public_values, proof, report))) => {
-                    verify_public_output(zkvm.zkvm_kind(), &io, &public_values)
-                        .context("Failed to verify public output from proof")?;
+                    let prover_output_matched =
+                        public_output_matched(zkvm.zkvm_kind(), &io, &public_values)
+                            .context("Failed to compare public output from proof")?;
 
                     // Save proof to disk if requested
                     if let Some(ref proofs_folder) = config.save_proofs_folder {
@@ -325,10 +328,12 @@ fn process_input(zkvm: &ZkVMInstance, io: impl GuestFixture, config: &RunConfig)
                     let verif_public_values =
                         zkvm.verify(&proof).context("Failed to verify proof")?;
                     let verification_time_ms = verify_start.elapsed().as_millis();
-                    verify_public_output(zkvm.zkvm_kind(), &io, &verif_public_values)
-                        .context("Failed to verify public output from proof verification")?;
+                    let verifier_output_matched =
+                        public_output_matched(zkvm.zkvm_kind(), &io, &verif_public_values)
+                            .context("Failed to compare public output from proof verification")?;
 
                     ProvingMetrics::Success {
+                        output_matched: prover_output_matched && verifier_output_matched,
                         proof_size: proof.len(),
                         proving_time_ms: report.proving_time.as_millis(),
                         verification_time_ms,
@@ -543,21 +548,113 @@ fn save_proof(
     Ok(())
 }
 
-fn verify_public_output(
+fn public_output_matched(
     zkvm_kind: zkVMKind,
     io: &impl GuestFixture,
     public_values: &[u8],
-) -> Result<()> {
+) -> Result<bool> {
     let expected_public_values =
         normalize_expected_public_values(zkvm_kind, io.expected_public_values()?);
 
     if expected_public_values == public_values {
-        Ok(())
+        Ok(true)
     } else {
-        Err(anyhow!(
-            "Output mismatch for {}: Public values mismatch: expected {expected_public_values:?}, got {public_values:?}",
-            io.name()
-        ))
+        warn!(
+            "Output mismatch for {}: Public values mismatch: expected {:?}, got {:?}",
+            io.name(),
+            expected_public_values,
+            public_values
+        );
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Fixture {
+        name: &'static str,
+        expected_public_values: Vec<u8>,
+    }
+
+    impl Fixture {
+        fn new(expected_public_values: Vec<u8>) -> Self {
+            Self {
+                name: "fixture",
+                expected_public_values,
+            }
+        }
+    }
+
+    impl GuestFixture for Fixture {
+        fn name(&self) -> String {
+            self.name.to_string()
+        }
+
+        fn metadata(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+
+        fn input(&self) -> Result<Input> {
+            Ok(Input::new())
+        }
+
+        fn expected_public_values(&self) -> Result<Vec<u8>> {
+            Ok(self.expected_public_values.clone())
+        }
+    }
+
+    #[test]
+    fn public_output_matched_returns_true_for_matching_values() -> Result<()> {
+        let fixture = Fixture::new(vec![1, 2, 3]);
+
+        assert!(public_output_matched(zkVMKind::SP1, &fixture, &[1, 2, 3],)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn public_output_matched_returns_false_for_mismatched_values() -> Result<()> {
+        let fixture = Fixture::new(vec![1, 2, 3]);
+
+        assert!(!public_output_matched(zkVMKind::SP1, &fixture, &[1, 2, 4],)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn public_output_matched_preserves_zkvm_padding_normalization() -> Result<()> {
+        let fixture = Fixture::new(vec![0xab]);
+
+        let mut thirty_two_byte_public_values = vec![0xab];
+        thirty_two_byte_public_values.resize(32, 0);
+
+        assert!(public_output_matched(
+            zkVMKind::Airbender,
+            &fixture,
+            &thirty_two_byte_public_values,
+        )?);
+        assert!(public_output_matched(
+            zkVMKind::OpenVM,
+            &fixture,
+            &thirty_two_byte_public_values,
+        )?);
+        assert!(!public_output_matched(
+            zkVMKind::SP1,
+            &fixture,
+            &thirty_two_byte_public_values,
+        )?);
+
+        let mut zisk_public_values = vec![0xab];
+        zisk_public_values.resize(256, 0);
+        assert!(public_output_matched(
+            zkVMKind::Zisk,
+            &fixture,
+            &zisk_public_values,
+        )?);
+
+        Ok(())
     }
 }
 

--- a/crates/metrics/README.md
+++ b/crates/metrics/README.md
@@ -20,12 +20,14 @@ Both `ExecutionMetrics` and `ProvingMetrics` can be either:
 
 `ExecutionMetrics::Success` stores:
 
+- `output_matched`: Whether public output matched the fixture's expected public values.
 - `total_num_cycles`: The total cycle count for the whole execution.
 - `region_cycles`: A map associating region names with cycle counts for specific workload phases.
 - `execution_duration`: The duration of the execution.
 
 `ProvingMetrics::Success` stores:
 
+- `output_matched`: Whether prover and verification public outputs matched the fixture's expected public values.
 - `proof_size`: The size of the generated proof in bytes.
 - `proving_time_ms`: The time taken to generate the proof in milliseconds.
 - `verification_time_ms`: The time taken to verify the proof in milliseconds.
@@ -78,6 +80,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 block_used_gas: 12345,
             },
             execution: Some(ExecutionMetrics::Success {
+                output_matched: true,
                 total_num_cycles: 1_000,
                 region_cycles: HashMap::from_iter([
                     ("setup".to_string(), 100),
@@ -97,6 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             },
             execution: None,
             proving: Some(ProvingMetrics::Success {
+                output_matched: true,
                 proof_size: 256,
                 proving_time_ms: 2_000,
                 verification_time_ms: 200,

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -111,6 +111,8 @@ pub struct CrashInfo {
 pub enum ExecutionMetrics {
     /// Metrics for a successful execution workload.
     Success {
+        /// Whether public output matched the fixture's expected public values.
+        output_matched: bool,
         /// Total number of cycles for the entire workload execution.
         total_num_cycles: u64,
         /// Region-specific cycles, mapping region names (e.g., "setup", "compute") to their cycle counts.
@@ -128,6 +130,8 @@ pub enum ExecutionMetrics {
 pub enum ProvingMetrics {
     /// Metrics for a successful proving workload.
     Success {
+        /// Whether prover and verification public outputs matched the fixture's expected public values.
+        output_matched: bool,
         /// Proof size in bytes.
         proof_size: usize,
         /// Proving time in milliseconds.
@@ -252,6 +256,7 @@ mod tests {
                     block_gas_used: 12345,
                 },
                 execution: Some(ExecutionMetrics::Success {
+                    output_matched: true,
                     total_num_cycles: 1_000,
                     region_cycles: HashMap::from_iter([
                         ("setup".to_string(), 100),
@@ -270,6 +275,7 @@ mod tests {
                     block_gas_used: 67890,
                 },
                 execution: Some(ExecutionMetrics::Success {
+                    output_matched: true,
                     total_num_cycles: 2_000,
                     region_cycles: HashMap::from_iter([
                         ("init".to_string(), 200),
@@ -279,6 +285,7 @@ mod tests {
                     execution_duration: Duration::from_millis(300),
                 }),
                 proving: Some(ProvingMetrics::Success {
+                    output_matched: true,
                     proof_size: 256,
                     proving_time_ms: 2_000,
                     verification_time_ms: 200,
@@ -293,6 +300,7 @@ mod tests {
                 },
                 execution: None,
                 proving: Some(ProvingMetrics::Success {
+                    output_matched: true,
                     proof_size: 512,
                     proving_time_ms: 5_000,
                     verification_time_ms: 500,
@@ -339,6 +347,7 @@ mod tests {
                 block_gas_used: 11111,
             },
             execution: Some(ExecutionMetrics::Success {
+                output_matched: true,
                 total_num_cycles: 1000,
                 region_cycles: HashMap::new(),
                 execution_duration: Duration::from_millis(150),
@@ -359,6 +368,7 @@ mod tests {
                 block_gas_used: 22222,
             },
             execution: Some(ExecutionMetrics::Success {
+                output_matched: true,
                 total_num_cycles: 500,
                 region_cycles: HashMap::from_iter([
                     ("setup".to_string(), 50),
@@ -368,6 +378,7 @@ mod tests {
                 execution_duration: Duration::from_millis(100),
             }),
             proving: Some(ProvingMetrics::Success {
+                output_matched: true,
                 proof_size: 128,
                 proving_time_ms: 1500,
                 verification_time_ms: 150,
@@ -377,5 +388,49 @@ mod tests {
         let json = BenchmarkRun::to_json(std::slice::from_ref(&bench)).expect("serialize mixed");
         let parsed = BenchmarkRun::from_json(&json).expect("deserialize mixed");
         assert_eq!(vec![bench], parsed);
+    }
+
+    #[test]
+    fn execution_success_serializes_output_matched_values() {
+        for output_matched in [true, false] {
+            let metrics = ExecutionMetrics::Success {
+                output_matched,
+                total_num_cycles: 42,
+                region_cycles: HashMap::new(),
+                execution_duration: Duration::from_millis(7),
+            };
+
+            let value = serde_json::to_value(&metrics).expect("serialize execution metrics");
+            assert_eq!(
+                value["success"]["output_matched"],
+                serde_json::Value::Bool(output_matched)
+            );
+
+            let parsed: ExecutionMetrics =
+                serde_json::from_value(value).expect("deserialize execution metrics");
+            assert_eq!(metrics, parsed);
+        }
+    }
+
+    #[test]
+    fn proving_success_serializes_output_matched_values() {
+        for output_matched in [true, false] {
+            let metrics = ProvingMetrics::Success {
+                output_matched,
+                proof_size: 256,
+                proving_time_ms: 2_000,
+                verification_time_ms: 200,
+            };
+
+            let value = serde_json::to_value(&metrics).expect("serialize proving metrics");
+            assert_eq!(
+                value["success"]["output_matched"],
+                serde_json::Value::Bool(output_matched)
+            );
+
+            let parsed: ProvingMetrics =
+                serde_json::from_value(value).expect("deserialize proving metrics");
+            assert_eq!(metrics, parsed);
+        }
     }
 }

--- a/docs/benchmark-execution.md
+++ b/docs/benchmark-execution.md
@@ -99,6 +99,8 @@ cargo run -p ere-hosts --release -- --zkvms sp1 \
 
 Generated repo fixtures are converted into the selected execution client's guest input format before execution. EEST fixtures are different: `ere-hosts` extracts each block's `statelessInputBytes` and sends those bytes directly to the selected guest program without EL-specific host conversion. The expected public values are the SHA-256 digest of the fixture's `statelessOutputBytes`, matching the current stateless validator guest binaries.
 
+Completed execution and proving runs are still written as successful metrics even when public values do not match the fixture expectation. In that case the runner logs a warning and writes `output_matched: false` inside `execution.success` or `proving.success`. zkVM errors, proof verification errors, expected-output computation errors, and panics are still recorded as crashed or returned as fatal infrastructure errors as before.
+
 Proofs are only saved when `--save-proofs <PATH>` is provided.
 
 Dump the raw serialized guest inputs used for a run:


### PR DESCRIPTION
Adds an `output_matched` flag to successful execution and proving metrics so benchmark results can distinguish performance success from public-output correctness.

- Records `execution.success.output_matched` for execute runs.
- Records `proving.success.output_matched` for prove runs, requiring both prover and verifier public outputs to match.
- Converts public-output mismatches from fatal errors into warnings while still writing successful metrics with `output_matched: false`.
- Keeps zkVM errors, proof verification errors, expected-output computation errors, and panics on the existing error/crash paths.
- Updates metrics docs and adds serialization/unit coverage for the new field and zkVM padding normalization.

To be clear: before this PR, when the received guest program output wasn't what we expected, we halted the whole fixtures run. Now we aren't strict on that front and consider `success` to refer to the guest program run, with the new `output_matched` field indicating correctness! If the guest program crashes, we still get teh `"crashed"` variant as usual.

Example new fixture result:
```
{
  "name": "rpc_block_24949813",
  "timestamp_completed": "2026-05-22T19:15:11.428143406Z",
  "metadata": {
    "block_used_gas": 32959986
  },
  "execution": {
    "success": {
      "output_matched": true,
      "total_num_cycles": 426715495,
      "region_cycles": {},
      "execution_duration": {
        "secs": 16,
        "nanos": 198990895
      }
    }
  }
}
```