### PR TITLE
feat: update ere and ere-guests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11420,6 +11420,7 @@ dependencies = [
  "ef-tests",
  "erased-serde",
  "flate2",
+ "futures",
  "http",
  "jsonrpsee",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,7 @@ dependencies = [
  "strum 0.26.3",
  "tar",
  "tempfile",
+ "tokio",
  "toml 0.8.23",
  "tracing",
  "walkdir",
@@ -2522,8 +2523,8 @@ dependencies = [
 
 [[package]]
 name = "downloader"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.12.1#06d48bb7239d65c63e72e68451c1510adf577a92"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -2750,8 +2751,8 @@ dependencies = [
 
 [[package]]
 name = "ere-catalog"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-util-build",
  "serde",
@@ -2760,8 +2761,8 @@ dependencies = [
 
 [[package]]
 name = "ere-cluster-client-zisk"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "bincode 2.0.1",
  "ere-compiler-core",
@@ -2775,25 +2776,26 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-prost",
+ "tracing",
 ]
 
 [[package]]
 name = "ere-codec"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-compiler-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ere-dockerized"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "anyhow",
  "ere-catalog",
@@ -2823,13 +2825,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-prover-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -2845,8 +2847,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-api"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "prost",
  "serde",
@@ -2855,8 +2857,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-client"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "bincode 2.0.1",
  "ere-prover-core",
@@ -2867,24 +2869,24 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "cargo_metadata 0.19.2",
 ]
 
 [[package]]
 name = "ere-util-tokio"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "ere-verifier-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "auto_impl",
  "ere-codec",
@@ -2893,8 +2895,8 @@ dependencies = [
 
 [[package]]
 name = "ere-verifier-zisk"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "bincode 2.0.1",
  "bytemuck",
@@ -2946,8 +2948,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -2968,8 +2970,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2983,10 +2985,10 @@ dependencies = [
  "indexmap 2.14.0",
  "lazy_static",
  "libc",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "lru",
  "once_cell",
  "rkyv",
@@ -3000,8 +3002,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3024,8 +3026,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3035,10 +3037,10 @@ dependencies = [
  "ethrex-rlp",
  "ethrex-vm",
  "hex",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "rkyv",
  "serde",
  "serde_with",
@@ -3047,8 +3049,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3065,8 +3067,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -3082,8 +3084,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -3098,8 +3100,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3140,8 +3142,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3150,8 +3152,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3189,8 +3191,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3211,8 +3213,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3230,8 +3232,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=b112f94748a222e78b642406155674df9e180ee4#b112f94748a222e78b642406155674df9e180ee4"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -3701,8 +3703,8 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.12.1#06d48bb7239d65c63e72e68451c1510adf577a92"
 dependencies = [
  "ere-codec",
  "ere-platform-core",
@@ -4380,8 +4382,8 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.12.1#06d48bb7239d65c63e72e68451c1510adf577a92"
 dependencies = [
  "alloy-primitives",
  "ere-dockerized",
@@ -4929,29 +4931,18 @@ dependencies = [
 [[package]]
 name = "libssz"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "libssz-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4965,13 +4956,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssz-merkle"
-version = "0.2.1"
+name = "libssz-derive"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4979,28 +4971,38 @@ name = "libssz-merkle"
 version = "0.2.1"
 source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
+dependencies = [
+ "libssz 0.2.2",
  "sha2",
 ]
 
 [[package]]
 name = "libssz-types"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.1",
+ "libssz-merkle 0.2.1",
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "smallvec",
 ]
 
@@ -9435,18 +9437,18 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.12.1#06d48bb7239d65c63e72e68451c1510adf577a92"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
  "anyhow",
  "ere-codec",
  "ere-platform-core",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-derive 0.2.2",
+ "libssz-merkle 0.2.2",
+ "libssz-types 0.2.2",
  "serde",
  "serde_with",
  "sha2",
@@ -9454,21 +9456,22 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator-ethrex"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.12.1#06d48bb7239d65c63e72e68451c1510adf577a92"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-rlp",
  "anyhow",
+ "ere-util-build",
  "ethrex-common",
  "ethrex-crypto",
  "ethrex-guest-program",
  "ethrex-rpc",
  "guest",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "rkyv",
  "stateless",
  "stateless-validator-common",
@@ -9477,8 +9480,8 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator-reth"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.11.0#91735556bb1bdd6a16c3bcecee46ef14078846d0"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere-guests?tag=v0.12.1#06d48bb7239d65c63e72e68451c1510adf577a92"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9489,6 +9492,7 @@ dependencies = [
  "anyhow",
  "bincode 2.0.1",
  "ere-prover-core",
+ "ere-util-build",
  "guest",
  "once_cell",
  "reth-chainspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ serde_derive = "*"
 jsonrpsee = "0.26.0"
 anyhow = "1.0"
 async-trait = "0.1.88"
+futures = "0.3.32"
 tokio = { version = "1.45.1" }
 tokio-util = "0.7.15"
 tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,17 +104,17 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 
 # ere
-ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
-ere-cluster-client-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
-ere-util-tokio = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
+ere-cluster-client-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
+ere-util-tokio = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
 
 # ere-guests
-ere-guests-stateless-validator-reth = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "stateless-validator-reth" }
-ere-guests-stateless-validator-ethrex = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "stateless-validator-ethrex" }
+ere-guests-stateless-validator-reth = { git = "https://github.com/eth-act/ere-guests", tag = "v0.12.1", package = "stateless-validator-reth" }
+ere-guests-stateless-validator-ethrex = { git = "https://github.com/eth-act/ere-guests", tag = "v0.12.1", package = "stateless-validator-ethrex" }
 stateless-validator-zilkworm = { git = "https://github.com/erigontech/zilkworm", tag = "v0.1.0-alpha.2-ere", package = "z6m_stateless_validator", features = ["download"] }
-ere-guests-guest = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "guest" }
-ere-guests-integration-tests = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "integration-tests" }
-ere-guests-downloader = { git = "https://github.com/eth-act/ere-guests", tag = "v0.11.0", package = "downloader" }
+ere-guests-guest = { git = "https://github.com/eth-act/ere-guests", tag = "v0.12.1", package = "guest" }
+ere-guests-integration-tests = { git = "https://github.com/eth-act/ere-guests", tag = "v0.12.1", package = "integration-tests" }
+ere-guests-downloader = { git = "https://github.com/eth-act/ere-guests", tag = "v0.12.1", package = "downloader" }
 
 reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.1.0" }
 reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.1.0" }

--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -13,6 +13,7 @@ ere-util-tokio.workspace = true
 
 rayon.workspace = true
 tracing.workspace = true
+tokio = { workspace = true, features = ["time"] }
 walkdir.workspace = true
 sha2.workspace = true
 serde.workspace = true

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -10,10 +10,10 @@ use ere_dockerized::{
 use ere_guests_downloader::{CompiledGuest, Downloader};
 use ere_util_tokio::block_on;
 use rayon::iter::{ParallelBridge, ParallelIterator};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{any::Any, env, panic};
-use std::{fs, thread::sleep};
 use tokio::time::Instant;
 use tracing::{info, warn};
 
@@ -376,14 +376,6 @@ fn process_input(zkvm: &ZkVMInstance, io: impl GuestFixture, config: &RunConfig)
 
     info!("Saving report {}", fixture_name);
     report.to_path(out_path)?;
-
-    // Sleep 10 seconds for the cluster to fully recover if the proving fails
-    // due to some worker connection dropped (usually OOM killed).
-    if matches!(zkvm, ZkVMInstance::ZiskClusterClient { .. }) && report.proving.is_some_and(
-        |proving| matches!(proving, ProvingMetrics::Crashed(info) if info.reason.contains("connection dropped")),
-    ) {
-        sleep(Duration::from_secs(10));
-    }
 
     Ok(())
 }

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -10,9 +10,11 @@ use ere_dockerized::{
 use ere_guests_downloader::{CompiledGuest, Downloader};
 use ere_util_tokio::block_on;
 use rayon::iter::{ParallelBridge, ParallelIterator};
-use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use std::{any::Any, env, panic};
+use std::{fs, thread::sleep};
+use tokio::time::Instant;
 use tracing::{info, warn};
 
 use zkevm_metrics::{BenchmarkRun, CrashInfo, ExecutionMetrics, HardwareInfo, ProvingMetrics};
@@ -42,6 +44,9 @@ pub enum ZkVMInstance {
     ZiskClusterClient {
         /// gRPC client connected to the remote Zisk cluster.
         client: ZiskClusterClient,
+        /// Per-request prove deadline cap, propagated from the
+        /// `DockerizedzkVMConfig` prove timeout. `None` means no cap.
+        prove_timeout: Duration,
         /// ELF of Zisk guest with feature `cycle-scope` enabled.
         /// `Some` only if the guest is a Zisk guest.
         profiling_elf: Option<Elf>,
@@ -98,8 +103,13 @@ impl ZkVMInstance {
     ) -> Result<(PublicValues, EncodedProof, ProgramProvingReport)> {
         match self {
             Self::Dockerized { zkvm, .. } => zkvm.prove(input),
-            Self::ZiskClusterClient { client, .. } => {
-                let (proof, proving_time) = block_on(client.prove(input, None))?;
+            Self::ZiskClusterClient {
+                client,
+                prove_timeout,
+                ..
+            } => {
+                let deadline = Instant::now() + *prove_timeout;
+                let (proof, proving_time) = block_on(client.prove(input, deadline))?;
                 let (_, public_values) = proof.program_vk_and_public_values()?;
                 let proof = proof.encode_to_vec()?;
                 Ok((
@@ -367,6 +377,14 @@ fn process_input(zkvm: &ZkVMInstance, io: impl GuestFixture, config: &RunConfig)
     info!("Saving report {}", fixture_name);
     report.to_path(out_path)?;
 
+    // Sleep 10 seconds for the cluster to fully recover if the proving fails
+    // due to some worker connection dropped (usually OOM killed).
+    if matches!(zkvm, ZkVMInstance::ZiskClusterClient { .. }) && report.proving.is_some_and(
+        |proving| matches!(proving, ProvingMetrics::Crashed(info) if info.reason.contains("connection dropped")),
+    ) {
+        sleep(Duration::from_secs(10));
+    }
+
     Ok(())
 }
 
@@ -417,11 +435,14 @@ pub async fn get_guest_zkvm_instances(
                 }
             }
             ProverResource::Cluster(cfg) if *zkvm == zkVMKind::Zisk => {
+                const DEFAULT_PROVE_TIMEOUT: Duration = Duration::from_mins(3);
+
                 let client = ZiskClusterClient::new(cfg, Elf(compiled.elf.clone()))
                     .await
                     .map_err(|e| anyhow!("Failed to connect to Zisk cluster: {e}"))?;
                 ZkVMInstance::ZiskClusterClient {
                     client,
+                    prove_timeout: zkvm_config.prove_timeout.unwrap_or(DEFAULT_PROVE_TIMEOUT),
                     profiling_elf: compiled.profiling_elf.map(Elf),
                 }
             }

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -44,8 +44,8 @@ pub enum ZkVMInstance {
     ZiskClusterClient {
         /// gRPC client connected to the remote Zisk cluster.
         client: ZiskClusterClient,
-        /// Per-request prove deadline cap, propagated from the
-        /// `DockerizedzkVMConfig` prove timeout. `None` means no cap.
+        /// Per-request prove timeout, propagated from the `DockerizedzkVMConfig`
+        /// prove timeout. Defaults to 3 minutes.
         prove_timeout: Duration,
         /// ELF of Zisk guest with feature `cycle-scope` enabled.
         /// `Some` only if the guest is a Zisk guest.

--- a/crates/witness-generator-cli/src/main.rs
+++ b/crates/witness-generator-cli/src/main.rs
@@ -82,7 +82,7 @@ enum SourceCommand {
         #[arg(long, value_name = "PATH")]
         genesis: Option<PathBuf>,
 
-        /// Maximum number of blocks and witnesses fetched concurrently
+        /// Maximum number of blocks fetched concurrently while catching up, only applies to `--follow`
         #[arg(long, default_value_t = 1)]
         max_concurrency: usize,
     },

--- a/crates/witness-generator-cli/src/main.rs
+++ b/crates/witness-generator-cli/src/main.rs
@@ -81,6 +81,10 @@ enum SourceCommand {
         /// Optional path to a geth-style genesis.json file for custom/devnet chain config
         #[arg(long, value_name = "PATH")]
         genesis: Option<PathBuf>,
+
+        /// Maximum number of blocks and witnesses fetched concurrently
+        #[arg(long, default_value_t = 1)]
+        max_concurrency: usize,
     },
 }
 
@@ -153,8 +157,10 @@ async fn build_generator(source: SourceCommand) -> Result<Box<dyn FixtureGenerat
             rpc_header,
             genesis,
             follow: listen,
+            max_concurrency,
         } => {
-            let mut builder = RpcBlocksAndWitnessesBuilder::new(rpc_url);
+            let mut builder =
+                RpcBlocksAndWitnessesBuilder::new(rpc_url).max_concurrency(max_concurrency);
 
             if let Some(rpc_header) = rpc_header {
                 let headers = RpcFlatHeaderKeyValues::new(rpc_header)

--- a/crates/witness-generator/Cargo.toml
+++ b/crates/witness-generator/Cargo.toml
@@ -22,6 +22,7 @@ serde.workspace = true
 serde_json.workspace = true
 erased-serde.workspace = true
 async-trait.workspace = true
+futures.workspace = true
 jsonrpsee.workspace = true
 http = "1.0"
 thiserror.workspace = true

--- a/crates/witness-generator/src/rpc_generator.rs
+++ b/crates/witness-generator/src/rpc_generator.rs
@@ -5,6 +5,7 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_genesis::{ChainConfig, Genesis};
 use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction, TransactionRequest};
 use async_trait::async_trait;
+use futures::stream::{StreamExt, TryStreamExt, iter};
 use http::{HeaderName, HeaderValue};
 use jsonrpsee::{
     http_client::{HeaderMap, HttpClient, HttpClientBuilder},
@@ -17,6 +18,7 @@ use stateless::StatelessInput;
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
+    time::{Duration, Instant},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -29,6 +31,7 @@ pub struct RpcBlocksAndWitnessesBuilder {
     block: Option<u64>,
     stop: Option<CancellationToken>,
     genesis: Option<PathBuf>,
+    max_concurrency: Option<usize>,
 }
 
 impl RpcBlocksAndWitnessesBuilder {
@@ -85,6 +88,15 @@ impl RpcBlocksAndWitnessesBuilder {
     /// * `block` - The block number to fetch
     pub const fn block(mut self, block: u64) -> Self {
         self.block = Some(block);
+        self
+    }
+
+    /// Sets the maximum number of blocks and witnesses fetched concurrently.
+    ///
+    /// # Arguments
+    /// * `max_concurrency` - Maximum number of in-flight block and witness fetches. Defaults to 1 (sequential).
+    pub const fn max_concurrency(mut self, max_concurrency: usize) -> Self {
+        self.max_concurrency = Some(max_concurrency);
         self
     }
 
@@ -157,6 +169,7 @@ impl RpcBlocksAndWitnessesBuilder {
             last_n_blocks: self.last_n_blocks,
             block: self.block,
             stop: self.stop,
+            max_concurrency: self.max_concurrency.unwrap_or(1).max(1),
         })
     }
 }
@@ -169,6 +182,7 @@ pub struct RpcFixtureGenerator {
     last_n_blocks: Option<usize>,
     block: Option<u64>,
     stop: Option<CancellationToken>,
+    max_concurrency: usize,
 }
 
 #[async_trait]
@@ -209,6 +223,37 @@ impl FixtureGenerator for RpcFixtureGenerator {
 }
 
 impl RpcFixtureGenerator {
+    /// Fetches a block by number or tag.
+    ///
+    /// # Arguments
+    /// * `number` - The block number or tag to fetch
+    /// * `full` - Whether to include full transaction bodies
+    ///
+    /// # Errors
+    /// Returns an error if the RPC call fails or if the block cannot be found.
+    async fn fetch_block_by_number(
+        &self,
+        number: BlockNumberOrTag,
+        full: bool,
+    ) -> Result<Block<TransactionSigned>> {
+        EthApiClient::<
+            TransactionRequest,
+            Transaction,
+            Block<TransactionSigned>,
+            Receipt,
+            Header,
+            TransactionSigned,
+        >::block_by_number(&self.client, number, full)
+        .await
+        .map_err(|e| WGError::RpcError(e.to_string()))?
+        .ok_or(
+            number
+                .as_number()
+                .map(WGError::BlockNotFoundForNumber)
+                .unwrap_or(WGError::LatestBlockFetchError),
+        )
+    }
+
     /// Fetches the last N blocks and their execution witnesses.
     ///
     /// # Arguments
@@ -221,43 +266,24 @@ impl RpcFixtureGenerator {
             return Ok(vec![]);
         }
 
-        let latest_block = EthApiClient::<
-            TransactionRequest,
-            Transaction,
-            Block,
-            Receipt,
-            Header,
-            TransactionSigned,
-        >::block_by_number(&self.client, BlockNumberOrTag::Latest, false)
-        .await
-        .map_err(|e| WGError::RpcError(e.to_string()))?
-        .ok_or(WGError::LatestBlockFetchError)?;
+        let latest_block = self
+            .fetch_block_by_number(BlockNumberOrTag::Latest, false)
+            .await?;
 
         let (block_num_start, block_num_end) = (
-            std::cmp::max(0, latest_block.header.number - (last_n_blocks as u64 - 1)),
+            latest_block
+                .header
+                .number
+                .saturating_sub(last_n_blocks as u64 - 1),
             latest_block.header.number,
         );
 
-        let mut hashes = Vec::with_capacity(last_n_blocks);
-        hashes.push((latest_block.header.number, latest_block.header.hash));
-        for n in (block_num_start..block_num_end).rev() {
-            let block_hash = hashes.last().unwrap().1;
-            let block = EthApiClient::<
-                TransactionRequest,
-                Transaction,
-                Block,
-                Receipt,
-                Header,
-                TransactionSigned,
-            >::block_by_hash(&self.client, block_hash, true)
-            .await
-            .map_err(|e| WGError::RpcError(e.to_string()))?
-            .ok_or(WGError::BlockNotFoundForNumber(n))?;
-            hashes.push((n, block.header.parent_hash));
-        }
-
-        let mut blocks_and_witnesses = Vec::with_capacity(hashes.len());
-        for (block_num, block_hash) in hashes {
+        let mut blocks: Vec<Block<TransactionSigned>> = Vec::with_capacity(last_n_blocks);
+        for n in (block_num_start..=block_num_end).rev() {
+            let block_hash = blocks
+                .last()
+                .map(|block| block.header.parent_hash)
+                .unwrap_or_else(|| latest_block.header.hash);
             let block = EthApiClient::<
                 TransactionRequest,
                 Transaction,
@@ -268,28 +294,34 @@ impl RpcFixtureGenerator {
             >::block_by_hash(&self.client, block_hash, true)
             .await
             .map_err(|e| WGError::RpcError(e.to_string()))?
-            .ok_or(WGError::BlockNotFoundForHash(block_hash.to_string()))?;
-
-            let witness = DebugApiClient::<()>::debug_execution_witness_by_block_hash(
-                &self.client,
-                block_hash,
-                None,
-            )
-            .await
-            .map_err(|e| WGError::RpcError(e.to_string()))?;
-
-            let bw = Box::new(StatelessValidationFixture {
-                name: format!("rpc_block_{block_num}"),
-                stateless_input: StatelessInput {
-                    block: block.into_consensus(),
-                    witness,
-                    chain_config: self.chain_config.clone(),
-                },
-                success: true,
-            }) as Box<dyn Fixture>;
-
-            blocks_and_witnesses.push(bw);
+            .ok_or(WGError::BlockNotFoundForNumber(n))?;
+            blocks.push(block);
         }
+
+        // Fetch up to `max_concurrency` block and witness pairs at a time.
+        let blocks_and_witnesses = iter(blocks)
+            .map(|block| async move {
+                let witness = DebugApiClient::<()>::debug_execution_witness_by_block_hash(
+                    &self.client,
+                    block.header.hash,
+                    None,
+                )
+                .await
+                .map_err(|e| WGError::RpcError(e.to_string()))?;
+
+                Ok::<_, WGError>(Box::new(StatelessValidationFixture {
+                    name: format!("rpc_block_{}", block.header.number),
+                    stateless_input: StatelessInput {
+                        block: block.into_consensus(),
+                        witness,
+                        chain_config: self.chain_config.clone(),
+                    },
+                    success: true,
+                }) as Box<dyn Fixture>)
+            })
+            .buffered(self.max_concurrency)
+            .try_collect()
+            .await?;
 
         Ok(blocks_and_witnesses)
     }
@@ -312,18 +344,9 @@ impl RpcFixtureGenerator {
         .map_err(|e| WGError::RpcError(e.to_string()))?;
 
         // Fetch the block details
-        let block =
-            EthApiClient::<
-                TransactionRequest,
-                Transaction,
-                Block<TransactionSigned>,
-                Receipt,
-                Header,
-                TransactionSigned,
-            >::block_by_number(&self.client, BlockNumberOrTag::Number(block_num), true)
-            .await
-            .map_err(|e| WGError::RpcError(e.to_string()))?
-            .ok_or(WGError::BlockNotFoundForNumber(block_num))?;
+        let block = self
+            .fetch_block_by_number(BlockNumberOrTag::Number(block_num), true)
+            .await?;
 
         let bw = StatelessValidationFixture {
             name: format!("rpc_block_{block_num}"),
@@ -340,31 +363,44 @@ impl RpcFixtureGenerator {
 
     /// Fetches blocks from a specific block number to the latest block and their execution witnesses.
     ///
+    /// The returned vector is the contiguous prefix of successfully fetched blocks
+    /// starting at `block_num`. On the first fetch failure the method stops and
+    /// returns the blocks gathered so far rather than the full range, so the caller
+    /// can resume from the block after the last returned one. A failure therefore
+    /// yields a shorter `Ok` result rather than an `Err`.
+    ///
     /// # Arguments
     /// * `block_num` - The starting block number to fetch
     ///
     /// # Returns
-    /// A vector of `BlockAndWitness` objects for all blocks in the range
+    /// A vector of `BlockAndWitness` objects forming the contiguous successful
+    /// prefix of the requested range
     ///
     /// # Errors
     ///
-    /// Returns an error if any RPC call fails or if blocks cannot be found.
+    /// Returns an error only if the latest block number cannot be resolved.
     async fn fetch_from_block(&self, block_num: u64) -> Result<Vec<Box<dyn Fixture>>> {
-        let latest_block = EthApiClient::<
-            TransactionRequest,
-            Transaction,
-            Block,
-            Receipt,
-            Header,
-            TransactionSigned,
-        >::block_by_number(&self.client, BlockNumberOrTag::Latest, false)
-        .await
-        .map_err(|e| WGError::RpcError(e.to_string()))?
-        .ok_or(WGError::LatestBlockFetchError)?;
+        let latest_block_num = self
+            .fetch_block_by_number(BlockNumberOrTag::Latest, false)
+            .await?
+            .header
+            .number;
+
+        // Fetch up to `max_concurrency` blocks at a time, returning the contiguous
+        // prefix of successes so the caller can resume from the first gap.
+        let mut stream = iter(block_num..=latest_block_num)
+            .map(|n| self.fetch_specific_block(n))
+            .buffered(self.max_concurrency);
 
         let mut bws = Vec::new();
-        for n in block_num..=latest_block.header.number {
-            bws.push(self.fetch_specific_block(n).await?);
+        while let Some(res) = stream.next().await {
+            match res {
+                Ok(bw) => bws.push(bw),
+                Err(err) => {
+                    error!("Error fetching block: {err}");
+                    break;
+                }
+            }
         }
 
         Ok(bws)
@@ -387,17 +423,9 @@ impl RpcFixtureGenerator {
     /// Returns an error if the cancellation token is not set, if RPC calls fail,
     /// or if file writing fails.
     async fn fetch_live(&self, path: &Path) -> Result<usize> {
-        let latest_block = EthApiClient::<
-            TransactionRequest,
-            Transaction,
-            Block,
-            Receipt,
-            Header,
-            TransactionSigned,
-        >::block_by_number(&self.client, BlockNumberOrTag::Latest, false)
-        .await
-        .map_err(|e| WGError::RpcError(e.to_string()))?
-        .ok_or(WGError::LatestBlockFetchError)?;
+        let latest_block = self
+            .fetch_block_by_number(BlockNumberOrTag::Latest, false)
+            .await?;
 
         let mut count: usize = 0;
         let mut next_block_num = latest_block.header.number;
@@ -407,7 +435,11 @@ impl RpcFixtureGenerator {
             .stop
             .as_ref()
             .ok_or(WGError::CancellationTokenRequired)?;
+
+        const MIN_LOOP_INTERVAL: Duration = Duration::from_secs(6);
         loop {
+            let iter_start = Instant::now();
+
             tokio::select! {
                 _ = stop_signal.cancelled() => {
                     info!("Stopped listening for new blocks.");
@@ -433,12 +465,15 @@ impl RpcFixtureGenerator {
                 }
             }
 
-            tokio::select! {
-                _ = stop_signal.cancelled() => {
-                    info!("Stopped listening for new blocks.");
-                    break;
-                }
-                _ = tokio::time::sleep(std::time::Duration::from_secs(6)) => {
+            // Throttle the remaining time up to the minimum interval.
+            let remaining = MIN_LOOP_INTERVAL.saturating_sub(iter_start.elapsed());
+            if !remaining.is_zero() {
+                tokio::select! {
+                    _ = stop_signal.cancelled() => {
+                        info!("Stopped listening for new blocks.");
+                        break;
+                    }
+                    _ = tokio::time::sleep(remaining) => {}
                 }
             }
         }

--- a/crates/witness-generator/src/rpc_generator.rs
+++ b/crates/witness-generator/src/rpc_generator.rs
@@ -5,7 +5,7 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_genesis::{ChainConfig, Genesis};
 use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction, TransactionRequest};
 use async_trait::async_trait;
-use futures::stream::{StreamExt, TryStreamExt, iter};
+use futures::stream::StreamExt;
 use http::{HeaderName, HeaderValue};
 use jsonrpsee::{
     http_client::{HeaderMap, HttpClient, HttpClientBuilder},
@@ -91,7 +91,7 @@ impl RpcBlocksAndWitnessesBuilder {
         self
     }
 
-    /// Sets the maximum number of blocks and witnesses fetched concurrently.
+    /// Sets the maximum number of blocks and witnesses fetched concurrently while catching up.
     ///
     /// # Arguments
     /// * `max_concurrency` - Maximum number of in-flight block and witness fetches. Defaults to 1 (sequential).
@@ -246,12 +246,12 @@ impl RpcFixtureGenerator {
         >::block_by_number(&self.client, number, full)
         .await
         .map_err(|e| WGError::RpcError(e.to_string()))?
-        .ok_or(
+        .ok_or_else(|| {
             number
                 .as_number()
                 .map(WGError::BlockNotFoundForNumber)
-                .unwrap_or(WGError::LatestBlockFetchError),
-        )
+                .unwrap_or(WGError::LatestBlockFetchError)
+        })
     }
 
     /// Fetches the last N blocks and their execution witnesses.
@@ -267,7 +267,7 @@ impl RpcFixtureGenerator {
         }
 
         let latest_block = self
-            .fetch_block_by_number(BlockNumberOrTag::Latest, false)
+            .fetch_block_by_number(BlockNumberOrTag::Latest, true)
             .await?;
 
         let (block_num_start, block_num_end) = (
@@ -278,12 +278,10 @@ impl RpcFixtureGenerator {
             latest_block.header.number,
         );
 
-        let mut blocks: Vec<Block<TransactionSigned>> = Vec::with_capacity(last_n_blocks);
-        for n in (block_num_start..=block_num_end).rev() {
-            let block_hash = blocks
-                .last()
-                .map(|block| block.header.parent_hash)
-                .unwrap_or_else(|| latest_block.header.hash);
+        let mut blocks = Vec::with_capacity(last_n_blocks);
+        blocks.push(latest_block);
+        for _ in (block_num_start..block_num_end).rev() {
+            let block_hash = blocks.last().unwrap().header.parent_hash;
             let block = EthApiClient::<
                 TransactionRequest,
                 Transaction,
@@ -294,34 +292,34 @@ impl RpcFixtureGenerator {
             >::block_by_hash(&self.client, block_hash, true)
             .await
             .map_err(|e| WGError::RpcError(e.to_string()))?
-            .ok_or(WGError::BlockNotFoundForNumber(n))?;
+            .ok_or(WGError::BlockNotFoundForHash(block_hash.to_string()))?;
             blocks.push(block);
         }
 
-        // Fetch up to `max_concurrency` block and witness pairs at a time.
-        let blocks_and_witnesses = iter(blocks)
-            .map(|block| async move {
-                let witness = DebugApiClient::<()>::debug_execution_witness_by_block_hash(
-                    &self.client,
-                    block.header.hash,
-                    None,
-                )
-                .await
-                .map_err(|e| WGError::RpcError(e.to_string()))?;
+        let mut blocks_and_witnesses = Vec::with_capacity(blocks.len());
+        for block in blocks {
+            let block_hash = block.header.hash;
+            let block_num = block.header.number;
+            let witness = DebugApiClient::<()>::debug_execution_witness_by_block_hash(
+                &self.client,
+                block_hash,
+                None,
+            )
+            .await
+            .map_err(|e| WGError::RpcError(e.to_string()))?;
 
-                Ok::<_, WGError>(Box::new(StatelessValidationFixture {
-                    name: format!("rpc_block_{}", block.header.number),
-                    stateless_input: StatelessInput {
-                        block: block.into_consensus(),
-                        witness,
-                        chain_config: self.chain_config.clone(),
-                    },
-                    success: true,
-                }) as Box<dyn Fixture>)
-            })
-            .buffered(self.max_concurrency)
-            .try_collect()
-            .await?;
+            let bw = Box::new(StatelessValidationFixture {
+                name: format!("rpc_block_{block_num}"),
+                stateless_input: StatelessInput {
+                    block: block.into_consensus(),
+                    witness,
+                    chain_config: self.chain_config.clone(),
+                },
+                success: true,
+            }) as Box<dyn Fixture>;
+
+            blocks_and_witnesses.push(bw);
+        }
 
         Ok(blocks_and_witnesses)
     }
@@ -380,24 +378,22 @@ impl RpcFixtureGenerator {
     ///
     /// Returns an error only if the latest block number cannot be resolved.
     async fn fetch_from_block(&self, block_num: u64) -> Result<Vec<Box<dyn Fixture>>> {
-        let latest_block_num = self
+        let latest_block = self
             .fetch_block_by_number(BlockNumberOrTag::Latest, false)
-            .await?
-            .header
-            .number;
+            .await?;
 
         // Fetch up to `max_concurrency` blocks at a time, returning the contiguous
         // prefix of successes so the caller can resume from the first gap.
-        let mut stream = iter(block_num..=latest_block_num)
-            .map(|n| self.fetch_specific_block(n))
+        let mut stream = futures::stream::iter(block_num..=latest_block.header.number)
+            .map(|n| async move { (n, self.fetch_specific_block(n).await) })
             .buffered(self.max_concurrency);
 
         let mut bws = Vec::new();
-        while let Some(res) = stream.next().await {
-            match res {
+        while let Some((n, result)) = stream.next().await {
+            match result {
                 Ok(bw) => bws.push(bw),
                 Err(err) => {
-                    error!("Error fetching block: {err}");
+                    error!("Fetch block {n} failed: {err}");
                     break;
                 }
             }


### PR DESCRIPTION
- Bump `ere` to `v0.12.1`
- Bump `ere-guests` to `v0.12.1`
- Add flag `--max-concurrency` to `witness-generator-cli rpc` subcommand to download live block concurrently to not fall behind the chain (default to 1 as the original behavior)
