### PR TITLE
feat: add --guest-artifact-base-url as workaround and zesu support

### DIFF
--- a/crates/benchmark-runner/src/guest_programs.rs
+++ b/crates/benchmark-runner/src/guest_programs.rs
@@ -1,6 +1,6 @@
 //! Guest program input generation and metadata types
 
-use ere_dockerized::Input;
+use ere_dockerized::{zkVMKind, Input};
 use ere_guests_guest::codec::Encode;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -20,6 +20,14 @@ pub trait GuestFixture: Sync + Send {
 
     /// Returns the expected public values of guest program fixture.
     fn expected_public_values(&self) -> anyhow::Result<Vec<u8>>;
+
+    /// Returns the expected public values normalized for the selected zkVM.
+    fn expected_public_values_for_zkvm(&self, zkvm_kind: zkVMKind) -> anyhow::Result<Vec<u8>> {
+        Ok(normalize_expected_public_values(
+            zkvm_kind,
+            self.expected_public_values()?,
+        ))
+    }
 
     /// Verifies that the provided `public_values` match the expected output.
     fn verify_public_values(&self, public_values: &[u8]) -> anyhow::Result<OutputVerifierResult> {
@@ -112,4 +120,21 @@ pub enum OutputVerifierResult {
     Match,
     /// Output does not match the expected result
     Mismatch(String),
+}
+
+fn normalize_expected_public_values(
+    zkvm_kind: zkVMKind,
+    mut expected_public_values: Vec<u8>,
+) -> Vec<u8> {
+    if matches!(zkvm_kind, zkVMKind::Airbender | zkVMKind::OpenVM)
+        && expected_public_values.len() < 32
+    {
+        expected_public_values.resize(32, 0);
+    }
+
+    if matches!(zkvm_kind, zkVMKind::Zisk) && expected_public_values.len() < 256 {
+        expected_public_values.resize(256, 0);
+    }
+
+    expected_public_values
 }

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -30,6 +30,32 @@ const ERE_GUESTS_DOWNLOAD_KIND: &str = env!("ERE_GUESTS_DOWNLOAD_KIND");
 /// Tag or commit SHA matching [`ERE_GUESTS_DOWNLOAD_KIND`].
 const ERE_GUESTS_DOWNLOAD_VALUE: &str = env!("ERE_GUESTS_DOWNLOAD_VALUE");
 
+/// Source used to resolve compiled guest programs.
+#[derive(Debug, Clone)]
+pub enum GuestProgramSource {
+    /// Resolve guest programs from the configured ere-guests dependency.
+    Default,
+    /// Resolve guest programs from a local directory.
+    LocalPath(PathBuf),
+    /// Resolve guest programs from a remote base URL.
+    ArtifactBaseUrl(String),
+}
+
+impl GuestProgramSource {
+    /// Returns a stable label for externally supplied guest artifacts.
+    pub fn version_label(&self) -> Option<String> {
+        match self {
+            Self::Default => None,
+            Self::LocalPath(path) => path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .filter(|name| !name.is_empty())
+                .map(std::string::ToString::to_string),
+            Self::ArtifactBaseUrl(url) => artifact_base_url_label(url),
+        }
+    }
+}
+
 /// A zkVM instance bundled with ELF bytes (used for profiling).
 pub enum ZkVMInstance {
     /// Dockerized zkVM instance
@@ -394,10 +420,17 @@ pub async fn get_el_zkvm_instances(
     zkvms: &[zkVMKind],
     resource: ProverResource,
     zkvm_config: DockerizedzkVMConfig,
-    bin_path: Option<&Path>,
+    guest_source: &GuestProgramSource,
 ) -> Result<Vec<ZkVMInstance>> {
     let guest_name_prefix = format!("stateless-validator-{el}");
-    get_guest_zkvm_instances(&guest_name_prefix, zkvms, resource, zkvm_config, bin_path).await
+    get_guest_zkvm_instances(
+        &guest_name_prefix,
+        zkvms,
+        resource,
+        zkvm_config,
+        guest_source,
+    )
+    .await
 }
 
 /// Creates the requested guest program zkVMs ere instances.
@@ -406,12 +439,12 @@ pub async fn get_guest_zkvm_instances(
     zkvms: &[zkVMKind],
     resource: ProverResource,
     zkvm_config: DockerizedzkVMConfig,
-    bin_path: Option<&Path>,
+    guest_source: &GuestProgramSource,
 ) -> Result<Vec<ZkVMInstance>> {
     let mut instances = Vec::new();
     for zkvm in zkvms {
         let guest_name = format!("{}-{}", guest_name_prefix, zkvm.as_str());
-        let compiled = load_compiled(&guest_name, bin_path).await?;
+        let compiled = load_compiled(&guest_name, guest_source).await?;
         let instance = match &resource {
             ProverResource::Cpu | ProverResource::Gpu => {
                 let zkvm = DockerizedzkVM::new(
@@ -448,8 +481,11 @@ pub async fn get_guest_zkvm_instances(
     Ok(instances)
 }
 
-async fn load_compiled(guest_name: &str, bin_path: Option<&Path>) -> Result<CompiledGuest> {
-    if let Some(path) = bin_path {
+async fn load_compiled(
+    guest_name: &str,
+    guest_source: &GuestProgramSource,
+) -> Result<CompiledGuest> {
+    if let GuestProgramSource::LocalPath(path) = guest_source {
         let elf = fs::read(path.join(format!("{guest_name}.elf")))
             .with_context(|| format!("Failed to read ELF from path: {}", path.display()))?;
         let program_vk = fs::read(path.join(format!("{guest_name}.vk")))
@@ -460,6 +496,10 @@ async fn load_compiled(guest_name: &str, bin_path: Option<&Path>) -> Result<Comp
             program_vk,
             profiling_elf,
         });
+    }
+
+    if let GuestProgramSource::ArtifactBaseUrl(base_url) = guest_source {
+        return load_compiled_from_artifact_base_url(guest_name, base_url).await;
     }
 
     if guest_name.starts_with("stateless-validator-zilkworm") {
@@ -540,6 +580,87 @@ async fn guest_downloader() -> Result<Downloader> {
     }
 }
 
+async fn load_compiled_from_artifact_base_url(
+    guest_name: &str,
+    base_url: &str,
+) -> Result<CompiledGuest> {
+    let client = reqwest::Client::new();
+    let elf_url = guest_artifact_url(base_url, &format!("{guest_name}.elf"));
+    let vk_url = guest_artifact_url(base_url, &format!("{guest_name}.vk"));
+    let profiling_url = guest_artifact_url(base_url, &format!("{guest_name}-profiling.elf"));
+
+    info!("Downloading guest program from {elf_url}");
+    let elf = download_required_artifact(&client, &elf_url).await?;
+    let program_vk = download_optional_artifact(&client, &vk_url)
+        .await?
+        .unwrap_or_default();
+    let profiling_elf = download_optional_artifact(&client, &profiling_url).await?;
+
+    Ok(CompiledGuest {
+        elf,
+        program_vk,
+        profiling_elf,
+    })
+}
+
+async fn download_required_artifact(client: &reqwest::Client, url: &str) -> Result<Vec<u8>> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("Failed to download required guest artifact from {url}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        bail!("Failed to download required guest artifact from {url}: HTTP {status}");
+    }
+    Ok(response
+        .bytes()
+        .await
+        .with_context(|| format!("Failed to read required guest artifact from {url}"))?
+        .to_vec())
+}
+
+async fn download_optional_artifact(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<Option<Vec<u8>>> {
+    let response = match client.get(url).send().await {
+        Ok(response) => response,
+        Err(err) => {
+            warn!("Skipping optional guest artifact {url}: {err}");
+            return Ok(None);
+        }
+    };
+    let status = response.status();
+    if !status.is_success() {
+        info!("Skipping optional guest artifact {url}: HTTP {status}");
+        return Ok(None);
+    }
+    Ok(Some(
+        response
+            .bytes()
+            .await
+            .with_context(|| format!("Failed to read optional guest artifact from {url}"))?
+            .to_vec(),
+    ))
+}
+
+fn guest_artifact_url(base_url: &str, filename: &str) -> String {
+    format!("{}/{}", base_url.trim_end_matches('/'), filename)
+}
+
+fn artifact_base_url_label(base_url: &str) -> Option<String> {
+    base_url
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(base_url)
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|label| !label.is_empty())
+        .map(std::string::ToString::to_string)
+}
+
 /// Dumps the raw input bytes to disk
 fn dump_input(
     input: &[u8],
@@ -590,8 +711,7 @@ fn public_output_matched(
     io: &impl GuestFixture,
     public_values: &[u8],
 ) -> Result<bool> {
-    let expected_public_values =
-        normalize_expected_public_values(zkvm_kind, io.expected_public_values()?);
+    let expected_public_values = io.expected_public_values_for_zkvm(zkvm_kind)?;
 
     if expected_public_values == public_values {
         Ok(true)
@@ -604,23 +724,6 @@ fn public_output_matched(
         );
         Ok(false)
     }
-}
-
-fn normalize_expected_public_values(
-    zkvm_kind: zkVMKind,
-    mut expected_public_values: Vec<u8>,
-) -> Vec<u8> {
-    if matches!(zkvm_kind, zkVMKind::Airbender | zkVMKind::OpenVM)
-        && expected_public_values.len() < 32
-    {
-        expected_public_values.resize(32, 0);
-    }
-
-    if matches!(zkvm_kind, zkVMKind::Zisk) && expected_public_values.len() < 256 {
-        expected_public_values.resize(256, 0);
-    }
-
-    expected_public_values
 }
 
 #[cfg(test)]
@@ -656,6 +759,30 @@ mod tests {
 
         fn expected_public_values(&self) -> Result<Vec<u8>> {
             Ok(self.expected_public_values.clone())
+        }
+    }
+
+    struct ExactFixture(Fixture);
+
+    impl GuestFixture for ExactFixture {
+        fn name(&self) -> String {
+            self.0.name()
+        }
+
+        fn metadata(&self) -> serde_json::Value {
+            self.0.metadata()
+        }
+
+        fn input(&self) -> Result<Input> {
+            self.0.input()
+        }
+
+        fn expected_public_values(&self) -> Result<Vec<u8>> {
+            self.0.expected_public_values()
+        }
+
+        fn expected_public_values_for_zkvm(&self, _zkvm_kind: zkVMKind) -> Result<Vec<u8>> {
+            self.expected_public_values()
         }
     }
 
@@ -709,5 +836,135 @@ mod tests {
         )?);
 
         Ok(())
+    }
+
+    #[test]
+    fn public_output_matched_can_skip_zkvm_padding_normalization() -> Result<()> {
+        let fixture = ExactFixture(Fixture::new(vec![0xab]));
+        let mut zisk_public_values = vec![0xab];
+        zisk_public_values.resize(256, 0);
+
+        assert!(public_output_matched(zkVMKind::Zisk, &fixture, &[0xab])?);
+        assert!(!public_output_matched(
+            zkVMKind::Zisk,
+            &fixture,
+            &zisk_public_values,
+        )?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn guest_artifact_url_joins_base_and_filename() {
+        assert_eq!(
+            guest_artifact_url(
+                "https://github.com/Consensys/zesu-zkvm/releases/download/bal-devnet-7-2026-06-12/",
+                "stateless-validator-zesu-zisk.elf",
+            ),
+            "https://github.com/Consensys/zesu-zkvm/releases/download/bal-devnet-7-2026-06-12/stateless-validator-zesu-zisk.elf"
+        );
+    }
+
+    #[test]
+    fn artifact_base_url_label_uses_last_path_segment() {
+        assert_eq!(
+            artifact_base_url_label(
+                "https://github.com/Consensys/zesu-zkvm/releases/download/bal-devnet-7-2026-06-12/"
+            )
+            .as_deref(),
+            Some("bal-devnet-7-2026-06-12")
+        );
+    }
+
+    #[test]
+    fn url_artifact_loader_requires_elf_but_not_vk_or_profiling_elf() -> Result<()> {
+        let server = TestServer::spawn(|path| {
+            (path == "/stateless-validator-zesu-zisk.elf").then(|| Vec::from("elf-bytes"))
+        });
+
+        let compiled = block_on(load_compiled(
+            "stateless-validator-zesu-zisk",
+            &GuestProgramSource::ArtifactBaseUrl(server.base_url()),
+        ))?;
+
+        assert_eq!(compiled.elf, b"elf-bytes");
+        assert!(compiled.program_vk.is_empty());
+        assert!(compiled.profiling_elf.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn url_artifact_loader_fails_when_elf_is_missing() {
+        let server = TestServer::spawn(|_| None);
+
+        let err = block_on(load_compiled(
+            "stateless-validator-zesu-zisk",
+            &GuestProgramSource::ArtifactBaseUrl(server.base_url()),
+        ))
+        .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("stateless-validator-zesu-zisk.elf"));
+    }
+
+    struct TestServer {
+        base_url: String,
+    }
+
+    impl TestServer {
+        fn spawn<F>(handler: F) -> Self
+        where
+            F: Fn(&str) -> Option<Vec<u8>> + Send + Sync + 'static,
+        {
+            use std::{
+                io::{Read, Write},
+                net::TcpListener,
+                sync::Arc,
+                thread,
+            };
+
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let base_url = format!("http://{}", listener.local_addr().unwrap());
+            let handler = Arc::new(handler);
+
+            thread::spawn(move || {
+                for stream in listener.incoming().take(3) {
+                    let Ok(mut stream) = stream else {
+                        continue;
+                    };
+                    let mut request = [0_u8; 1024];
+                    let Ok(read) = stream.read(&mut request) else {
+                        continue;
+                    };
+                    let request = String::from_utf8_lossy(&request[..read]);
+                    let path = request
+                        .lines()
+                        .next()
+                        .and_then(|line| line.split_whitespace().nth(1))
+                        .unwrap_or("/");
+
+                    if let Some(body) = handler(path) {
+                        let response = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            body.len()
+                        );
+                        let _ = stream.write_all(response.as_bytes());
+                        let _ = stream.write_all(&body);
+                    } else {
+                        let _ = stream.write_all(
+                            b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        );
+                    }
+                }
+            });
+
+            Self { base_url }
+        }
+
+        fn base_url(&self) -> String {
+            self.base_url.clone()
+        }
     }
 }

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -762,30 +762,6 @@ mod tests {
         }
     }
 
-    struct ExactFixture(Fixture);
-
-    impl GuestFixture for ExactFixture {
-        fn name(&self) -> String {
-            self.0.name()
-        }
-
-        fn metadata(&self) -> serde_json::Value {
-            self.0.metadata()
-        }
-
-        fn input(&self) -> Result<Input> {
-            self.0.input()
-        }
-
-        fn expected_public_values(&self) -> Result<Vec<u8>> {
-            self.0.expected_public_values()
-        }
-
-        fn expected_public_values_for_zkvm(&self, _zkvm_kind: zkVMKind) -> Result<Vec<u8>> {
-            self.expected_public_values()
-        }
-    }
-
     #[test]
     fn public_output_matched_returns_true_for_matching_values() -> Result<()> {
         let fixture = Fixture::new(vec![1, 2, 3]);
@@ -839,13 +815,13 @@ mod tests {
     }
 
     #[test]
-    fn public_output_matched_can_skip_zkvm_padding_normalization() -> Result<()> {
-        let fixture = ExactFixture(Fixture::new(vec![0xab]));
+    fn public_output_matched_requires_zisk_padding_normalization() -> Result<()> {
+        let fixture = Fixture::new(vec![0xab]);
         let mut zisk_public_values = vec![0xab];
         zisk_public_values.resize(256, 0);
 
-        assert!(public_output_matched(zkVMKind::Zisk, &fixture, &[0xab])?);
-        assert!(!public_output_matched(
+        assert!(!public_output_matched(zkVMKind::Zisk, &fixture, &[0xab])?);
+        assert!(public_output_matched(
             zkVMKind::Zisk,
             &fixture,
             &zisk_public_values,

--- a/crates/benchmark-runner/src/stateless_validator.rs
+++ b/crates/benchmark-runner/src/stateless_validator.rs
@@ -22,6 +22,8 @@ pub enum ExecutionClient {
     Ethrex,
     /// Zilkworm stateless block validation guest program.
     Zilkworm,
+    /// Zesu stateless block validation guest program.
+    Zesu,
 }
 
 /// Extra information about the block being benchmarked
@@ -39,6 +41,7 @@ impl ExecutionClient {
             Self::Reth => env!("RETH_EL_VERSION"),
             Self::Ethrex => env!("ETHREX_EL_VERSION"),
             Self::Zilkworm => env!("ZILKWORM_EL_VERSION"),
+            Self::Zesu => "unknown", // TODO: Temporary until gets republished through ere-guests and remove --guest-artifact-base-url new-ish flag.
         }
     }
 }

--- a/crates/benchmark-runner/src/stateless_validator/fixtures.rs
+++ b/crates/benchmark-runner/src/stateless_validator/fixtures.rs
@@ -149,7 +149,7 @@ where
     I: Iterator<Item = PathBuf>,
 {
     paths.flat_map(move |path| {
-        let results: Vec<_> = match load_benchmark_fixtures(&path, &input_root) {
+        let results: Vec<_> = match load_benchmark_fixtures(&path, &input_root, el) {
             Ok(fixtures) => fixtures
                 .into_iter()
                 .filter(|fixture| fixture_matches_prefixes(fixture, fixture_prefixes.as_deref()))
@@ -183,12 +183,21 @@ fn fixture_matches_prefixes(fixture: &BenchmarkFixture, prefixes: Option<&[Strin
     })
 }
 
-fn load_benchmark_fixtures(path: &Path, input_root: &Path) -> Result<Vec<BenchmarkFixture>> {
+fn load_benchmark_fixtures(
+    path: &Path,
+    input_root: &Path,
+    el: ExecutionClient,
+) -> Result<Vec<BenchmarkFixture>> {
     let content = std::fs::read(path)?;
     let value: serde_json::Value = serde_json::from_slice(&content)
         .with_context(|| format!("Failed to parse {}", path.display()))?;
 
     if value.get("stateless_input").is_some() {
+        if matches!(el, ExecutionClient::Zesu) {
+            bail!(
+                "Zesu supports only EEST blockchain_tests fixtures with statelessInputBytes/statelessOutputBytes"
+            );
+        }
         let fixture = serde_json::from_value(value)
             .with_context(|| format!("Failed to parse legacy fixture {}", path.display()))?;
         return Ok(vec![BenchmarkFixture::Legacy(Box::new(fixture))]);
@@ -270,7 +279,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let fixture_path = dir.path().join("mcopy.json");
         fs::write(&fixture_path, sample_eest_fixture())?;
-        let fixtures = load_benchmark_fixtures(&fixture_path, dir.path())?;
+        let fixtures = load_benchmark_fixtures(&fixture_path, dir.path(), ExecutionClient::Reth)?;
         let fixture = fixtures
             .iter()
             .find(|fixture| {

--- a/crates/benchmark-runner/src/stateless_validator/inputs.rs
+++ b/crates/benchmark-runner/src/stateless_validator/inputs.rs
@@ -5,7 +5,7 @@ use crate::{
     },
 };
 use anyhow::{bail, Context, Result};
-use ere_dockerized::{zkVMKind, Input};
+use ere_dockerized::Input;
 use ere_guests_guest::Guest;
 use ere_guests_integration_tests::NoopPlatform;
 use ere_guests_stateless_validator_ethrex::{
@@ -92,40 +92,7 @@ fn raw_eest_input_from_fixture(
         metadata,
     };
 
-    Ok(match expected_output {
-        EestExpectedOutput::Sha256 => fixture.into_boxed(),
-        EestExpectedOutput::Raw => Box::new(ExactPublicValuesFixture { fixture }),
-    })
-}
-
-#[derive(Debug)]
-struct ExactPublicValuesFixture<M> {
-    fixture: GenericGuestFixture<M>,
-}
-
-impl<M> GuestFixture for ExactPublicValuesFixture<M>
-where
-    M: 'static + Send + Sync + Serialize,
-{
-    fn name(&self) -> String {
-        self.fixture.name()
-    }
-
-    fn metadata(&self) -> serde_json::Value {
-        self.fixture.metadata()
-    }
-
-    fn input(&self) -> Result<Input> {
-        self.fixture.input()
-    }
-
-    fn expected_public_values(&self) -> Result<Vec<u8>> {
-        self.fixture.expected_public_values()
-    }
-
-    fn expected_public_values_for_zkvm(&self, _zkvm_kind: zkVMKind) -> Result<Vec<u8>> {
-        self.expected_public_values()
-    }
+    Ok(fixture.into_boxed())
 }
 
 fn ethrex_input_from_fixture(fixture: StatelessValidationFixture) -> Result<Box<dyn GuestFixture>> {

--- a/crates/benchmark-runner/src/stateless_validator/inputs.rs
+++ b/crates/benchmark-runner/src/stateless_validator/inputs.rs
@@ -5,7 +5,7 @@ use crate::{
     },
 };
 use anyhow::{bail, Context, Result};
-use ere_dockerized::Input;
+use ere_dockerized::{zkVMKind, Input};
 use ere_guests_guest::Guest;
 use ere_guests_integration_tests::NoopPlatform;
 use ere_guests_stateless_validator_ethrex::{
@@ -42,9 +42,17 @@ pub(crate) fn stateless_validator_input_from_fixture(
             ExecutionClient::Reth => reth_input_from_fixture(*fixture),
             ExecutionClient::Ethrex => ethrex_input_from_fixture(*fixture),
             ExecutionClient::Zilkworm => zilkworm_input_from_fixture(*fixture),
+            ExecutionClient::Zesu => {
+                bail!(
+                    "Zesu supports only EEST blockchain_tests fixtures with statelessInputBytes/statelessOutputBytes"
+                )
+            }
         },
         BenchmarkFixture::Eest(fixture) => match el {
-            ExecutionClient::Reth | ExecutionClient::Ethrex => raw_eest_input_from_fixture(fixture),
+            ExecutionClient::Reth | ExecutionClient::Ethrex => {
+                raw_eest_input_from_fixture(fixture, EestExpectedOutput::Sha256)
+            }
+            ExecutionClient::Zesu => raw_eest_input_from_fixture(fixture, EestExpectedOutput::Raw),
             ExecutionClient::Zilkworm => {
                 bail!("EEST fixture format not yet supported for Zilkworm")
             }
@@ -52,7 +60,16 @@ pub(crate) fn stateless_validator_input_from_fixture(
     }
 }
 
-fn raw_eest_input_from_fixture(fixture: EestStatelessFixture) -> Result<Box<dyn GuestFixture>> {
+#[derive(Debug, Clone, Copy)]
+enum EestExpectedOutput {
+    Sha256,
+    Raw,
+}
+
+fn raw_eest_input_from_fixture(
+    fixture: EestStatelessFixture,
+    expected_output: EestExpectedOutput,
+) -> Result<Box<dyn GuestFixture>> {
     let metadata = EestBlockMetadata {
         fixture_format: "eest",
         original_test_name: fixture.original_test_name,
@@ -63,15 +80,52 @@ fn raw_eest_input_from_fixture(fixture: EestStatelessFixture) -> Result<Box<dyn 
         block_number: fixture.block_number,
         block_used_gas: fixture.block_used_gas,
     };
-    let expected_public_values = Sha256::digest(fixture.stateless_output_bytes).to_vec();
+    let expected_public_values = match expected_output {
+        EestExpectedOutput::Sha256 => Sha256::digest(fixture.stateless_output_bytes).to_vec(),
+        EestExpectedOutput::Raw => fixture.stateless_output_bytes,
+    };
 
-    Ok(GenericGuestFixture::<EestBlockMetadata> {
+    let fixture = GenericGuestFixture::<EestBlockMetadata> {
         name: fixture.name,
         input: Input::new().with_stdin(fixture.stateless_input_bytes),
         expected_public_values,
         metadata,
+    };
+
+    Ok(match expected_output {
+        EestExpectedOutput::Sha256 => fixture.into_boxed(),
+        EestExpectedOutput::Raw => Box::new(ExactPublicValuesFixture { fixture }),
+    })
+}
+
+#[derive(Debug)]
+struct ExactPublicValuesFixture<M> {
+    fixture: GenericGuestFixture<M>,
+}
+
+impl<M> GuestFixture for ExactPublicValuesFixture<M>
+where
+    M: 'static + Send + Sync + Serialize,
+{
+    fn name(&self) -> String {
+        self.fixture.name()
     }
-    .into_boxed())
+
+    fn metadata(&self) -> serde_json::Value {
+        self.fixture.metadata()
+    }
+
+    fn input(&self) -> Result<Input> {
+        self.fixture.input()
+    }
+
+    fn expected_public_values(&self) -> Result<Vec<u8>> {
+        self.fixture.expected_public_values()
+    }
+
+    fn expected_public_values_for_zkvm(&self, _zkvm_kind: zkVMKind) -> Result<Vec<u8>> {
+        self.expected_public_values()
+    }
 }
 
 fn ethrex_input_from_fixture(fixture: StatelessValidationFixture) -> Result<Box<dyn GuestFixture>> {

--- a/crates/ere-hosts/src/cli.rs
+++ b/crates/ere-hosts/src/cli.rs
@@ -63,8 +63,12 @@ pub struct Cli {
 
     /// Base path for pre-compiled guest program binaries. If not set, they will be downloaded
     /// from the resolved ere-guests release or commit artifacts.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "guest_artifact_base_url")]
     pub bin_path: Option<PathBuf>,
+
+    /// Base URL for pre-compiled guest program artifacts.
+    #[arg(long, conflicts_with = "bin_path")]
+    pub guest_artifact_base_url: Option<String>,
 
     /// Timeout for the selected action only, for example `15m`, `5m`, or `2s`.
     #[arg(long, value_name = "DURATION", value_parser = parse_duration)]
@@ -107,6 +111,8 @@ pub enum ExecutionClient {
     Ethrex,
     /// Zilkworm execution client
     Zilkworm,
+    /// Zesu execution client
+    Zesu,
 }
 
 impl ExecutionClient {
@@ -116,6 +122,7 @@ impl ExecutionClient {
             Self::Reth => "stateless-validator/reth",
             Self::Ethrex => "stateless-validator/ethrex",
             Self::Zilkworm => "stateless-validator/zilkworm",
+            Self::Zesu => "stateless-validator/zesu",
         };
         PathBuf::from(path)
     }
@@ -180,6 +187,7 @@ impl From<ExecutionClient> for stateless_validator::ExecutionClient {
             ExecutionClient::Reth => Self::Reth,
             ExecutionClient::Ethrex => Self::Ethrex,
             ExecutionClient::Zilkworm => Self::Zilkworm,
+            ExecutionClient::Zesu => Self::Zesu,
         }
     }
 }

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -6,8 +6,8 @@ use anyhow::{Context, Result, bail};
 use benchmark_runner::{
     empty_program,
     runner::{
-        Action, ProfileConfig, RunConfig, benchmark_output_dir, get_el_zkvm_instances,
-        get_guest_zkvm_instances, run_benchmark_iter,
+        Action, GuestProgramSource, ProfileConfig, RunConfig, benchmark_output_dir,
+        get_el_zkvm_instances, get_guest_zkvm_instances, run_benchmark_iter,
     },
     stateless_validator::{self},
     verification::{download_and_extract_proofs, resolve_extracted_root, run_verify_from_disk},
@@ -97,7 +97,12 @@ async fn main() -> Result<()> {
     } else {
         (None, cli.proofs_folder)
     };
-    let bin_path = cli.bin_path.as_deref();
+    let guest_source = match (cli.bin_path, cli.guest_artifact_base_url) {
+        (Some(path), None) => GuestProgramSource::LocalPath(path),
+        (None, Some(url)) => GuestProgramSource::ArtifactBaseUrl(url),
+        (None, None) => GuestProgramSource::Default,
+        (Some(_), Some(_)) => unreachable!("clap conflicts_with should reject this combination"),
+    };
     let config_base = RunConfig {
         output_folder: cli.output_folder,
         sub_folder: None,
@@ -117,13 +122,21 @@ async fn main() -> Result<()> {
             let el: stateless_validator::ExecutionClient = execution_client.into();
 
             let el_name = el.as_ref().to_lowercase();
-            let el_str = format!("{}-{}", el_name, el.version());
+            // TODO: For Zesu until integrated to ere-guests when removing `--guest-artifact-base-url.yy
+            let el_version = if matches!(el, stateless_validator::ExecutionClient::Zesu) {
+                guest_source
+                    .version_label()
+                    .unwrap_or_else(|| el.version().to_string())
+            } else {
+                el.version().to_string()
+            };
+            let el_str = format!("{}-{}", el_name, el_version);
             let zkvms = get_el_zkvm_instances(
                 &el_name,
                 &cli.zkvms,
                 resource,
                 zkvm_config.clone(),
-                bin_path,
+                &guest_source,
             )
             .await
             .context("Failed to get EL zkvm instances")?;
@@ -166,7 +179,7 @@ async fn main() -> Result<()> {
                 &cli.zkvms,
                 resource,
                 zkvm_config.clone(),
-                bin_path,
+                &guest_source,
             )
             .await
             .context("Failed to get guest zkvm instances")?;


### PR DESCRIPTION
## Description

This PR adds temporary support for loading precompiled guest artifacts from a remote base URL via `--guest-artifact-base-url`. This provides a workaround while the required guest ELFs are not yet available through the normal `ere-guests` publication flow.

It also adds Zesu as a supported stateless-validator execution client. Zesu is wired through the CLI, runner, guest resolution flow, and EEST fixture handling. Since Zesu expects raw `statelessOutputBytes`, this PR adds fixture-level control over public-value normalization so Zesu outputs can be compared exactly, while preserving the existing zkVM padding normalization for other clients.

## Changes

- Add `--guest-artifact-base-url`, mutually exclusive with `--bin-path`.
- Introduce `GuestProgramSource` for default, local path, and remote artifact resolution.
- Download remote guest `.elf` artifacts, with optional `.vk` and profiling ELF support.
- Add `zesu` to stateless-validator execution-client options.
- Support Zesu with EEST `blockchain_tests` fixtures using raw `statelessInputBytes` / `statelessOutputBytes`.
- Reject unsupported Zesu legacy fixtures with a clear error.
- Move expected public-value normalization behind the `GuestFixture` trait so exact-output fixtures can opt out.
- Use the remote artifact URL label as the temporary Zesu version label in benchmark output paths.

## Notes

- Keeping in draft since I haven't tried it yet with https://github.com/eth-act/eest-execution-witness-dashboard, which is main intention.
- I think eventually we'll remove this `--guest-artifact-base-url` new flag when we republish all ELFs/artefacts in `ere-guests`. For now, it is a good workaround to target remote publishes since `--bin-path` is only for local, which is a bit ugly for CIs since they require extra `curl` step or similar. This flag is a bit more compact.
- Maybe part of this PR will be kept reg Zesu outputting raw bytes instead of SHA256 -- we're coming again to the Zisk situation of potential limits etc. For now, we allow workload to support both styles a bit more formally until we fully resolve this thing.
- Left two `// TODO` comments that I think are the only "ugly" part of this PR, mainly related on how Zesu version is extracted, since we can't take it from `Cargo.lock` coming from `ere-guests` (and I think with `--bin-path` was already handwavy, but that's okay since is for debugging I guess).

cc @han0110  mainly for above notes awareness. This relieves some pressure on us for some pending republishing ELFs in ere-guests, although I know it might happen soon; just creating a temp escape hatch here to try things out. As usual, after `ere-guests` mature on things, we nuke things here if not needed. Deleting code is easy :)

Until I try this out with https://github.com/eth-act/eest-execution-witness-dashboard a bit I won't merge since might realize needs some tunning, but gist of it should be stable.