### PR TITLE
Add experimental witness-generator-spec-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,11 @@ dependencies = [
 
 [[package]]
 name = "ere-codec"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+
+[[package]]
+name = "ere-codec"
 version = "0.12.1"
 source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
@@ -2825,6 +2830,11 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+
+[[package]]
+name = "ere-platform-core"
 version = "0.12.1"
 source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
@@ -2837,7 +2847,7 @@ dependencies = [
  "auto_impl",
  "bincode 2.0.1",
  "clap",
- "ere-codec",
+ "ere-codec 0.12.1",
  "ere-verifier-core",
  "indexmap 2.14.0",
  "serde",
@@ -2889,7 +2899,7 @@ version = "0.12.1"
 source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "auto_impl",
- "ere-codec",
+ "ere-codec 0.12.1",
  "serde",
 ]
 
@@ -3706,8 +3716,8 @@ name = "guest"
 version = "0.12.1"
 source = "git+https://github.com/eth-act/ere-guests?tag=v0.12.1#06d48bb7239d65c63e72e68451c1510adf577a92"
 dependencies = [
- "ere-codec",
- "ere-platform-core",
+ "ere-codec 0.12.1",
+ "ere-platform-core 0.12.1",
  "sha2",
 ]
 
@@ -4394,7 +4404,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "stateless",
- "stateless-validator-common",
+ "stateless-validator-common 0.12.1",
  "tar",
  "tempfile",
  "tracing",
@@ -9437,14 +9447,31 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator-common"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
+dependencies = [
+ "anyhow",
+ "ere-codec 0.11.0",
+ "ere-platform-core 0.11.0",
+ "libssz 0.2.2",
+ "libssz-derive 0.2.2",
+ "libssz-merkle 0.2.2",
+ "libssz-types 0.2.2",
+ "serde",
+ "serde_with",
+ "sha2",
+]
+
+[[package]]
+name = "stateless-validator-common"
 version = "0.12.1"
 source = "git+https://github.com/eth-act/ere-guests?tag=v0.12.1#06d48bb7239d65c63e72e68451c1510adf577a92"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
  "anyhow",
- "ere-codec",
- "ere-platform-core",
+ "ere-codec 0.12.1",
+ "ere-platform-core 0.12.1",
  "libssz 0.2.2",
  "libssz-derive 0.2.2",
  "libssz-merkle 0.2.2",
@@ -9474,7 +9501,7 @@ dependencies = [
  "libssz-merkle 0.2.2",
  "rkyv",
  "stateless",
- "stateless-validator-common",
+ "stateless-validator-common 0.12.1",
  "stateless-validator-reth",
 ]
 
@@ -9505,7 +9532,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "stateless",
- "stateless-validator-common",
+ "stateless-validator-common 0.12.1",
  "tries",
 ]
 
@@ -11469,7 +11496,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "stateless-validator-common",
+ "stateless-validator-common 0.11.0",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,10 +2982,10 @@ dependencies = [
  "indexmap 2.14.0",
  "lazy_static",
  "libc",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "lru",
  "once_cell",
  "rkyv",
@@ -3034,10 +3034,10 @@ dependencies = [
  "ethrex-rlp",
  "ethrex-vm",
  "hex",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "rkyv",
  "serde",
  "serde_with",
@@ -4088,7 +4088,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4927,29 +4927,18 @@ dependencies = [
 [[package]]
 name = "libssz"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "libssz-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4963,13 +4952,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssz-merkle"
-version = "0.2.1"
+name = "libssz-derive"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4977,28 +4967,38 @@ name = "libssz-merkle"
 version = "0.2.1"
 source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
+dependencies = [
+ "libssz 0.2.2",
  "sha2",
 ]
 
 [[package]]
 name = "libssz-types"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.1",
+ "libssz-merkle 0.2.1",
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "smallvec",
 ]
 
@@ -9440,10 +9440,10 @@ dependencies = [
  "anyhow",
  "ere-codec",
  "ere-platform-core",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-derive 0.2.2",
+ "libssz-merkle 0.2.2",
+ "libssz-types 0.2.2",
  "serde",
  "serde_with",
  "sha2",
@@ -9464,8 +9464,8 @@ dependencies = [
  "ethrex-guest-program",
  "ethrex-rpc",
  "guest",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "rkyv",
  "stateless",
  "stateless-validator-common",
@@ -11434,6 +11434,26 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.23",
  "witness-generator",
+]
+
+[[package]]
+name = "witness-generator-spec-cli"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.1",
+ "alloy-primitives",
+ "alloy-rlp",
+ "anyhow",
+ "clap",
+ "libssz 0.2.2",
+ "libssz-derive 0.2.2",
+ "libssz-types 0.2.2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "stateless-validator-common",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/metrics",
     "crates/witness-generator",
     "crates/witness-generator-cli",
+    "crates/witness-generator-spec-cli",
     "crates/ere-hosts",
 ]
 resolver = "2"
@@ -100,6 +101,7 @@ zero_sized_map_values = "warn"
 
 # local dependencies
 witness-generator = { path = "crates/witness-generator" }
+witness-generator-spec-cli = { path = "crates/witness-generator-spec-cli" }
 zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 
@@ -114,6 +116,7 @@ ere-guests-stateless-validator-ethrex = { git = "https://github.com/eth-act/ere-
 ere-guests-guest = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "guest" }
 ere-guests-integration-tests = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "integration-tests" }
 ere-guests-downloader = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "downloader" }
+stateless-validator-common = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "stateless-validator-common" }
 
 reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.1.0" }
 reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.1.0" }
@@ -122,9 +125,17 @@ ef-tests = { git = "https://github.com/paradigmxyz/stateless", rev = "e5480e71a8
 stateless = { git = "https://github.com/paradigmxyz/stateless", rev = "e5480e71a8031641ff471cad9dc482a7a14b32d5", default-features = false }
 
 # alloy
+alloy-consensus = { version = "2.0", default-features = false }
 alloy-eips = { version = "2.0" }
+alloy-primitives = { version = "1.5.6", default-features = false }
 alloy-rpc-types-eth = "2.0"
 alloy-genesis = { version = "2.0", default-features = false }
+alloy-rlp = { version = "0.3", default-features = false }
+
+# ssz
+libssz = "0.2.2"
+libssz_derive = { package = "libssz-derive", version = "0.2.2" }
+libssz_types = { package = "libssz-types", version = "0.2.2" }
 
 # misc
 clap = { version = "4.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository benchmarks Ethereum-related guest programs across multiple zkVMs
 ## Workspace At a Glance
 
 - **`crates/witness-generator-cli`**: fixture-generation CLI for EEST, RPC, and raw-input sources.
+- **`crates/witness-generator-spec-cli`**: CLI and library for generating canonical stateless input bytes from CL/EL RPC endpoints.
 - **`crates/ere-hosts`**: benchmark CLI for execution, proving, and verification jobs.
 - **`crates/benchmark-runner`**: shared orchestration for guest resolution, execution, proof flow, and verification.
 - **`crates/metrics`**: serializable result types such as `BenchmarkRun`.
@@ -31,6 +32,7 @@ Verify that both CLIs are reachable from the repo root:
 
 ```bash
 cargo run -p witness-generator-cli -- --help
+cargo run -p witness-generator-spec-cli -- --help
 cargo run -p ere-hosts -- --help
 ```
 

--- a/crates/witness-generator-spec-cli/Cargo.toml
+++ b/crates/witness-generator-spec-cli/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "witness-generator-spec-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "witness-generator-spec-cli"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+# alloy
+alloy-consensus = { workspace = true, features = ["k256"] }
+alloy-eips.workspace = true
+alloy-primitives = { workspace = true, features = ["k256", "serde", "std"] }
+alloy-rlp.workspace = true
+
+# ssz
+libssz.workspace = true
+libssz_derive.workspace = true
+libssz_types.workspace = true
+
+# local
+stateless-validator-common.workspace = true

--- a/crates/witness-generator-spec-cli/src/builder.rs
+++ b/crates/witness-generator-spec-cli/src/builder.rs
@@ -1,0 +1,475 @@
+//! Assembly of canonical Amsterdam stateless input bytes.
+
+use alloy_consensus::{Header, Transaction as AlloyTransaction, TxEnvelope};
+use alloy_eips::eip2718::Decodable2718;
+use alloy_primitives::{B256, Bytes};
+use alloy_rlp::Decodable;
+use anyhow::{Context, ensure};
+use libssz::SszEncode;
+use libssz_types::SszList;
+use stateless_validator_common::new_payload_request::{
+    BlockAccessList, ConsolidationRequest, ConsolidationRequests, DepositRequest, DepositRequests,
+    ExecutionPayloadV4, ExecutionRequests, ExtraData, NewPayloadRequestAmsterdam,
+    Transaction as PayloadTransaction, Transactions, VersionedHashes, Withdrawal,
+    WithdrawalRequest, WithdrawalRequests, Withdrawals,
+};
+
+use crate::{
+    rpc::{
+        BeaconExecutionPayload, ConsolidationRequestJson, DepositRequestJson,
+        ExecutionPayloadEnvelope, ExecutionRequestsJson, RpcExecutionWitness, WithdrawalJson,
+        WithdrawalRequestJson,
+    },
+    schema::{self, PublicKeys, SszExecutionWitness, SszStatelessInput},
+};
+
+/// Canonical stateless guest input generated from network RPC data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratedInput {
+    /// Bytes encoded as `0x0001 || SSZ(SszStatelessInput)`.
+    pub bytes: Vec<u8>,
+    /// Execution block hash.
+    pub block_hash: B256,
+    /// Execution block number.
+    pub block_number: u64,
+    /// Consensus slot number copied from the Amsterdam execution payload.
+    pub slot_number: u64,
+    /// Execution chain id.
+    pub chain_id: u64,
+}
+
+pub(crate) fn build_generated_input(
+    envelope: ExecutionPayloadEnvelope,
+    witness: RpcExecutionWitness,
+    chain_id: u64,
+) -> anyhow::Result<GeneratedInput> {
+    let payload = &envelope.payload;
+    let slot_number = payload.slot_number;
+    let block_hash = payload.block_hash;
+    let block_number = payload.block_number;
+    let transaction_artifacts = decode_transaction_artifacts(&payload.transactions)?;
+
+    let new_payload_request = NewPayloadRequestAmsterdam {
+        execution_payload: convert_execution_payload(payload)?,
+        versioned_hashes: transaction_artifacts.versioned_hashes,
+        parent_beacon_block_root: envelope.parent_beacon_block_root.0,
+        execution_requests: convert_execution_requests(&envelope.execution_requests)?,
+    };
+
+    let witness = convert_witness(witness, block_number)?;
+    let chain_config = schema::amsterdam_chain_config(chain_id)?;
+    let public_keys = PublicKeys::try_from(transaction_artifacts.public_keys)
+        .map_err(|err| anyhow::anyhow!("public_keys exceed SSZ bound: {err:?}"))?;
+
+    let stateless_input = SszStatelessInput {
+        new_payload_request,
+        witness,
+        chain_config,
+        public_keys,
+    };
+
+    let stateless_input_bytes = stateless_input.to_ssz();
+    let mut bytes = Vec::with_capacity(2 + stateless_input_bytes.len());
+    bytes.extend_from_slice(&schema::STATELESS_INPUT_SCHEMA_ID_BYTES);
+    bytes.extend(stateless_input_bytes);
+
+    Ok(GeneratedInput {
+        bytes,
+        block_hash,
+        block_number,
+        slot_number,
+        chain_id,
+    })
+}
+
+fn convert_execution_payload(
+    payload: &BeaconExecutionPayload,
+) -> anyhow::Result<ExecutionPayloadV4> {
+    let transactions = payload
+        .transactions
+        .iter()
+        .enumerate()
+        .map(|(i, tx)| {
+            PayloadTransaction::try_from(tx.to_vec())
+                .map_err(|err| anyhow::anyhow!("transaction #{i} exceeds SSZ bound: {err:?}"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let withdrawals = payload
+        .withdrawals
+        .iter()
+        .map(convert_withdrawal)
+        .collect::<Vec<_>>();
+
+    Ok(ExecutionPayloadV4 {
+        parent_hash: payload.parent_hash.0,
+        fee_recipient: payload.fee_recipient.into_array(),
+        state_root: payload.state_root.0,
+        receipts_root: payload.receipts_root.0,
+        logs_bloom: payload.logs_bloom.0,
+        prev_randao: payload.prev_randao.0,
+        block_number: payload.block_number,
+        gas_limit: payload.gas_limit,
+        gas_used: payload.gas_used,
+        timestamp: payload.timestamp,
+        extra_data: ExtraData::try_from(payload.extra_data.to_vec())
+            .map_err(|err| anyhow::anyhow!("extra_data exceeds SSZ bound: {err:?}"))?,
+        base_fee_per_gas: payload.base_fee_per_gas.to_le_bytes(),
+        block_hash: payload.block_hash.0,
+        transactions: Transactions::try_from(transactions)
+            .map_err(|err| anyhow::anyhow!("transactions exceed SSZ bound: {err:?}"))?,
+        withdrawals: Withdrawals::try_from(withdrawals)
+            .map_err(|err| anyhow::anyhow!("withdrawals exceed SSZ bound: {err:?}"))?,
+        blob_gas_used: payload.blob_gas_used,
+        excess_blob_gas: payload.excess_blob_gas,
+        block_access_list: BlockAccessList::try_from(payload.block_access_list.to_vec())
+            .map_err(|err| anyhow::anyhow!("block_access_list exceeds SSZ bound: {err:?}"))?,
+        slot_number: payload.slot_number,
+    })
+}
+
+const fn convert_withdrawal(withdrawal: &WithdrawalJson) -> Withdrawal {
+    Withdrawal {
+        index: withdrawal.index,
+        validator_index: withdrawal.validator_index,
+        address: withdrawal.address.into_array(),
+        amount: withdrawal.amount,
+    }
+}
+
+fn convert_execution_requests(
+    requests: &ExecutionRequestsJson,
+) -> anyhow::Result<ExecutionRequests> {
+    let deposits = requests
+        .deposits
+        .iter()
+        .map(convert_deposit_request)
+        .collect::<Vec<_>>();
+    let withdrawals = requests
+        .withdrawals
+        .iter()
+        .map(convert_withdrawal_request)
+        .collect::<Vec<_>>();
+    let consolidations = requests
+        .consolidations
+        .iter()
+        .map(convert_consolidation_request)
+        .collect::<Vec<_>>();
+
+    Ok(ExecutionRequests {
+        deposits: DepositRequests::try_from(deposits)
+            .map_err(|err| anyhow::anyhow!("deposit requests exceed SSZ bound: {err:?}"))?,
+        withdrawals: WithdrawalRequests::try_from(withdrawals)
+            .map_err(|err| anyhow::anyhow!("withdrawal requests exceed SSZ bound: {err:?}"))?,
+        consolidations: ConsolidationRequests::try_from(consolidations)
+            .map_err(|err| anyhow::anyhow!("consolidation requests exceed SSZ bound: {err:?}"))?,
+    })
+}
+
+const fn convert_deposit_request(request: &DepositRequestJson) -> DepositRequest {
+    DepositRequest {
+        pubkey: request.pubkey.0,
+        withdrawal_credentials: request.withdrawal_credentials.0,
+        amount: request.amount,
+        signature: request.signature.0,
+        index: request.index,
+    }
+}
+
+const fn convert_withdrawal_request(request: &WithdrawalRequestJson) -> WithdrawalRequest {
+    WithdrawalRequest {
+        source_address: request.source_address.into_array(),
+        validator_pubkey: request.validator_pubkey.0,
+        amount: request.amount,
+    }
+}
+
+const fn convert_consolidation_request(request: &ConsolidationRequestJson) -> ConsolidationRequest {
+    ConsolidationRequest {
+        source_address: request.source_address.into_array(),
+        source_pubkey: request.source_pubkey.0,
+        target_pubkey: request.target_pubkey.0,
+    }
+}
+
+fn convert_witness(
+    witness: RpcExecutionWitness,
+    block_number: u64,
+) -> anyhow::Result<SszExecutionWitness> {
+    let headers = normalize_headers(witness.headers, block_number)?;
+    Ok(SszExecutionWitness {
+        state: bytes_to_nested_ssz_list::<
+            { schema::MAX_BYTES_PER_WITNESS_NODE },
+            { schema::MAX_WITNESS_NODES },
+        >(witness.state, "witness.state")?,
+        codes: bytes_to_nested_ssz_list::<
+            { schema::MAX_BYTES_PER_CODE },
+            { schema::MAX_WITNESS_CODES },
+        >(witness.codes, "witness.codes")?,
+        headers: bytes_to_nested_ssz_list::<
+            { schema::MAX_BYTES_PER_HEADER },
+            { schema::MAX_WITNESS_HEADERS },
+        >(headers, "witness.headers")?,
+    })
+}
+
+fn bytes_to_nested_ssz_list<const MAX_BYTES: usize, const MAX_ITEMS: usize>(
+    values: Vec<Bytes>,
+    label: &str,
+) -> anyhow::Result<SszList<SszList<u8, MAX_BYTES>, MAX_ITEMS>> {
+    let values = values
+        .into_iter()
+        .enumerate()
+        .map(|(i, bytes)| {
+            SszList::<u8, MAX_BYTES>::try_from(bytes.to_vec())
+                .map_err(|err| anyhow::anyhow!("{label}[{i}] exceeds SSZ byte bound: {err:?}"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    SszList::<SszList<u8, MAX_BYTES>, MAX_ITEMS>::try_from(values)
+        .map_err(|err| anyhow::anyhow!("{label} exceeds SSZ item bound: {err:?}"))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TransactionArtifacts {
+    public_keys: Vec<[u8; 65]>,
+    versioned_hashes: VersionedHashes,
+}
+
+fn decode_transaction_artifacts(transactions: &[Bytes]) -> anyhow::Result<TransactionArtifacts> {
+    let mut public_keys = Vec::with_capacity(transactions.len());
+    let mut versioned_hashes = Vec::new();
+
+    for (i, tx) in transactions.iter().enumerate() {
+        let envelope = TxEnvelope::decode_2718_exact(tx.as_ref())
+            .with_context(|| format!("failed to decode transaction #{i}"))?;
+        let public_key = envelope
+            .signature()
+            .recover_from_prehash(&envelope.signature_hash())
+            .map(|key| key.to_encoded_point(false).as_bytes().try_into().unwrap())
+            .with_context(|| format!("failed to recover public key for transaction #{i}"))?;
+        public_keys.push(public_key);
+
+        if let Some(hashes) = envelope.blob_versioned_hashes() {
+            versioned_hashes.extend(hashes.iter().map(|hash| hash.0));
+        }
+    }
+
+    let versioned_hashes = VersionedHashes::try_from(versioned_hashes)
+        .map_err(|err| anyhow::anyhow!("versioned_hashes exceed SSZ bound: {err:?}"))?;
+
+    Ok(TransactionArtifacts {
+        public_keys,
+        versioned_hashes,
+    })
+}
+
+#[cfg(test)]
+fn recover_public_keys(transactions: &[Bytes]) -> anyhow::Result<Vec<[u8; 65]>> {
+    Ok(decode_transaction_artifacts(transactions)?.public_keys)
+}
+
+#[cfg(test)]
+fn decode_versioned_hashes(transactions: &[Bytes]) -> anyhow::Result<VersionedHashes> {
+    Ok(decode_transaction_artifacts(transactions)?.versioned_hashes)
+}
+
+fn normalize_headers(headers: Vec<Bytes>, block_number: u64) -> anyhow::Result<Vec<Bytes>> {
+    ensure!(
+        block_number > 0,
+        "cannot require parent header for genesis block"
+    );
+    let parent_number = block_number - 1;
+    let mut headers = headers
+        .into_iter()
+        .enumerate()
+        .map(|(i, bytes)| {
+            let number = decode_header_number(&bytes)
+                .with_context(|| format!("failed to decode witness header #{i}"))?;
+            Ok((number, bytes))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    headers.sort_by_key(|(number, _)| *number);
+
+    for pair in headers.windows(2) {
+        let prev = pair[0].0;
+        let next = pair[1].0;
+        ensure!(next != prev, "duplicate witness header for block #{next}");
+        ensure!(
+            next == prev + 1,
+            "witness headers are not contiguous: block #{prev} followed by block #{next}",
+        );
+    }
+
+    ensure!(
+        headers
+            .last()
+            .map(|(number, _)| *number)
+            .is_some_and(|number| number == parent_number),
+        "witness parent header for block #{parent_number} is absent",
+    );
+
+    Ok(headers.into_iter().map(|(_, bytes)| bytes).collect())
+}
+
+fn decode_header_number(bytes: &[u8]) -> anyhow::Result<u64> {
+    let mut slice = bytes;
+    let header = Header::decode(&mut slice).context("invalid RLP header")?;
+    ensure!(slice.is_empty(), "RLP header has trailing bytes");
+    Ok(header.number)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{b256, hex};
+    use alloy_rlp::Encodable;
+
+    use super::*;
+
+    #[test]
+    fn extracts_versioned_hashes_from_blob_transaction() {
+        let raw = hex::decode(
+            "0x03f9011d83aa36a7820fa28477359400852e90edd0008252089411e9ca82a3a762b4b5bd264d4173a242e7a770648080c08504a817c800f8a5a0012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921aa00152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4a0013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7a001148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1a0011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e654901a0c8de4cced43169f9aa3d36506363b2d2c44f6c49fc1fd91ea114c86f3757077ea01e11fdd0d1934eda0492606ee0bb80a7bf8f35cc5f86ec60fe5031ba48bfd544",
+        )
+        .unwrap();
+
+        let hashes = decode_versioned_hashes(&[Bytes::from(raw)]).unwrap();
+
+        assert_eq!(
+            &*hashes,
+            &[
+                b256!("012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921a").0,
+                b256!("0152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4").0,
+                b256!("013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7").0,
+                b256!("01148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1").0,
+                b256!("011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e6549").0,
+            ]
+        );
+    }
+
+    #[test]
+    fn recovers_public_key_from_raw_transaction() {
+        let raw = hex::decode(
+            "f86e81fa843127403882f61894db8d964741c53e55df9c2d4e9414c6c96482874e870aa87bee538000808360306ca03aa421df67a101c45ff9cb06ce28f518a5d8d8dbb76a79361280071909650a27a05a447ff053c4ae601cfe81859b58d5603f2d0a73481c50f348089032feb0b073",
+        )
+        .unwrap();
+
+        let public_keys = recover_public_keys(&[Bytes::from(raw)]).unwrap();
+
+        assert_eq!(public_keys.len(), 1);
+        assert_eq!(public_keys[0][0], 0x04);
+    }
+
+    #[test]
+    fn normalizes_headers_to_oldest_first_and_parent_last() {
+        let header_8 = rlp_header(8);
+        let header_9 = rlp_header(9);
+
+        let normalized = normalize_headers(vec![header_9.clone(), header_8.clone()], 10).unwrap();
+
+        assert_eq!(normalized, vec![header_8, header_9]);
+    }
+
+    #[test]
+    fn rejects_missing_parent_header() {
+        let err = normalize_headers(vec![rlp_header(7), rlp_header(8)], 10).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("witness parent header for block #9 is absent")
+        );
+    }
+
+    #[test]
+    fn rejects_non_contiguous_headers() {
+        let err = normalize_headers(vec![rlp_header(7), rlp_header(9)], 10).unwrap_err();
+
+        assert!(err.to_string().contains("not contiguous"));
+    }
+
+    #[test]
+    fn witness_lists_enforce_bounds() {
+        let oversized = Bytes::from(vec![0_u8; schema::MAX_BYTES_PER_HEADER + 1]);
+        let err = bytes_to_nested_ssz_list::<
+            { schema::MAX_BYTES_PER_HEADER },
+            { schema::MAX_WITNESS_HEADERS },
+        >(vec![oversized], "headers")
+        .unwrap_err();
+
+        assert!(err.to_string().contains("exceeds SSZ byte bound"));
+    }
+
+    #[test]
+    fn fixture_json_builds_deterministic_stateless_input_bytes() {
+        let parent_header = rlp_header(9);
+        let envelope_response = serde_json::json!({
+            "version": "gloas",
+            "execution_optimistic": false,
+            "finalized": false,
+            "data": {
+                "message": {
+                    "payload": {
+                        "parent_hash": format!("0x{}", "01".repeat(32)),
+                        "fee_recipient": format!("0x{}", "02".repeat(20)),
+                        "state_root": format!("0x{}", "03".repeat(32)),
+                        "receipts_root": format!("0x{}", "04".repeat(32)),
+                        "logs_bloom": format!("0x{}", "00".repeat(256)),
+                        "prev_randao": format!("0x{}", "05".repeat(32)),
+                        "block_number": "10",
+                        "gas_limit": "30000000",
+                        "gas_used": "21000",
+                        "timestamp": "1000",
+                        "extra_data": "0x",
+                        "base_fee_per_gas": "0x7",
+                        "block_hash": format!("0x{}", "06".repeat(32)),
+                        "transactions": [],
+                        "withdrawals": [],
+                        "blob_gas_used": "0",
+                        "excess_blob_gas": "0",
+                        "block_access_list": "0xc0",
+                        "slot_number": "64"
+                    },
+                    "execution_requests": {},
+                    "builder_index": "0",
+                    "beacon_block_root": format!("0x{}", "bb".repeat(32)),
+                    "parent_beacon_block_root": format!("0x{}", "aa".repeat(32))
+                }
+            }
+        });
+        let witness_json = serde_json::json!({
+            "state": ["0x80"],
+            "keys": ["0x01"],
+            "codes": ["0x"],
+            "headers": [format!("0x{}", hex::encode(&parent_header))]
+        });
+        let parsed: crate::rpc::ExecutionPayloadEnvelopeResponse =
+            serde_json::from_value(envelope_response).unwrap();
+        let envelope = parsed.data.message;
+        let witness: RpcExecutionWitness = serde_json::from_value(witness_json).unwrap();
+
+        let first = build_generated_input(envelope.clone(), witness.clone(), 1).unwrap();
+        let second = build_generated_input(envelope, witness, 1).unwrap();
+
+        assert_eq!(first.bytes, second.bytes);
+        assert_eq!(&first.bytes[..2], &schema::STATELESS_INPUT_SCHEMA_ID_BYTES);
+        assert_eq!(first.block_number, 10);
+        assert_eq!(first.slot_number, 64);
+        assert_eq!(first.chain_id, 1);
+    }
+
+    fn rlp_header(number: u64) -> Bytes {
+        let header = Header {
+            number,
+            base_fee_per_gas: Some(7),
+            withdrawals_root: Some(B256::ZERO),
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(0),
+            parent_beacon_block_root: Some(B256::ZERO),
+            requests_hash: Some(B256::ZERO),
+            block_access_list_hash: Some(B256::ZERO),
+            slot_number: Some(number + 1),
+            ..Default::default()
+        };
+        let mut bytes = Vec::new();
+        header.encode(&mut bytes);
+        Bytes::from(bytes)
+    }
+}

--- a/crates/witness-generator-spec-cli/src/lib.rs
+++ b/crates/witness-generator-spec-cli/src/lib.rs
@@ -1,0 +1,185 @@
+//! Build canonical Amsterdam stateless guest input bytes from live network RPC data.
+
+mod builder;
+mod rpc;
+mod schema;
+mod serde_helpers;
+
+use std::time::Duration;
+
+use alloy_primitives::B256;
+use anyhow::{Context, ensure};
+pub use builder::GeneratedInput;
+use reqwest::Client;
+
+// These dependencies are used by this package's CLI target.
+use clap as _;
+use tokio as _;
+
+/// Configuration for consensus-layer and execution-layer RPC access.
+#[derive(Debug, Clone)]
+pub struct NetworkWitnessConfig {
+    /// Consensus-layer Beacon API endpoint.
+    pub cl_endpoint: String,
+    /// Execution-layer JSON-RPC endpoint.
+    pub el_endpoint: String,
+    /// Request timeout.
+    pub timeout: Duration,
+    /// Extra HTTP headers sent to the consensus-layer endpoint.
+    pub cl_headers: Vec<(String, String)>,
+    /// Extra HTTP headers sent to the execution-layer endpoint.
+    pub el_headers: Vec<(String, String)>,
+}
+
+impl NetworkWitnessConfig {
+    /// Creates a config with a conservative default timeout and no custom headers.
+    pub fn new(cl_endpoint: impl Into<String>, el_endpoint: impl Into<String>) -> Self {
+        Self {
+            cl_endpoint: cl_endpoint.into(),
+            el_endpoint: el_endpoint.into(),
+            timeout: Duration::from_secs(30),
+            cl_headers: Vec::new(),
+            el_headers: Vec::new(),
+        }
+    }
+}
+
+/// Block selection for canonical stateless input generation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum BlockSelector {
+    /// The current consensus head block.
+    #[default]
+    Head,
+    /// A Beacon API block id such as `head`, `finalized`, a slot, or a block root.
+    BeaconBlockId(String),
+    /// An execution block number. The matching CL slot is derived from the EL block timestamp.
+    ExecutionBlockNumber(u64),
+}
+
+/// Client for fetching network data and building canonical stateless input bytes.
+#[derive(Debug, Clone)]
+pub struct NetworkWitnessClient {
+    rpc: rpc::RpcClient,
+}
+
+impl NetworkWitnessClient {
+    /// Creates a new network witness client.
+    pub fn new(config: NetworkWitnessConfig) -> anyhow::Result<Self> {
+        let http = Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .context("failed to build HTTP client")?;
+
+        Ok(Self {
+            rpc: rpc::RpcClient::new(config, http),
+        })
+    }
+
+    /// Fetches network data for `selector` and returns canonical spec guest input bytes.
+    pub async fn stateless_input_bytes(
+        &self,
+        selector: BlockSelector,
+    ) -> anyhow::Result<GeneratedInput> {
+        let envelope = self.fetch_payload_envelope(selector).await?;
+        let block_hash = envelope.payload.block_hash;
+
+        let witness = self
+            .rpc
+            .debug_execution_witness_by_block_hash(block_hash)
+            .await
+            .with_context(|| format!("failed to fetch execution witness for {block_hash}"))?;
+        let chain_id = self.rpc.eth_chain_id().await?;
+
+        builder::build_generated_input(envelope, witness, chain_id)
+    }
+
+    async fn fetch_payload_envelope(
+        &self,
+        selector: BlockSelector,
+    ) -> anyhow::Result<rpc::ExecutionPayloadEnvelope> {
+        match selector {
+            BlockSelector::Head => self.rpc.execution_payload_envelope("head").await,
+            BlockSelector::BeaconBlockId(block_id) => {
+                self.rpc.execution_payload_envelope(&block_id).await
+            }
+            BlockSelector::ExecutionBlockNumber(number) => {
+                self.fetch_payload_envelope_for_execution_number(number)
+                    .await
+            }
+        }
+    }
+
+    async fn fetch_payload_envelope_for_execution_number(
+        &self,
+        number: u64,
+    ) -> anyhow::Result<rpc::ExecutionPayloadEnvelope> {
+        let el_block = self.rpc.eth_block_by_number(number).await?;
+        ensure!(
+            el_block.number == number,
+            "EL returned block number {} for requested block number {}",
+            el_block.number,
+            number,
+        );
+
+        let genesis = self.rpc.beacon_genesis().await?;
+        let spec = self.rpc.beacon_spec().await?;
+        ensure!(
+            spec.seconds_per_slot > 0,
+            "CL spec SECONDS_PER_SLOT must be greater than zero",
+        );
+        ensure!(
+            el_block.timestamp >= genesis.genesis_time,
+            "EL block timestamp {} is before CL genesis time {}",
+            el_block.timestamp,
+            genesis.genesis_time,
+        );
+        let slot = (el_block.timestamp - genesis.genesis_time) / spec.seconds_per_slot;
+
+        let envelope = self
+            .rpc
+            .execution_payload_envelope(&slot.to_string())
+            .await?;
+        ensure_matching_hash(envelope.payload.block_hash, el_block.hash, number, slot)?;
+        Ok(envelope)
+    }
+}
+
+fn ensure_matching_hash(
+    cl_hash: B256,
+    el_hash: B256,
+    number: u64,
+    slot: u64,
+) -> anyhow::Result<()> {
+    ensure!(
+        cl_hash == el_hash,
+        "CL payload envelope at slot {slot} has execution block hash {cl_hash}, expected EL block #{number} hash {el_hash}",
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore]
+    async fn live_generation_from_env() -> anyhow::Result<()> {
+        let (Ok(cl_endpoint), Ok(el_endpoint)) =
+            (std::env::var("CL_RPC_URL"), std::env::var("EL_RPC_URL"))
+        else {
+            return Ok(());
+        };
+
+        let client =
+            NetworkWitnessClient::new(NetworkWitnessConfig::new(cl_endpoint, el_endpoint))?;
+        let generated = client.stateless_input_bytes(BlockSelector::Head).await?;
+
+        assert!(
+            generated
+                .bytes
+                .starts_with(&schema::STATELESS_INPUT_SCHEMA_ID_BYTES)
+        );
+        assert!(generated.block_number > 0);
+        Ok(())
+    }
+}

--- a/crates/witness-generator-spec-cli/src/main.rs
+++ b/crates/witness-generator-spec-cli/src/main.rs
@@ -1,0 +1,76 @@
+//! CLI entry point for generating canonical stateless input bytes from network RPC data.
+
+#![allow(
+    unused_crate_dependencies,
+    reason = "library dependencies are compiled separately from this CLI target"
+)]
+
+use std::{
+    fs,
+    io::{self, Write},
+    path::PathBuf,
+};
+
+use alloy_primitives::hex;
+use clap::{Parser, ValueEnum};
+use witness_generator_spec_cli::{BlockSelector, NetworkWitnessClient, NetworkWitnessConfig};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "witness-generator-spec-cli",
+    about = "Generate canonical Amsterdam stateless guest input bytes from CL/EL RPC endpoints.",
+    long_about = None
+)]
+struct Cli {
+    /// Consensus-layer Beacon API endpoint.
+    #[arg(long)]
+    cl_url: String,
+    /// Execution-layer JSON-RPC endpoint.
+    #[arg(long)]
+    el_url: String,
+    /// Beacon API block id: head, finalized, slot, or block root. Defaults to head.
+    #[arg(long)]
+    block_id: Option<String>,
+    /// Execution block number to resolve to a CL slot via block timestamp.
+    #[arg(long, conflicts_with = "block_id")]
+    execution_block_number: Option<u64>,
+    /// Output encoding.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Hex)]
+    format: OutputFormat,
+    /// Output file. Stdout is used when omitted.
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum OutputFormat {
+    Hex,
+    Raw,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let selector = match cli.execution_block_number {
+        Some(number) => BlockSelector::ExecutionBlockNumber(number),
+        None => match cli.block_id.as_deref().unwrap_or("head") {
+            "head" => BlockSelector::Head,
+            other => BlockSelector::BeaconBlockId(other.to_owned()),
+        },
+    };
+
+    let client = NetworkWitnessClient::new(NetworkWitnessConfig::new(cli.cl_url, cli.el_url))?;
+    let generated = client.stateless_input_bytes(selector).await?;
+    let output = match cli.format {
+        OutputFormat::Hex => format!("0x{}\n", hex::encode(&generated.bytes)).into_bytes(),
+        OutputFormat::Raw => generated.bytes,
+    };
+
+    if let Some(path) = cli.out {
+        fs::write(path, output)?;
+    } else {
+        io::stdout().write_all(&output)?;
+    }
+
+    Ok(())
+}

--- a/crates/witness-generator-spec-cli/src/rpc.rs
+++ b/crates/witness-generator-spec-cli/src/rpc.rs
@@ -1,0 +1,429 @@
+//! Minimal Beacon API and JSON-RPC client/types for network witness generation.
+
+use alloy_primitives::{Address, B256, Bytes, FixedBytes};
+use anyhow::{Context, bail};
+use reqwest::{
+    Client, RequestBuilder,
+    header::{HeaderName, HeaderValue},
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::{Value, json};
+
+use crate::{
+    NetworkWitnessConfig,
+    serde_helpers::{de_u64, hex_quantity, parse_u64},
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct RpcClient {
+    config: NetworkWitnessConfig,
+    http: Client,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ExecutionPayloadEnvelopeResponse {
+    pub(crate) data: SignedExecutionPayloadEnvelope,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SignedExecutionPayloadEnvelope {
+    pub(crate) message: ExecutionPayloadEnvelope,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ExecutionPayloadEnvelope {
+    pub(crate) payload: BeaconExecutionPayload,
+    pub(crate) execution_requests: ExecutionRequestsJson,
+    pub(crate) parent_beacon_block_root: B256,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BeaconExecutionPayload {
+    pub(crate) parent_hash: B256,
+    pub(crate) fee_recipient: Address,
+    pub(crate) state_root: B256,
+    pub(crate) receipts_root: B256,
+    pub(crate) logs_bloom: FixedBytes<256>,
+    pub(crate) prev_randao: B256,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) block_number: u64,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) gas_limit: u64,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) gas_used: u64,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) timestamp: u64,
+    pub(crate) extra_data: Bytes,
+    #[serde(deserialize_with = "crate::serde_helpers::de_u256")]
+    pub(crate) base_fee_per_gas: alloy_primitives::U256,
+    pub(crate) block_hash: B256,
+    #[serde(default)]
+    pub(crate) transactions: Vec<Bytes>,
+    #[serde(default)]
+    pub(crate) withdrawals: Vec<WithdrawalJson>,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) blob_gas_used: u64,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) excess_blob_gas: u64,
+    pub(crate) block_access_list: Bytes,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) slot_number: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct WithdrawalJson {
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) index: u64,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) validator_index: u64,
+    pub(crate) address: Address,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) amount: u64,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct ExecutionRequestsJson {
+    #[serde(default)]
+    pub(crate) deposits: Vec<DepositRequestJson>,
+    #[serde(default)]
+    pub(crate) withdrawals: Vec<WithdrawalRequestJson>,
+    #[serde(default)]
+    pub(crate) consolidations: Vec<ConsolidationRequestJson>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct DepositRequestJson {
+    pub(crate) pubkey: FixedBytes<48>,
+    pub(crate) withdrawal_credentials: B256,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) amount: u64,
+    pub(crate) signature: FixedBytes<96>,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) index: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct WithdrawalRequestJson {
+    pub(crate) source_address: Address,
+    pub(crate) validator_pubkey: FixedBytes<48>,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) amount: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ConsolidationRequestJson {
+    pub(crate) source_address: Address,
+    pub(crate) source_pubkey: FixedBytes<48>,
+    pub(crate) target_pubkey: FixedBytes<48>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct RpcExecutionWitness {
+    #[serde(default)]
+    pub(crate) state: Vec<Bytes>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub(crate) keys: Vec<Bytes>,
+    #[serde(default)]
+    pub(crate) codes: Vec<Bytes>,
+    #[serde(default)]
+    pub(crate) headers: Vec<Bytes>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ElBlock {
+    pub(crate) hash: B256,
+    pub(crate) number: u64,
+    pub(crate) timestamp: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ElBlockRpc {
+    hash: B256,
+    #[serde(deserialize_with = "de_u64")]
+    number: u64,
+    #[serde(deserialize_with = "de_u64")]
+    timestamp: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BeaconGenesis {
+    pub(crate) genesis_time: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BeaconGenesisResponse {
+    data: BeaconGenesisData,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BeaconGenesisData {
+    #[serde(deserialize_with = "de_u64")]
+    genesis_time: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BeaconSpec {
+    pub(crate) seconds_per_slot: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BeaconSpecResponse {
+    data: BeaconSpecData,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BeaconSpecData {
+    #[serde(rename = "SECONDS_PER_SLOT", deserialize_with = "de_u64")]
+    seconds_per_slot: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcRequest<'a> {
+    jsonrpc: &'static str,
+    id: u64,
+    method: &'a str,
+    params: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcResponse<T> {
+    result: Option<T>,
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcError {
+    code: i64,
+    message: String,
+}
+
+impl RpcClient {
+    pub(crate) const fn new(config: NetworkWitnessConfig, http: Client) -> Self {
+        Self { config, http }
+    }
+
+    pub(crate) async fn execution_payload_envelope(
+        &self,
+        block_id: &str,
+    ) -> anyhow::Result<ExecutionPayloadEnvelope> {
+        let url = format!(
+            "{}/eth/v1/beacon/execution_payload_envelope/{}",
+            trim_endpoint(&self.config.cl_endpoint),
+            block_id,
+        );
+        let response: ExecutionPayloadEnvelopeResponse = self
+            .send_get_with_headers(&url, &self.config.cl_headers)
+            .await
+            .with_context(|| format!("failed to fetch execution payload envelope `{block_id}`"))?;
+        Ok(response.data.message)
+    }
+
+    pub(crate) async fn beacon_genesis(&self) -> anyhow::Result<BeaconGenesis> {
+        let url = format!(
+            "{}/eth/v1/beacon/genesis",
+            trim_endpoint(&self.config.cl_endpoint)
+        );
+        let response: BeaconGenesisResponse = self
+            .send_get_with_headers(&url, &self.config.cl_headers)
+            .await
+            .context("failed to fetch CL genesis")?;
+        Ok(BeaconGenesis {
+            genesis_time: response.data.genesis_time,
+        })
+    }
+
+    pub(crate) async fn beacon_spec(&self) -> anyhow::Result<BeaconSpec> {
+        let url = format!(
+            "{}/eth/v1/config/spec",
+            trim_endpoint(&self.config.cl_endpoint)
+        );
+        let response: BeaconSpecResponse = self
+            .send_get_with_headers(&url, &self.config.cl_headers)
+            .await
+            .context("failed to fetch CL spec")?;
+        Ok(BeaconSpec {
+            seconds_per_slot: response.data.seconds_per_slot,
+        })
+    }
+
+    pub(crate) async fn debug_execution_witness_by_block_hash(
+        &self,
+        block_hash: B256,
+    ) -> anyhow::Result<RpcExecutionWitness> {
+        self.el_rpc(
+            "debug_executionWitnessByBlockHash",
+            json!([block_hash.to_string()]),
+        )
+        .await
+    }
+
+    pub(crate) async fn eth_chain_id(&self) -> anyhow::Result<u64> {
+        let chain_id: String = self.el_rpc("eth_chainId", json!([])).await?;
+        parse_u64(&chain_id).context("failed to parse eth_chainId")
+    }
+
+    pub(crate) async fn eth_block_by_number(&self, number: u64) -> anyhow::Result<ElBlock> {
+        let result: Option<ElBlockRpc> = self
+            .el_rpc("eth_getBlockByNumber", json!([hex_quantity(number), false]))
+            .await?;
+        let block = result.with_context(|| format!("EL block #{number} not found"))?;
+        Ok(ElBlock {
+            hash: block.hash,
+            number: block.number,
+            timestamp: block.timestamp,
+        })
+    }
+
+    async fn el_rpc<T>(&self, method: &str, params: Value) -> anyhow::Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0",
+            id: 1,
+            method,
+            params,
+        };
+        let url = trim_endpoint(&self.config.el_endpoint).to_owned();
+        let builder = self.http.post(url).json(&request);
+        let response: JsonRpcResponse<T> = apply_headers(builder, &self.config.el_headers)?
+            .send()
+            .await
+            .with_context(|| format!("JSON-RPC method `{method}` failed"))?
+            .error_for_status()
+            .with_context(|| format!("JSON-RPC method `{method}` returned HTTP error"))?
+            .json()
+            .await
+            .with_context(|| format!("failed to decode JSON-RPC response for `{method}`"))?;
+
+        if let Some(error) = response.error {
+            bail!(
+                "JSON-RPC method `{method}` returned error {}: {}",
+                error.code,
+                error.message
+            );
+        }
+        response
+            .result
+            .with_context(|| format!("JSON-RPC method `{method}` returned no result"))
+    }
+
+    async fn send_get_with_headers<T>(
+        &self,
+        url: &str,
+        headers: &[(String, String)],
+    ) -> anyhow::Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let builder = self.http.get(url);
+        apply_headers(builder, headers)?
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .context("failed to decode JSON response")
+    }
+}
+
+fn apply_headers(
+    mut builder: RequestBuilder,
+    headers: &[(String, String)],
+) -> anyhow::Result<RequestBuilder> {
+    for (name, value) in headers {
+        let name = HeaderName::from_bytes(name.as_bytes())
+            .with_context(|| format!("invalid HTTP header name `{name}`"))?;
+        let value = HeaderValue::from_str(value)
+            .with_context(|| format!("invalid value for HTTP header `{name}`"))?;
+        builder = builder.header(name, value);
+    }
+    Ok(builder)
+}
+
+fn trim_endpoint(endpoint: &str) -> &str {
+    endpoint.trim_end_matches('/')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_execution_requests_with_mixed_quantities() {
+        let json = serde_json::json!({
+            "deposits": [{
+                "pubkey": format!("0x{}", "11".repeat(48)),
+                "withdrawal_credentials": format!("0x{}", "22".repeat(32)),
+                "amount": "32000000000",
+                "signature": format!("0x{}", "33".repeat(96)),
+                "index": "0x2a"
+            }],
+            "withdrawals": [{
+                "source_address": format!("0x{}", "44".repeat(20)),
+                "validator_pubkey": format!("0x{}", "55".repeat(48)),
+                "amount": "0x01"
+            }],
+            "consolidations": [{
+                "source_address": format!("0x{}", "66".repeat(20)),
+                "source_pubkey": format!("0x{}", "77".repeat(48)),
+                "target_pubkey": format!("0x{}", "88".repeat(48))
+            }]
+        });
+
+        let parsed: ExecutionRequestsJson = serde_json::from_value(json).unwrap();
+
+        assert_eq!(parsed.deposits[0].amount, 32_000_000_000);
+        assert_eq!(parsed.deposits[0].index, 42);
+        assert_eq!(parsed.withdrawals[0].amount, 1);
+        assert_eq!(parsed.consolidations.len(), 1);
+    }
+
+    #[test]
+    fn parses_execution_payload_envelope_with_amsterdam_fields() {
+        let response = serde_json::json!({
+            "version": "gloas",
+            "execution_optimistic": false,
+            "finalized": false,
+            "data": {
+                "message": {
+                    "payload": {
+                        "parent_hash": format!("0x{}", "01".repeat(32)),
+                        "fee_recipient": format!("0x{}", "02".repeat(20)),
+                        "state_root": format!("0x{}", "03".repeat(32)),
+                        "receipts_root": format!("0x{}", "04".repeat(32)),
+                        "logs_bloom": format!("0x{}", "00".repeat(256)),
+                        "prev_randao": format!("0x{}", "05".repeat(32)),
+                        "block_number": "11",
+                        "gas_limit": "30000000",
+                        "gas_used": "21000",
+                        "timestamp": "1000",
+                        "extra_data": "0x",
+                        "base_fee_per_gas": "0x7",
+                        "block_hash": format!("0x{}", "06".repeat(32)),
+                        "transactions": [],
+                        "withdrawals": [],
+                        "blob_gas_used": "0",
+                        "excess_blob_gas": "0",
+                        "block_access_list": "0xc0",
+                        "slot_number": "64"
+                    },
+                    "execution_requests": {},
+                    "builder_index": "0",
+                    "beacon_block_root": format!("0x{}", "bb".repeat(32)),
+                    "parent_beacon_block_root": format!("0x{}", "aa".repeat(32))
+                }
+            }
+        });
+
+        let parsed: ExecutionPayloadEnvelopeResponse = serde_json::from_value(response).unwrap();
+
+        assert_eq!(parsed.data.message.payload.block_number, 11);
+        assert_eq!(parsed.data.message.payload.slot_number, 64);
+        assert_eq!(
+            parsed.data.message.parent_beacon_block_root,
+            B256::repeat_byte(0xaa)
+        );
+    }
+}

--- a/crates/witness-generator-spec-cli/src/schema.rs
+++ b/crates/witness-generator-spec-cli/src/schema.rs
@@ -1,0 +1,162 @@
+//! Minimal canonical Amsterdam stateless input SSZ schema.
+
+use libssz_derive::{SszDecode, SszEncode};
+use libssz_types::SszList;
+use stateless_validator_common::new_payload_request::NewPayloadRequestAmsterdam;
+
+/// Canonical stateless input schema id.
+pub(crate) const STATELESS_INPUT_SCHEMA_ID: u16 = 0x0001;
+/// Big-endian schema id prefix bytes.
+pub(crate) const STATELESS_INPUT_SCHEMA_ID_BYTES: [u8; 2] = STATELESS_INPUT_SCHEMA_ID.to_be_bytes();
+
+pub(crate) const MAX_WITNESS_NODES: usize = 1 << 22;
+pub(crate) const MAX_WITNESS_CODES: usize = 1 << 18;
+pub(crate) const MAX_WITNESS_HEADERS: usize = 256;
+pub(crate) const MAX_BYTES_PER_WITNESS_NODE: usize = 1 << 10;
+pub(crate) const MAX_BYTES_PER_CODE: usize = 1 << 16;
+pub(crate) const MAX_BYTES_PER_HEADER: usize = 1 << 10;
+pub(crate) const MAX_OPTIONAL_FORK_ACTIVATION_VALUES: usize = 1;
+pub(crate) const MAX_BLOB_SCHEDULES_PER_FORK: usize = 1;
+pub(crate) const MAX_PUBLIC_KEYS: usize = 1 << 15;
+pub(crate) const PUBLIC_KEY_BYTES: usize = 65;
+
+pub(crate) const AMSTERDAM_PROTOCOL_FORK_INDEX: u64 = 20;
+pub(crate) const AMSTERDAM_BLOB_SCHEDULE_TARGET: u64 = 14;
+pub(crate) const AMSTERDAM_BLOB_SCHEDULE_MAX: u64 = 21;
+pub(crate) const AMSTERDAM_BLOB_BASE_FEE_UPDATE_FRACTION: u64 = 11_684_671;
+
+pub(crate) type WitnessNodes = SszList<SszList<u8, MAX_BYTES_PER_WITNESS_NODE>, MAX_WITNESS_NODES>;
+pub(crate) type WitnessCodes = SszList<SszList<u8, MAX_BYTES_PER_CODE>, MAX_WITNESS_CODES>;
+pub(crate) type WitnessHeaders = SszList<SszList<u8, MAX_BYTES_PER_HEADER>, MAX_WITNESS_HEADERS>;
+pub(crate) type OptionalForkActivationValue = SszList<u64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES>;
+pub(crate) type OptionalBlobSchedule = SszList<SszBlobSchedule, MAX_BLOB_SCHEDULES_PER_FORK>;
+pub(crate) type PublicKeys = SszList<[u8; PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS>;
+
+/// Canonical stateless execution witness.
+#[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode)]
+pub(crate) struct SszExecutionWitness {
+    /// RLP-encoded trie node preimages.
+    pub(crate) state: WitnessNodes,
+    /// Contract bytecode preimages.
+    pub(crate) codes: WitnessCodes,
+    /// RLP-encoded ancestor headers.
+    pub(crate) headers: WitnessHeaders,
+}
+
+/// Canonical optional fork activation values.
+#[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode)]
+pub(crate) struct SszForkActivation {
+    /// Optional activation block number.
+    pub(crate) block_number: OptionalForkActivationValue,
+    /// Optional activation timestamp.
+    pub(crate) timestamp: OptionalForkActivationValue,
+}
+
+/// Canonical blob schedule.
+#[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode)]
+pub(crate) struct SszBlobSchedule {
+    /// Target blob count.
+    pub(crate) target: u64,
+    /// Maximum blob count.
+    pub(crate) max: u64,
+    /// Blob base fee update fraction.
+    pub(crate) base_fee_update_fraction: u64,
+}
+
+/// Canonical active fork config.
+#[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode)]
+pub(crate) struct SszForkConfig {
+    /// Numeric protocol fork index.
+    pub(crate) fork: u64,
+    /// Fork activation details.
+    pub(crate) activation: SszForkActivation,
+    /// Optional blob schedule.
+    pub(crate) blob_schedule: OptionalBlobSchedule,
+}
+
+/// Canonical compact chain config.
+#[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode)]
+pub(crate) struct SszChainConfig {
+    /// Chain id.
+    pub(crate) chain_id: u64,
+    /// Active fork config.
+    pub(crate) active_fork: SszForkConfig,
+}
+
+/// Canonical Amsterdam stateless input.
+#[derive(Debug, Clone, SszEncode, SszDecode)]
+pub(crate) struct SszStatelessInput {
+    /// Amsterdam new-payload request.
+    pub(crate) new_payload_request: NewPayloadRequestAmsterdam,
+    /// Execution witness.
+    pub(crate) witness: SszExecutionWitness,
+    /// Compact chain config.
+    pub(crate) chain_config: SszChainConfig,
+    /// Uncompressed transaction public keys in payload order.
+    pub(crate) public_keys: PublicKeys,
+}
+
+pub(crate) fn amsterdam_chain_config(chain_id: u64) -> anyhow::Result<SszChainConfig> {
+    let activation = SszForkActivation {
+        block_number: OptionalForkActivationValue::try_from(Vec::<u64>::new())
+            .map_err(|err| anyhow::anyhow!("block_number optional list invalid: {err:?}"))?,
+        timestamp: OptionalForkActivationValue::try_from(vec![0])
+            .map_err(|err| anyhow::anyhow!("timestamp optional list invalid: {err:?}"))?,
+    };
+
+    let blob_schedule = OptionalBlobSchedule::try_from(vec![SszBlobSchedule {
+        target: AMSTERDAM_BLOB_SCHEDULE_TARGET,
+        max: AMSTERDAM_BLOB_SCHEDULE_MAX,
+        base_fee_update_fraction: AMSTERDAM_BLOB_BASE_FEE_UPDATE_FRACTION,
+    }])
+    .map_err(|err| anyhow::anyhow!("blob_schedule optional list invalid: {err:?}"))?;
+
+    Ok(SszChainConfig {
+        chain_id,
+        active_fork: SszForkConfig {
+            fork: AMSTERDAM_PROTOCOL_FORK_INDEX,
+            activation,
+            blob_schedule,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use libssz::SszEncode;
+
+    use super::*;
+
+    #[test]
+    fn amsterdam_chain_config_uses_spec_defaults() {
+        let cfg = amsterdam_chain_config(1).unwrap();
+
+        assert_eq!(cfg.chain_id, 1);
+        assert_eq!(cfg.active_fork.fork, AMSTERDAM_PROTOCOL_FORK_INDEX);
+        assert!(cfg.active_fork.activation.block_number.is_empty());
+        assert_eq!(
+            cfg.active_fork.activation.timestamp.first().copied(),
+            Some(0)
+        );
+        let schedule = cfg.active_fork.blob_schedule.first().unwrap();
+        assert_eq!(schedule.target, 14);
+        assert_eq!(schedule.max, 21);
+        assert_eq!(schedule.base_fee_update_fraction, 11_684_671);
+    }
+
+    #[test]
+    fn schema_prefix_is_big_endian() {
+        assert_eq!(STATELESS_INPUT_SCHEMA_ID_BYTES, [0x00, 0x01]);
+        assert_eq!(STATELESS_INPUT_SCHEMA_ID.to_be_bytes(), [0x00, 0x01]);
+    }
+
+    #[test]
+    fn optional_values_have_distinct_encodings() {
+        let absent = OptionalForkActivationValue::try_from(Vec::<u64>::new()).unwrap();
+        let present = OptionalForkActivationValue::try_from(vec![0_u64]).unwrap();
+
+        assert_ne!(absent.to_ssz(), present.to_ssz());
+        assert!(absent.is_empty());
+        assert_eq!(present.len(), 1);
+    }
+}

--- a/crates/witness-generator-spec-cli/src/serde_helpers.rs
+++ b/crates/witness-generator-spec-cli/src/serde_helpers.rs
@@ -1,0 +1,119 @@
+//! Serde helpers for Beacon API and JSON-RPC quantity fields.
+
+use std::{fmt, str::FromStr};
+
+use alloy_primitives::U256;
+use serde::de::{self, Visitor};
+
+pub(crate) fn de_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserializer.deserialize_any(U64Visitor)
+}
+
+pub(crate) fn de_u256<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserializer.deserialize_any(U256Visitor)
+}
+
+struct U64Visitor;
+
+impl Visitor<'_> for U64Visitor {
+    type Value = u64;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a decimal or 0x-prefixed u64")
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(value)
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        parse_u64(value).map_err(E::custom)
+    }
+}
+
+struct U256Visitor;
+
+impl Visitor<'_> for U256Visitor {
+    type Value = U256;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a decimal or 0x-prefixed uint256")
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(U256::from(value))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        parse_u256(value).map_err(E::custom)
+    }
+}
+
+pub(crate) fn parse_u64(value: &str) -> anyhow::Result<u64> {
+    let value = value.trim();
+    if let Some(hex) = value.strip_prefix("0x") {
+        return Ok(u64::from_str_radix(hex, 16)?);
+    }
+    Ok(value.parse()?)
+}
+
+pub(crate) fn parse_u256(value: &str) -> anyhow::Result<U256> {
+    let value = value.trim();
+    if let Some(hex) = value.strip_prefix("0x") {
+        return Ok(U256::from_str_radix(hex, 16)?);
+    }
+    Ok(U256::from_str(value)?)
+}
+
+pub(crate) fn hex_quantity(value: u64) -> String {
+    format!("0x{value:x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct U64Value {
+        #[serde(deserialize_with = "de_u64")]
+        value: u64,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct U256Value {
+        #[serde(deserialize_with = "de_u256")]
+        value: U256,
+    }
+
+    #[test]
+    fn parses_decimal_and_hex_u64() {
+        let decimal: U64Value = serde_json::from_str(r#"{"value":"42"}"#).unwrap();
+        let hex: U64Value = serde_json::from_str(r#"{"value":"0x2a"}"#).unwrap();
+
+        assert_eq!(decimal.value, 42);
+        assert_eq!(hex.value, 42);
+    }
+
+    #[test]
+    fn parses_decimal_and_hex_u256() {
+        let decimal: U256Value = serde_json::from_str(r#"{"value":"42"}"#).unwrap();
+        let hex: U256Value = serde_json::from_str(r#"{"value":"0x2a"}"#).unwrap();
+
+        assert_eq!(decimal.value, U256::from(42));
+        assert_eq!(hex.value, U256::from(42));
+    }
+}


### PR DESCRIPTION
This PR adds a new experimental `witness-generator-spec-cli` which builds guest program input for live networks using the spec format.

Notes:
- I created it separately from `witness-generator{-cli}` stuff to not mix existing stuff. I think at some point they can be merged, or probably replace the old one, since ideally we should stop using the old format. 
- We leverage as many structs from `stateless-validator-common` as possible. Still, some were missing and have now been added in `schema.rs`. Not sure where this will live eventually -- we could move the `schema.rs` stuff to `ere-guests` eventually so both `workload` and `zkboost` can leverage them as a neutral definition of things.
- It now uses both a CL and an EL RPC, compared to the previous EL-only RPC. 

Regarding the last bullet, I think my goal is to have super-simple code for stateless input generation. Using EL-only RPC means having to do some gymnastics that we already suffered in `ere-guests` reg having to re-execute statelessly to get some fields (e.g. `requests`).

I think I would prefer to avoid all those complex things for two reasons:
- For now, only stateless Reth provides those generated results. I think we should avoid as much as possible, depending on ELs in particular, for our tooling. EL and CL RPC are neutral; we can switch to different implementations, and they have a spec. 
- Avoid re-executing the block to generate inputs.

The current implementation is super simple, mainly does JSON-RPC calls, which usually 1:1 map into our neutral structs, the only exceptions are:
- `StatelessInputs.public_keys`, since it is a field invented for stateless guests and not part of RPCs
- The `versioned_hashes` aren't part of CL RPC. From what I've seen, kzg blobs commitments aren't part of CL RPC in Gloas, which looks a bit surprising to me. I would like to dig a bit more into whether there was a reason for this, since in Osaka RPC I think they were returned.

For both cases, we deserialise the RLP transactions and derive both things, which is quite simple anyway.

Next steps are I'm waiting for `glamsterdam-devnet-4` to be healthy, and would like to test this out in that devnet. If this works correctly, we could incorporate this experiment more into `workload` to generate live network spec guest inputs for live networks (prob only Glamsterdam devnets).