### PR TITLE
fix: comment out schedule section in EEST R2 Stateless Inputs workflow

### DIFF
--- a/.github/workflows/eest-r2-stateless-inputs.yml
+++ b/.github/workflows/eest-r2-stateless-inputs.yml
@@ -18,8 +18,8 @@ on:
         required: false
         default: "10"
         type: string
-  schedule:
-    - cron: "23 */2 * * *"
+  # schedule:
+  #   - cron: "23 */2 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
Pausing the automatic check since realised when trying to do a [first run](https://github.com/eth-act/zkevm-benchmark-workload/actions/runs/29449097312/job/87466899842) something seems to be wrong.

I'll try to check why this fails, and we can reschedule automatically.