### PR TITLE
feat: add opcode_count to eest block metadata

### DIFF
--- a/crates/benchmark-runner/src/stateless_validator/eest.rs
+++ b/crates/benchmark-runner/src/stateless_validator/eest.rs
@@ -18,6 +18,7 @@ pub(crate) struct EestStatelessFixture {
     pub(crate) chain_id: u64,
     pub(crate) block_number: Option<u64>,
     pub(crate) block_used_gas: Option<u64>,
+    pub(crate) opcode_count: BTreeMap<String, u64>,
     pub(crate) stateless_input_bytes: Vec<u8>,
     pub(crate) stateless_output_bytes: Vec<u8>,
 }
@@ -28,11 +29,26 @@ struct EestBlockchainTest {
     network: String,
     config: EestConfig,
     blocks: Vec<EestBlock>,
+    #[serde(default, rename = "_info")]
+    info: EestInfo,
 }
 
 #[derive(Debug, Deserialize)]
 struct EestConfig {
     chainid: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct EestInfo {
+    #[serde(default)]
+    metadata: EestMetadata,
+}
+
+/// EEST writes `_info.metadata` keys in snake case.
+#[derive(Debug, Default, Deserialize)]
+struct EestMetadata {
+    #[serde(default)]
+    opcode_count_per_block: Vec<BTreeMap<String, u64>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -77,6 +93,15 @@ pub(crate) fn load_eest_benchmark_fixtures(
     for (test_name, case) in cases {
         let chain_id = parse_json_u64(&case.config.chainid)
             .with_context(|| format!("Failed to parse chainid for EEST test {test_name}"))?;
+
+        let opcode_count_per_block = case.info.metadata.opcode_count_per_block;
+        if !opcode_count_per_block.is_empty() && opcode_count_per_block.len() != case.blocks.len() {
+            bail!(
+                "EEST test {test_name} has {} opcode_count_per_block entries but {} blocks",
+                opcode_count_per_block.len(),
+                case.blocks.len()
+            );
+        }
 
         for (block_index, block) in case.blocks.into_iter().enumerate() {
             let Some(input_hex) = block.stateless_input_bytes else {
@@ -140,6 +165,10 @@ pub(crate) fn load_eest_benchmark_fixtures(
                 chain_id,
                 block_number,
                 block_used_gas,
+                opcode_count: opcode_count_per_block
+                    .get(block_index)
+                    .cloned()
+                    .unwrap_or_default(),
                 stateless_input_bytes,
                 stateless_output_bytes,
             });
@@ -318,6 +347,16 @@ mod tests {
         assert_eq!(fixture.chain_id, 1);
         assert_eq!(fixture.block_number, Some(1));
         assert_eq!(fixture.block_used_gas, Some(16));
+        assert_eq!(
+            fixture.opcode_count,
+            BTreeMap::from([("PUSH1".to_string(), 5), ("SSTORE".to_string(), 2)])
+        );
+
+        let info_without_per_block = fixtures
+            .iter()
+            .find(|fixture| fixture.original_test_name == "tests/foo.py::test_same[name?a]")
+            .unwrap();
+        assert!(info_without_per_block.opcode_count.is_empty());
 
         Ok(())
     }
@@ -375,6 +414,39 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn eest_opcode_count_per_block_length_must_match_blocks() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let fixture_path = dir.path().join("mismatched-opcode-count.json");
+        fs::write(
+            &fixture_path,
+            r#"{
+                "tests/foo.py::test_mismatch": {
+                    "network": "Amsterdam",
+                    "config": {"chainid": "0x01"},
+                    "blocks": [
+                        {"statelessInputBytes": "0x0102", "statelessOutputBytes": "0xaa"}
+                    ],
+                    "_info": {
+                        "metadata": {
+                            "opcode_count_per_block": [{"PUSH1": 1}, {"PUSH1": 2}]
+                        }
+                    }
+                }
+            }"#,
+        )?;
+
+        let err = load_eest_benchmark_fixtures(
+            serde_json::from_str(&fs::read_to_string(&fixture_path)?)?,
+            &fixture_path,
+            dir.path(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("opcode_count_per_block"));
+
+        Ok(())
+    }
+
     pub(crate) fn sample_eest_fixture() -> &'static str {
         r#"{
             "tests/foo.py::test_same[name/a]": {
@@ -393,7 +465,18 @@ mod tests {
                         "statelessInputBytes": "0x",
                         "statelessOutputBytes": "0xcc"
                     }
-                ]
+                ],
+                "_info": {
+                    "metadata": {
+                        "opcode_count": {"PUSH1": 8, "SSTORE": 2, "MCOPY": 7},
+                        "target_opcode": "MCOPY",
+                        "opcode_count_per_block": [
+                            {"PUSH1": 5, "SSTORE": 2},
+                            {"PUSH1": 3},
+                            {"MCOPY": 7}
+                        ]
+                    }
+                }
             },
             "tests/foo.py::test_same[name?a]": {
                 "network": "Amsterdam",
@@ -405,7 +488,13 @@ mod tests {
                         "blocknumber": "0x03",
                         "blockHeader": {"gasUsed": "0x30"}
                     }
-                ]
+                ],
+                "_info": {
+                    "metadata": {
+                        "opcode_count": {"ADD": 3},
+                        "target_opcode": "ADD"
+                    }
+                }
             }
         }"#
     }

--- a/crates/benchmark-runner/src/stateless_validator/fixtures.rs
+++ b/crates/benchmark-runner/src/stateless_validator/fixtures.rs
@@ -285,6 +285,8 @@ mod tests {
             "tests/foo.py::test_same[name/a]"
         );
         assert_eq!(metadata["block_used_gas"].as_u64(), Some(16));
+        assert_eq!(metadata["opcode_count"]["PUSH1"].as_u64(), Some(5));
+        assert_eq!(metadata["opcode_count"]["SSTORE"].as_u64(), Some(2));
 
         Ok(())
     }
@@ -390,7 +392,12 @@ mod tests {
                         "statelessOutputBytes": "0xaabb",
                         "blockHeader": {"number": "0x01", "gasUsed": "0x10"}
                     }
-                ]
+                ],
+                "_info": {
+                    "metadata": {
+                        "opcode_count_per_block": [{"PUSH1": 5, "SSTORE": 2}]
+                    }
+                }
             },
             "tests/foo.py::test_same[name?a]": {
                 "network": "Amsterdam",

--- a/crates/benchmark-runner/src/stateless_validator/inputs.rs
+++ b/crates/benchmark-runner/src/stateless_validator/inputs.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Context, Result};
 use ere_dockerized::Input;
 use serde::Serialize;
 use stateless_validator_common::guest::input::{ProtocolFork, StatelessInput};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Serialize)]
 struct EestBlockMetadata {
@@ -17,6 +18,7 @@ struct EestBlockMetadata {
     chain_id: u64,
     block_number: Option<u64>,
     block_used_gas: Option<u64>,
+    opcode_count: BTreeMap<String, u64>,
 }
 
 pub(crate) fn stateless_validator_input_from_fixture(
@@ -65,6 +67,7 @@ fn raw_eest_input_from_fixture(fixture: EestStatelessFixture) -> Result<Box<dyn 
         chain_id: fixture.chain_id,
         block_number: fixture.block_number,
         block_used_gas: fixture.block_used_gas,
+        opcode_count: fixture.opcode_count,
     };
     let fixture = GenericGuestFixture::<EestBlockMetadata> {
         name: fixture.name,

--- a/docs/benchmark-execution-inputs.md
+++ b/docs/benchmark-execution-inputs.md
@@ -46,7 +46,17 @@ The only accepted benchmark fixture format is an EEST `blockchain_tests` JSON ob
           "gasUsed": "0x10"
         }
       }
-    ]
+    ],
+    "_info": {
+      "metadata": {
+        "opcode_count_per_block": [
+          {
+            "PUSH1": 5,
+            "SSTORE": 2
+          }
+        ]
+      }
+    }
   }
 }
 ```
@@ -59,6 +69,7 @@ Rules:
 - A block without `statelessInputBytes`, or with empty `statelessInputBytes`, is skipped.
 - A block with non-empty `statelessInputBytes` must also contain `statelessOutputBytes`.
 - Both byte fields are hexadecimal strings with an optional `0x` prefix and an even number of hexadecimal digits after that prefix.
+- `_info.metadata.opcode_count_per_block` holds one opcode-count map per block in block order, so entry N describes `blocks[N]`. A present array whose length differs from the block count is rejected, and an absent array leaves each block's opcode count empty.
 
 Each accepted block becomes one benchmark fixture. Its safe output name is derived from the original EEST test name, block index, and source context; collisions are disambiguated. The original test name remains available for fixture-prefix selection.
 
@@ -86,7 +97,7 @@ A prefix may match either the sanitized fixture name or the original EEST test n
 
 ## Metadata, Existing Outputs, And Public Values
 
-Benchmark metadata preserves the fixture format, original test name, source path, block index, network, chain ID, block number, and gas used. See [Benchmark Execution Output](benchmark-execution-output.md#metadata-by-workload) for the serialized shape.
+Benchmark metadata preserves the fixture format, original test name, source path, block index, network, chain ID, block number, gas used, and the block's opcode count. See [Benchmark Execution Output](benchmark-execution-output.md#metadata-by-workload) for the serialized shape.
 
 Unless `--force-rerun` is set, fixture preparation skips cases whose metrics output already exists. Execution and proving both compare the guest's public values with the fixture's raw `statelessOutputBytes`; proof verification retains the existing stored-proof verification behavior.
 

--- a/docs/benchmark-execution-output.md
+++ b/docs/benchmark-execution-output.md
@@ -66,7 +66,11 @@ A successful execution metrics file has this shape:
     "network": "Amsterdam",
     "chain_id": 1,
     "block_number": 1,
-    "block_used_gas": 16
+    "block_used_gas": 16,
+    "opcode_count": {
+      "PUSH1": 5,
+      "SSTORE": 2
+    }
   },
   "execution": {
     "success": {
@@ -162,11 +166,15 @@ Canonical EEST metadata has this shape:
   "network": "Amsterdam",
   "chain_id": 1,
   "block_number": 1,
-  "block_used_gas": 16
+  "block_used_gas": 16,
+  "opcode_count": {
+    "PUSH1": 5,
+    "SSTORE": 2
+  }
 }
 ```
 
-`block_number` and `block_used_gas` are `null` when the source fixture does not provide those values.
+`block_number` and `block_used_gas` are `null` when the source fixture does not provide those values. `opcode_count` is the per-block opcode tally taken from `_info.metadata.opcode_count_per_block`, and it is `{}` when the source fixture predates that field.
 
 ## Proofs And Verification
 


### PR DESCRIPTION
After https://github.com/ethereum/execution-specs/pull/3183 is merged, I'd expect future `tests-benchmark@vX.Y.Z` or `tests-zkevm-benchmarks@vX.Y.Z` (or local filled fixtures) will contain `_info.metadata.opcode_count_per_block`. This PR includes that info into `EestBlockMetadata` so the `zkevm-metrics` can be used by `evm-gasfit` alone without having access to the benchmark fixtures.