### PR TITLE
Update to tentative ere-guests v0.14

### DIFF
--- a/.github/workflows/eest-r2-stateless-inputs.yml
+++ b/.github/workflows/eest-r2-stateless-inputs.yml
@@ -18,8 +18,8 @@ on:
         required: false
         default: "10"
         type: string
-  # schedule:
-  #   - cron: "23 */2 * * *"
+  schedule:
+    - cron: "23 */2 * * *"
 
 permissions:
   contents: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,8 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=721c59b9e4f640c9e646c0516e5be7142c956a26#721c59b9e4f640c9e646c0516e5be7142c956a26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acde665074b478c97047dc2a461b4916cac77922d690e5b7415d1941ae7ff7bf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4335,7 +4336,8 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb43f4858fef4e3b42b80954d2edf1ff67c8ad7498347083cdc7d0f6eff2f081"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4352,7 +4354,8 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5798ae4d6b264764bc0d742468bd32c7fb515e774645d4930f95ff6311f3ae14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4534,7 +4537,8 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59c928b2865af5bcdbce94800270b7f7798f27a22ca0aabdd2b7d3e6587c9ce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4649,7 +4653,8 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1bd4ae4f54a2ba813eef082910bc646bd31cab8ed134308fa71f1068331fb84"
 dependencies = [
  "zstd",
 ]
@@ -4657,7 +4662,8 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -4675,7 +4681,8 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -4686,7 +4693,8 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -4701,7 +4709,8 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -4715,7 +4724,8 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
 dependencies = [
  "derive_more 2.1.1",
  "either",
@@ -4728,7 +4738,8 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
 dependencies = [
  "auto_impl",
  "either",
@@ -4740,7 +4751,8 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -4757,7 +4769,8 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
 dependencies = [
  "auto_impl",
  "either",
@@ -4772,7 +4785,8 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -4783,7 +4797,8 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4804,7 +4819,8 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -4814,7 +4830,8 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
 dependencies = [
  "alloy-eip7928",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44937ce84d2cbf1ee4010667bd9214bb7db134a91dd9ffa6b1b8b1d6b030449"
+checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
+checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154b0f566ebbfc256b63c8d643c6a299f40a6fcd50a9d756c1d191487dd06483"
+checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -162,9 +162,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
+version = "0.37.1"
+source = "git+https://github.com/alloy-rs/evm?rev=721c59b9e4f640c9e646c0516e5be7142c956a26#721c59b9e4f640c9e646c0516e5be7142c956a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -180,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a930a68a6f0ac19231bc2f5f0bf13fad3a26fa7df2525354890c72366c2998"
+checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -207,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
+checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -248,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -270,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff0a296b58194c7464aa56f2bdad065c5a24b43a6de5d62b8a985ae3969ecd0"
+checksum = "b9e9c1f9ac81c56b2d96901201db7eb95c4e9fc3c21237a4690f8c652aa62089"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -283,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eba59e1c069f168a01982f42a57797736923b76aa854194df4930be17867e1c"
+checksum = "5b1f682c4881aa7000ac7cc86d7aeeb3b09836a77a90b329820140233651aeea"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -300,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.5"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
+checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -1296,7 +1295,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1704,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "downloader"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.13.0#cffc3f1a299e0e5f097305775d6ba1141b5f9546"
+source = "git+https://github.com/eth-act/ere-guests?rev=b2ed4d88a30174b1eb5d75c55b63deab8516e8bd#b2ed4d88a30174b1eb5d75c55b63deab8516e8bd"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -1819,7 +1818,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-catalog"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "ere-util-build",
  "serde",
@@ -1829,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "ere-cluster-client-zisk"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "bincode",
  "ere-compiler-core",
@@ -1849,12 +1848,12 @@ dependencies = [
 [[package]]
 name = "ere-codec"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 
 [[package]]
 name = "ere-compiler-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "serde",
 ]
@@ -1862,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "ere-dockerized"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "anyhow",
  "ere-catalog",
@@ -1893,12 +1892,12 @@ dependencies = [
 [[package]]
 name = "ere-platform-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 
 [[package]]
 name = "ere-prover-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -1915,7 +1914,7 @@ dependencies = [
 [[package]]
 name = "ere-server-api"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "prost",
  "serde",
@@ -1925,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "ere-server-client"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "bincode",
  "ere-prover-core",
@@ -1937,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ere-util-build"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "cargo_metadata",
 ]
@@ -1945,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "ere-util-tokio"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "tokio",
 ]
@@ -1953,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "ere-verifier-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "auto_impl",
  "ere-codec",
@@ -1963,7 +1962,7 @@ dependencies = [
 [[package]]
 name = "ere-verifier-zisk"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.13.0#fcbf0dc8a2e1ea2af43cf0158a92dfbd33871fe0"
+source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -1983,7 +1982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2015,8 +2014,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "19.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?tag=v19.0.0#68b2f4f523a7c34675acfafac0d52c895e03db29"
+version = "21.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=e8860d2918921603afa67f62687e9a39f197367e#e8860d2918921603afa67f62687e9a39f197367e"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2047,8 +2046,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "19.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?tag=v19.0.0#68b2f4f523a7c34675acfafac0d52c895e03db29"
+version = "21.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=e8860d2918921603afa67f62687e9a39f197367e#e8860d2918921603afa67f62687e9a39f197367e"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2066,8 +2065,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "19.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?tag=v19.0.0#68b2f4f523a7c34675acfafac0d52c895e03db29"
+version = "21.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=e8860d2918921603afa67f62687e9a39f197367e#e8860d2918921603afa67f62687e9a39f197367e"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2089,8 +2088,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "19.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?tag=v19.0.0#68b2f4f523a7c34675acfafac0d52c895e03db29"
+version = "21.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=e8860d2918921603afa67f62687e9a39f197367e#e8860d2918921603afa67f62687e9a39f197367e"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2107,8 +2106,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "19.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?tag=v19.0.0#68b2f4f523a7c34675acfafac0d52c895e03db29"
+version = "21.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=e8860d2918921603afa67f62687e9a39f197367e#e8860d2918921603afa67f62687e9a39f197367e"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -2124,8 +2123,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "19.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?tag=v19.0.0#68b2f4f523a7c34675acfafac0d52c895e03db29"
+version = "21.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=e8860d2918921603afa67f62687e9a39f197367e#e8860d2918921603afa67f62687e9a39f197367e"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2134,8 +2133,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "19.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?tag=v19.0.0#68b2f4f523a7c34675acfafac0d52c895e03db29"
+version = "21.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=e8860d2918921603afa67f62687e9a39f197367e#e8860d2918921603afa67f62687e9a39f197367e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2153,8 +2152,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "19.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?tag=v19.0.0#68b2f4f523a7c34675acfafac0d52c895e03db29"
+version = "21.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=e8860d2918921603afa67f62687e9a39f197367e#e8860d2918921603afa67f62687e9a39f197367e"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -4049,7 +4048,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4315,8 +4314,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4335,9 +4334,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c37bb4d1bac98661bf9128e1141b969034640d68697b22f70377e492fd332c"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4353,9 +4351,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceeb8dab90194305d3f7e3f043a22d2db1fb54b6dcf5d8e75c5a4fa8540e1f57"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4364,8 +4361,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -4378,8 +4375,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4391,8 +4388,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4401,8 +4398,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4417,8 +4414,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -4429,8 +4426,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4443,8 +4440,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -4465,8 +4462,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4485,8 +4482,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4498,8 +4495,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4514,8 +4511,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4526,8 +4523,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -4536,9 +4533,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9102518f0bbf99bc8f0e656a56fb2a7513248630275b608d3706076a82fde42b"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4562,8 +4558,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -4574,8 +4570,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -4583,8 +4579,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -4596,8 +4592,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -4614,13 +4610,13 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "revm-database",
+ "revm",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4630,15 +4626,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
- "revm-state",
+ "revm",
  "thiserror",
 ]
 
 [[package]]
 name = "reth-trie-common"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
+version = "2.4.0"
+source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4648,39 +4643,21 @@ dependencies = [
  "itertools 0.14.0",
  "nybbles",
  "reth-primitives-traits",
- "revm-database",
-]
-
-[[package]]
-name = "reth-trie-sparse"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.3.0#9384bc53d8c0c77e59cac83fdaaf3b372c6d2216"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "either",
- "reth-execution-errors",
- "reth-primitives-traits",
- "reth-trie-common",
- "smallvec",
- "tracing",
+ "revm",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e86cf594718932d42cebce1fa48292fb7b92721f7c914631add1ca970e814"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "40.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -4697,9 +4674,8 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -4709,9 +4685,8 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "18.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -4725,9 +4700,8 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "19.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -4740,11 +4714,11 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "15.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "derive_more 2.1.1",
+ "either",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -4753,9 +4727,8 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "12.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "auto_impl",
  "either",
@@ -4766,9 +4739,8 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "20.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -4784,9 +4756,8 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "21.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "auto_impl",
  "either",
@@ -4800,9 +4771,8 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "37.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -4812,9 +4782,8 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "36.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4834,9 +4803,8 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "24.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -4845,9 +4813,8 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "12.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -5015,7 +4982,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5508,7 +5475,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5535,13 +5502,14 @@ dependencies = [
 [[package]]
 name = "stateless-validator-common"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.13.0#cffc3f1a299e0e5f097305775d6ba1141b5f9546"
+source = "git+https://github.com/eth-act/ere-guests?rev=b2ed4d88a30174b1eb5d75c55b63deab8516e8bd#b2ed4d88a30174b1eb5d75c55b63deab8516e8bd"
 dependencies = [
  "const-hex",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
  "libssz-types",
+ "paste",
  "sha2",
  "thiserror",
 ]
@@ -5549,7 +5517,7 @@ dependencies = [
 [[package]]
 name = "stateless-validator-ethrex"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.13.0#cffc3f1a299e0e5f097305775d6ba1141b5f9546"
+source = "git+https://github.com/eth-act/ere-guests?rev=b2ed4d88a30174b1eb5d75c55b63deab8516e8bd#b2ed4d88a30174b1eb5d75c55b63deab8516e8bd"
 dependencies = [
  "ere-platform-core",
  "ere-util-build",
@@ -5564,7 +5532,7 @@ dependencies = [
 [[package]]
 name = "stateless-validator-reth"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere-guests?tag=v0.13.0#cffc3f1a299e0e5f097305775d6ba1141b5f9546"
+source = "git+https://github.com/eth-act/ere-guests?rev=b2ed4d88a30174b1eb5d75c55b63deab8516e8bd#b2ed4d88a30174b1eb5d75c55b63deab8516e8bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5778,7 +5746,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6179,16 +6147,13 @@ dependencies = [
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "alloy-trie",
- "itertools 0.14.0",
  "reth-trie-common",
- "reth-trie-sparse",
- "revm-bytecode",
  "revm-database-interface",
  "thiserror",
  "zeth-mpt",
@@ -6503,7 +6468,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6934,7 +6899,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,20 +103,20 @@ zkevm-metrics = { path = "crates/metrics" }
 benchmark-runner = { path = "crates/benchmark-runner" }
 
 # ere
-ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.13.0" }
-ere-cluster-client-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.13.0" }
-ere-util-tokio = { git = "https://github.com/eth-act/ere", tag = "v0.13.0" }
+ere-dockerized = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010" }
+ere-cluster-client-zisk = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010" }
+ere-util-tokio = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010" }
 
 # ere-guests
-stateless-validator-common = { git = "https://github.com/eth-act/ere-guests", tag = "v0.13.0", package = "stateless-validator-common" }
-ere-guests-stateless-validator-ethrex = { git = "https://github.com/eth-act/ere-guests", tag = "v0.13.0", package = "stateless-validator-ethrex" }
-ere-guests-stateless-validator-reth = { git = "https://github.com/eth-act/ere-guests", tag = "v0.13.0", package = "stateless-validator-reth" }
-ere-guests-downloader = { git = "https://github.com/eth-act/ere-guests", tag = "v0.13.0", package = "downloader" }
+stateless-validator-common = { git = "https://github.com/eth-act/ere-guests", rev = "b2ed4d88a30174b1eb5d75c55b63deab8516e8bd", package = "stateless-validator-common" }
+ere-guests-stateless-validator-ethrex = { git = "https://github.com/eth-act/ere-guests", rev = "b2ed4d88a30174b1eb5d75c55b63deab8516e8bd", package = "stateless-validator-ethrex" }
+ere-guests-stateless-validator-reth = { git = "https://github.com/eth-act/ere-guests", rev = "b2ed4d88a30174b1eb5d75c55b63deab8516e8bd", package = "stateless-validator-reth" }
+ere-guests-downloader = { git = "https://github.com/eth-act/ere-guests", rev = "b2ed4d88a30174b1eb5d75c55b63deab8516e8bd", package = "downloader" }
 
 # alloy
-alloy-consensus = { version = "2.0.5", default-features = false }
-alloy-eips = { version = "2.0.5", default-features = false }
-alloy-primitives = { version = "1.6.0", default-features = false }
+alloy-consensus = { version = "=2.1.1", default-features = false }
+alloy-eips = { version = "=2.1.1", default-features = false }
+alloy-primitives = { version = "=1.6.0", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
 
 # misc
@@ -146,3 +146,24 @@ tar = "0.4"
 toml = "0.8"
 hex = "0.4"
 zstd = "0.13"
+
+# Temporary patches required by the Reth revision used in ere-guests.
+# Remove these once Glamsterdam devnet support is available in released crates.
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "721c59b9e4f640c9e646c0516e5be7142c956a26" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,24 +146,3 @@ tar = "0.4"
 toml = "0.8"
 hex = "0.4"
 zstd = "0.13"
-
-# Temporary patches required by the Reth revision used in ere-guests.
-# Remove these once Glamsterdam devnet support is available in released crates.
-[patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "721c59b9e4f640c9e646c0516e5be7142c956a26" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository benchmarks Ethereum stateless-validator guests across multiple z
 - **`crates/metrics`**: serializable result types such as `BenchmarkRun`.
 - **`crates/witness-generator-spec-cli`**: separate CLI and library for producing and publishing canonical stateless inputs from CL/EL RPC endpoints.
 
-The benchmark supports the Reth, Ethrex, and Zesu execution clients. Guest programs are maintained in [eth-act/ere-guests](https://github.com/eth-act/ere-guests) and are downloaded automatically from the resolved release or commit artifacts unless `--bin-path` or `--guest-artifact-base-url` is provided.
+Reth and Ethrex are enabled across the supported zkVMs. Zesu remains a valid CLI execution-client value and its routing is retained, but it is temporarily gated until `ere-guests` publishes a `tests-zkevm` v0.6.2-compatible artifact. Enabled guest programs are maintained in [eth-act/ere-guests](https://github.com/eth-act/ere-guests) and are downloaded automatically from the resolved release or commit artifacts unless `--bin-path` or `--guest-artifact-base-url` is provided.
 
 ## Prerequisites
 

--- a/crates/benchmark-runner/src/guest_programs.rs
+++ b/crates/benchmark-runner/src/guest_programs.rs
@@ -97,9 +97,7 @@ fn normalize_expected_public_values(
     zkvm_kind: zkVMKind,
     mut expected_public_values: Vec<u8>,
 ) -> Vec<u8> {
-    if matches!(zkvm_kind, zkVMKind::Airbender | zkVMKind::OpenVM)
-        && expected_public_values.len() < 32
-    {
+    if matches!(zkvm_kind, zkVMKind::OpenVM) && expected_public_values.len() < 32 {
         expected_public_values.resize(32, 0);
     }
 

--- a/crates/benchmark-runner/src/guest_programs.rs
+++ b/crates/benchmark-runner/src/guest_programs.rs
@@ -1,6 +1,6 @@
 //! Guest program input generation and metadata types
 
-use ere_dockerized::{zkVMKind, Input};
+use ere_dockerized::Input;
 use serde::Serialize;
 use std::fmt::Debug;
 
@@ -18,14 +18,6 @@ pub trait GuestFixture: Sync + Send {
 
     /// Returns the expected public values of guest program fixture.
     fn expected_public_values(&self) -> anyhow::Result<Vec<u8>>;
-
-    /// Returns the expected public values normalized for the selected zkVM.
-    fn expected_public_values_for_zkvm(&self, zkvm_kind: zkVMKind) -> anyhow::Result<Vec<u8>> {
-        Ok(normalize_expected_public_values(
-            zkvm_kind,
-            self.expected_public_values()?,
-        ))
-    }
 
     /// Verifies that the provided `public_values` match the expected output.
     fn verify_public_values(&self, public_values: &[u8]) -> anyhow::Result<OutputVerifierResult> {
@@ -91,19 +83,4 @@ pub enum OutputVerifierResult {
     Match,
     /// Output does not match the expected result
     Mismatch(String),
-}
-
-fn normalize_expected_public_values(
-    zkvm_kind: zkVMKind,
-    mut expected_public_values: Vec<u8>,
-) -> Vec<u8> {
-    if matches!(zkvm_kind, zkVMKind::OpenVM) && expected_public_values.len() < 32 {
-        expected_public_values.resize(32, 0);
-    }
-
-    if matches!(zkvm_kind, zkVMKind::Zisk) && expected_public_values.len() < 256 {
-        expected_public_values.resize(256, 0);
-    }
-
-    expected_public_values
 }

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -321,9 +321,8 @@ fn process_input(zkvm: &ZkVMInstance, io: impl GuestFixture, config: &RunConfig)
             let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm.execute(&input)));
             let execution = match run {
                 Ok(Ok((public_values, report))) => {
-                    let output_matched =
-                        public_output_matched(zkvm.zkvm_kind(), &io, &public_values)
-                            .context("Failed to compare public output from execution")?;
+                    let output_matched = public_output_matched(&io, &public_values)
+                        .context("Failed to compare public output from execution")?;
 
                     ExecutionMetrics::Success {
                         output_matched,
@@ -345,9 +344,8 @@ fn process_input(zkvm: &ZkVMInstance, io: impl GuestFixture, config: &RunConfig)
             let run = panic::catch_unwind(panic::AssertUnwindSafe(|| zkvm.prove(&input)));
             let proving = match run {
                 Ok(Ok((public_values, proof, report))) => {
-                    let prover_output_matched =
-                        public_output_matched(zkvm.zkvm_kind(), &io, &public_values)
-                            .context("Failed to compare public output from proof")?;
+                    let prover_output_matched = public_output_matched(&io, &public_values)
+                        .context("Failed to compare public output from proof")?;
 
                     // Save proof to disk if requested
                     if let Some(ref proofs_folder) = config.save_proofs_folder {
@@ -364,9 +362,8 @@ fn process_input(zkvm: &ZkVMInstance, io: impl GuestFixture, config: &RunConfig)
                     let verif_public_values =
                         zkvm.verify(&proof).context("Failed to verify proof")?;
                     let verification_time_ms = verify_start.elapsed().as_millis();
-                    let verifier_output_matched =
-                        public_output_matched(zkvm.zkvm_kind(), &io, &verif_public_values)
-                            .context("Failed to compare public output from proof verification")?;
+                    let verifier_output_matched = public_output_matched(&io, &verif_public_values)
+                        .context("Failed to compare public output from proof verification")?;
 
                     ProvingMetrics::Success {
                         output_matched: prover_output_matched && verifier_output_matched,
@@ -682,14 +679,15 @@ fn save_proof(
     Ok(())
 }
 
-fn public_output_matched(
-    zkvm_kind: zkVMKind,
-    io: &impl GuestFixture,
-    public_values: &[u8],
-) -> Result<bool> {
-    let expected_public_values = io.expected_public_values_for_zkvm(zkvm_kind)?;
+fn public_output_matched(io: &impl GuestFixture, public_values: &[u8]) -> Result<bool> {
+    let expected_public_values = io.expected_public_values()?;
 
-    if expected_public_values == public_values {
+    if public_values
+        .split_at_checked(expected_public_values.len())
+        .is_some_and(|(actual, trailing)| {
+            actual == expected_public_values && trailing.iter().all(|byte| *byte == 0)
+        })
+    {
         Ok(true)
     } else {
         warn!(
@@ -742,7 +740,7 @@ mod tests {
     fn public_output_matched_returns_true_for_matching_values() -> Result<()> {
         let fixture = Fixture::new(vec![1, 2, 3]);
 
-        assert!(public_output_matched(zkVMKind::SP1, &fixture, &[1, 2, 3],)?);
+        assert!(public_output_matched(&fixture, &[1, 2, 3],)?);
 
         Ok(())
     }
@@ -751,52 +749,37 @@ mod tests {
     fn public_output_matched_returns_false_for_mismatched_values() -> Result<()> {
         let fixture = Fixture::new(vec![1, 2, 3]);
 
-        assert!(!public_output_matched(zkVMKind::SP1, &fixture, &[1, 2, 4],)?);
+        assert!(!public_output_matched(&fixture, &[1, 2, 4],)?);
 
         Ok(())
     }
 
     #[test]
-    fn public_output_matched_preserves_zkvm_padding_normalization() -> Result<()> {
+    fn public_output_matched_accepts_zero_padding() -> Result<()> {
         let fixture = Fixture::new(vec![0xab]);
 
-        let mut thirty_two_byte_public_values = vec![0xab];
-        thirty_two_byte_public_values.resize(32, 0);
+        let mut padded_public_values = vec![0xab];
+        padded_public_values.resize(256, 0);
 
-        assert!(public_output_matched(
-            zkVMKind::OpenVM,
-            &fixture,
-            &thirty_two_byte_public_values,
-        )?);
-        assert!(!public_output_matched(
-            zkVMKind::SP1,
-            &fixture,
-            &thirty_two_byte_public_values,
-        )?);
-
-        let mut zisk_public_values = vec![0xab];
-        zisk_public_values.resize(256, 0);
-        assert!(public_output_matched(
-            zkVMKind::Zisk,
-            &fixture,
-            &zisk_public_values,
-        )?);
+        assert!(public_output_matched(&fixture, &padded_public_values,)?);
 
         Ok(())
     }
 
     #[test]
-    fn public_output_matched_requires_zisk_padding_normalization() -> Result<()> {
+    fn public_output_matched_rejects_nonzero_trailing_bytes() -> Result<()> {
         let fixture = Fixture::new(vec![0xab]);
-        let mut zisk_public_values = vec![0xab];
-        zisk_public_values.resize(256, 0);
 
-        assert!(!public_output_matched(zkVMKind::Zisk, &fixture, &[0xab])?);
-        assert!(public_output_matched(
-            zkVMKind::Zisk,
-            &fixture,
-            &zisk_public_values,
-        )?);
+        assert!(!public_output_matched(&fixture, &[0xab, 0x01])?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn public_output_matched_rejects_truncated_output() -> Result<()> {
+        let fixture = Fixture::new(vec![0xab, 0xcd]);
+
+        assert!(!public_output_matched(&fixture, &[0xab])?);
 
         Ok(())
     }

--- a/crates/benchmark-runner/src/runner.rs
+++ b/crates/benchmark-runner/src/runner.rs
@@ -764,11 +764,6 @@ mod tests {
         thirty_two_byte_public_values.resize(32, 0);
 
         assert!(public_output_matched(
-            zkVMKind::Airbender,
-            &fixture,
-            &thirty_two_byte_public_values,
-        )?);
-        assert!(public_output_matched(
             zkVMKind::OpenVM,
             &fixture,
             &thirty_two_byte_public_values,

--- a/crates/benchmark-runner/src/stateless_validator.rs
+++ b/crates/benchmark-runner/src/stateless_validator.rs
@@ -23,7 +23,7 @@ pub enum ExecutionClient {
     Zesu,
 }
 
-/// Zesu version republished with the ere-guests v0.13.0 artifacts.
+/// Last published Zesu version, retained while its v0.6.2 artifact is unavailable.
 const ZESU_EL_VERSION: &str = "bal-devnet-7-2026-06-24";
 
 impl ExecutionClient {

--- a/crates/benchmark-runner/src/stateless_validator/eest.rs
+++ b/crates/benchmark-runner/src/stateless_validator/eest.rs
@@ -337,7 +337,7 @@ mod tests {
             .iter()
             .find(|fixture| fixture.original_test_name == "tests/foo.py::test_same[name/a]")
             .unwrap();
-        assert_eq!(fixture.stateless_input_bytes, [0x00, 0x01, 0x02]);
+        assert_eq!(fixture.stateless_input_bytes, [0x15, 0x01, 0x02]);
         assert_eq!(fixture.stateless_output_bytes, [0xaa, 0xbb]);
         assert_eq!(
             fixture.source_path,
@@ -454,7 +454,7 @@ mod tests {
                 "config": {"chainid": "0x01"},
                 "blocks": [
                     {
-                        "statelessInputBytes": "0x000102",
+                        "statelessInputBytes": "0x150102",
                         "statelessOutputBytes": "0xaabb",
                         "blockHeader": {"number": "0x01", "gasUsed": "0x10"}
                     },

--- a/crates/benchmark-runner/src/stateless_validator/fixtures.rs
+++ b/crates/benchmark-runner/src/stateless_validator/fixtures.rs
@@ -275,7 +275,7 @@ mod tests {
         assert!(fixtures.next().is_none());
 
         let input = guest_fixture.input()?;
-        assert_eq!(input.stdin(), [0x00, 0x01, 0x02]);
+        assert_eq!(input.stdin(), [0x15, 0x01, 0x02]);
         assert_eq!(guest_fixture.expected_public_values()?, [0xaa, 0xbb]);
 
         let metadata = guest_fixture.metadata();
@@ -388,7 +388,7 @@ mod tests {
                 "config": {"chainid": "0x01"},
                 "blocks": [
                     {
-                        "statelessInputBytes": "0x000102",
+                        "statelessInputBytes": "0x150102",
                         "statelessOutputBytes": "0xaabb",
                         "blockHeader": {"number": "0x01", "gasUsed": "0x10"}
                     }

--- a/crates/benchmark-runner/src/stateless_validator/inputs.rs
+++ b/crates/benchmark-runner/src/stateless_validator/inputs.rs
@@ -32,14 +32,13 @@ pub(crate) fn stateless_validator_input_from_fixture(
 }
 
 fn zesu_input_from_fixture(fixture: EestStatelessFixture) -> Result<Box<dyn GuestFixture>> {
-    let input = StatelessInput::from_schema_prefixed_ssz(&fixture.stateless_input_bytes)
+    let (fork, _input) = StatelessInput::from_schema_prefixed_ssz(&fixture.stateless_input_bytes)
         .with_context(|| {
-            format!(
-                "failed to decode canonical stateless input for Zesu fixture {}",
-                fixture.name
-            )
-        })?;
-    let fork = input.chain_config.active_fork.fork;
+        format!(
+            "failed to decode canonical stateless input for Zesu fixture {}",
+            fixture.name
+        )
+    })?;
     validate_zesu_fork(fork, &fixture.name)?;
 
     raw_eest_input_from_fixture(fixture)

--- a/crates/ere-hosts/src/cli.rs
+++ b/crates/ere-hosts/src/cli.rs
@@ -108,7 +108,7 @@ pub enum ExecutionClient {
     Reth,
     /// Ethrex execution client
     Ethrex,
-    /// Zesu execution client
+    /// Zesu execution client (temporarily unavailable)
     Zesu,
 }
 

--- a/crates/ere-hosts/src/main.rs
+++ b/crates/ere-hosts/src/main.rs
@@ -25,6 +25,8 @@ pub mod cli;
 const DEFAULT_EXECUTE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const DEFAULT_PROVE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const DEFAULT_VERIFY_TIMEOUT: Duration = Duration::from_secs(2);
+/// Temporary gate until ere-guests publishes a tests-zkevm v0.6.2-compatible Zesu artifact.
+const ZESU_ARTIFACTS_AVAILABLE: bool = false;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -184,6 +186,12 @@ fn validate_guest_compatibility(
     zkvms: &[zkVMKind],
     guest_source: &GuestProgramSource,
 ) -> Result<()> {
+    if matches!(el, stateless_validator::ExecutionClient::Zesu) && !ZESU_ARTIFACTS_AVAILABLE {
+        bail!(
+            "Zesu is temporarily unavailable pending a tests-zkevm v0.6.2-compatible ere-guests artifact"
+        );
+    }
+
     if !matches!(el, stateless_validator::ExecutionClient::Zesu)
         || !matches!(guest_source, GuestProgramSource::Default)
     {

--- a/crates/witness-generator-spec-cli/src/artifact.rs
+++ b/crates/witness-generator-spec-cli/src/artifact.rs
@@ -12,7 +12,6 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use witness_generator_spec_cli::GeneratedInput;
 
 const ARTIFACT_SCHEMA_VERSION: u64 = 1;
-const STATELESS_INPUT_SCHEMA_ID: &str = "0x0001";
 const ZSTD_LEVEL: i32 = 3;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,6 +79,11 @@ impl StatelessInputArtifact {
         collected_at: &str,
         generator_git_commit: String,
     ) -> anyhow::Result<Self> {
+        let schema_id = generated
+            .bytes
+            .get(..2)
+            .context("generated stateless input is missing its two-byte schema id")?;
+
         Ok(Self {
             schema_version: ARTIFACT_SCHEMA_VERSION,
             network: network.to_owned(),
@@ -92,7 +96,7 @@ impl StatelessInputArtifact {
             generator_package: env!("CARGO_PKG_NAME").to_owned(),
             generator_version: env!("CARGO_PKG_VERSION").to_owned(),
             generator_git_commit,
-            stateless_input_schema_id: STATELESS_INPUT_SCHEMA_ID.to_owned(),
+            stateless_input_schema_id: format!("0x{}", hex::encode(schema_id)),
             stateless_input_byte_length: generated.bytes.len(),
             stateless_input_sha256: sha256_hex(&generated.bytes),
             stateless_input_bytes: format!("0x{}", hex::encode(&generated.bytes)),
@@ -289,7 +293,8 @@ mod tests {
         assert_eq!(decoded, artifact);
         assert_eq!(decoded.stateless_input_byte_length, generated.bytes.len());
         assert_eq!(decoded.stateless_input_sha256, sha256_hex(&generated.bytes));
-        assert_eq!(decoded.stateless_input_bytes, "0x00010203");
+        assert_eq!(decoded.stateless_input_schema_id, "0x1501");
+        assert_eq!(decoded.stateless_input_bytes, "0x15010203");
         assert_eq!(decoded.collection_mode, "head");
 
         let file = fs::File::open(&result.path).unwrap();
@@ -329,9 +334,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn artifact_rejects_generated_input_without_schema_id() {
+        let mut generated = generated_input(42, B256::repeat_byte(0xaa));
+        generated.bytes = vec![0x15];
+
+        let error = StatelessInputArtifact::from_generated_at(
+            "glamsterdam-devnet-7",
+            "head",
+            &generated,
+            "2026-06-11T00:00:00Z",
+            "test-commit".to_owned(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("two-byte schema id"));
+    }
+
     fn generated_input(block_number: u64, block_hash: B256) -> GeneratedInput {
         GeneratedInput {
-            bytes: vec![0x00, 0x01, 0x02, 0x03],
+            bytes: vec![0x15, 0x01, 0x02, 0x03],
             block_hash,
             block_number,
             slot_number: 64,

--- a/crates/witness-generator-spec-cli/src/builder.rs
+++ b/crates/witness-generator-spec-cli/src/builder.rs
@@ -10,12 +10,14 @@ use stateless_validator_common::{
     guest::input::{
         ExecutionWitness, MAX_BYTES_PER_CODE, MAX_BYTES_PER_HEADER, MAX_BYTES_PER_WITNESS_NODE,
         MAX_PUBLIC_KEYS, MAX_WITNESS_CODES, MAX_WITNESS_HEADERS, MAX_WITNESS_NODES,
-        PUBLIC_KEY_BYTES, StatelessInput,
+        PUBLIC_KEY_BYTES, ProtocolFork, StatelessInput,
         new_payload_request::{
-            BlockAccessList, ConsolidationRequest, ConsolidationRequests, DepositRequest,
-            DepositRequests, ExecutionPayloadV4, ExecutionRequests, ExtraData, NewPayloadRequest,
-            NewPayloadRequestGloas, Transaction as PayloadTransaction, Transactions,
-            VersionedHashes, Withdrawal, WithdrawalRequest, WithdrawalRequests, Withdrawals,
+            BlockAccessList, BuilderDepositRequest, BuilderDepositRequests, BuilderExitRequest,
+            BuilderExitRequests, ConsolidationRequest, ConsolidationRequests, DepositRequest,
+            DepositRequests, ExecutionPayloadV4, ExecutionRequestsGloas, ExtraData,
+            NewPayloadRequest, NewPayloadRequestGloas, Transaction as PayloadTransaction,
+            Transactions, VersionedHashes, Withdrawal, WithdrawalRequest, WithdrawalRequests,
+            Withdrawals,
         },
     },
 };
@@ -23,16 +25,16 @@ use stateless_validator_common::{
 use crate::{
     chain_config,
     rpc::{
-        BeaconExecutionPayload, ConsolidationRequestJson, DepositRequestJson,
-        ExecutionPayloadEnvelope, ExecutionRequestsJson, RpcExecutionWitness, WithdrawalJson,
-        WithdrawalRequestJson,
+        BeaconExecutionPayload, BuilderDepositRequestJson, BuilderExitRequestJson,
+        ConsolidationRequestJson, DepositRequestJson, ExecutionPayloadEnvelope,
+        ExecutionRequestsJson, RpcExecutionWitness, WithdrawalJson, WithdrawalRequestJson,
     },
 };
 
 /// Canonical stateless guest input generated from network RPC data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GeneratedInput {
-    /// Bytes encoded as `0x0001 || SSZ(SszStatelessInput)`.
+    /// Bytes encoded as `0x1501 || SSZ(StatelessInput)`.
     pub bytes: Vec<u8>,
     /// Execution block hash.
     pub block_hash: B256,
@@ -76,7 +78,7 @@ pub(crate) fn build_generated_input(
         public_keys,
     };
 
-    let bytes = stateless_input.to_schema_prefixed_ssz();
+    let bytes = stateless_input.to_schema_prefixed_ssz(ProtocolFork::Amsterdam);
 
     Ok(GeneratedInput {
         bytes,
@@ -143,7 +145,7 @@ const fn convert_withdrawal(withdrawal: &WithdrawalJson) -> Withdrawal {
 
 fn convert_execution_requests(
     requests: &ExecutionRequestsJson,
-) -> anyhow::Result<ExecutionRequests> {
+) -> anyhow::Result<ExecutionRequestsGloas> {
     let deposits = requests
         .deposits
         .iter()
@@ -159,14 +161,28 @@ fn convert_execution_requests(
         .iter()
         .map(convert_consolidation_request)
         .collect::<Vec<_>>();
+    let builder_deposits = requests
+        .builder_deposits
+        .iter()
+        .map(convert_builder_deposit_request)
+        .collect::<Vec<_>>();
+    let builder_exits = requests
+        .builder_exits
+        .iter()
+        .map(convert_builder_exit_request)
+        .collect::<Vec<_>>();
 
-    Ok(ExecutionRequests {
+    Ok(ExecutionRequestsGloas {
         deposits: DepositRequests::try_from(deposits)
             .map_err(|err| anyhow::anyhow!("deposit requests exceed SSZ bound: {err:?}"))?,
         withdrawals: WithdrawalRequests::try_from(withdrawals)
             .map_err(|err| anyhow::anyhow!("withdrawal requests exceed SSZ bound: {err:?}"))?,
         consolidations: ConsolidationRequests::try_from(consolidations)
             .map_err(|err| anyhow::anyhow!("consolidation requests exceed SSZ bound: {err:?}"))?,
+        builder_deposits: BuilderDepositRequests::try_from(builder_deposits)
+            .map_err(|err| anyhow::anyhow!("builder deposit requests exceed SSZ bound: {err:?}"))?,
+        builder_exits: BuilderExitRequests::try_from(builder_exits)
+            .map_err(|err| anyhow::anyhow!("builder exit requests exceed SSZ bound: {err:?}"))?,
     })
 }
 
@@ -193,6 +209,24 @@ const fn convert_consolidation_request(request: &ConsolidationRequestJson) -> Co
         source_address: request.source_address.into_array(),
         source_pubkey: request.source_pubkey.0,
         target_pubkey: request.target_pubkey.0,
+    }
+}
+
+const fn convert_builder_deposit_request(
+    request: &BuilderDepositRequestJson,
+) -> BuilderDepositRequest {
+    BuilderDepositRequest {
+        pubkey: request.pubkey.0,
+        withdrawal_credentials: request.withdrawal_credentials.0,
+        amount: request.amount,
+        signature: request.signature.0,
+    }
+}
+
+const fn convert_builder_exit_request(request: &BuilderExitRequestJson) -> BuilderExitRequest {
+    BuilderExitRequest {
+        source_address: request.source_address.into_array(),
+        pubkey: request.pubkey.0,
     }
 }
 
@@ -326,7 +360,6 @@ fn decode_header_number(bytes: &[u8]) -> anyhow::Result<u64> {
 mod tests {
     use alloy_primitives::{b256, hex};
     use alloy_rlp::Encodable;
-    use stateless_validator_common::guest::input::{ProtocolFork, STATELESS_INPUT_SCHEMA_ID};
 
     use super::*;
 
@@ -433,7 +466,18 @@ mod tests {
                         "block_access_list": "0xc0",
                         "slot_number": "64"
                     },
-                    "execution_requests": {},
+                    "execution_requests": {
+                        "builder_deposits": [{
+                            "pubkey": format!("0x{}", "11".repeat(48)),
+                            "withdrawal_credentials": format!("0x{}", "22".repeat(32)),
+                            "amount": "32000000000",
+                            "signature": format!("0x{}", "33".repeat(96))
+                        }],
+                        "builder_exits": [{
+                            "source_address": format!("0x{}", "44".repeat(20)),
+                            "pubkey": format!("0x{}", "55".repeat(48))
+                        }]
+                    },
                     "builder_index": "0",
                     "beacon_block_root": format!("0x{}", "bb".repeat(32)),
                     "parent_beacon_block_root": format!("0x{}", "aa".repeat(32))
@@ -455,16 +499,13 @@ mod tests {
         let second = build_generated_input(envelope, witness, 1).unwrap();
 
         assert_eq!(first.bytes, second.bytes);
-        assert_eq!(&first.bytes[..2], &STATELESS_INPUT_SCHEMA_ID.to_be_bytes());
+        assert_eq!(&first.bytes[..2], &[0x15, 0x01]);
         assert_eq!(first.block_number, 10);
         assert_eq!(first.slot_number, 64);
         assert_eq!(first.chain_id, 1);
 
-        let decoded = StatelessInput::from_schema_prefixed_ssz(&first.bytes).unwrap();
-        assert_eq!(
-            decoded.chain_config.active_fork.fork,
-            ProtocolFork::Amsterdam
-        );
+        let (fork, decoded) = StatelessInput::from_schema_prefixed_ssz(&first.bytes).unwrap();
+        assert_eq!(fork, ProtocolFork::Amsterdam);
         assert_eq!(decoded.witness.state.len(), 1);
         assert_eq!(decoded.public_keys.len(), 0);
         let NewPayloadRequest::Gloas(request) = decoded.new_payload_request else {
@@ -472,6 +513,32 @@ mod tests {
         };
         assert_eq!(request.execution_payload.block_number, 10);
         assert_eq!(request.execution_payload.slot_number, 64);
+        assert_eq!(request.execution_requests.builder_deposits.len(), 1);
+        assert_eq!(
+            request.execution_requests.builder_deposits[0].pubkey,
+            [0x11; 48]
+        );
+        assert_eq!(
+            request.execution_requests.builder_deposits[0].withdrawal_credentials,
+            [0x22; 32]
+        );
+        assert_eq!(
+            request.execution_requests.builder_deposits[0].amount,
+            32_000_000_000
+        );
+        assert_eq!(
+            request.execution_requests.builder_deposits[0].signature,
+            [0x33; 96]
+        );
+        assert_eq!(request.execution_requests.builder_exits.len(), 1);
+        assert_eq!(
+            request.execution_requests.builder_exits[0].source_address,
+            [0x44; 20]
+        );
+        assert_eq!(
+            request.execution_requests.builder_exits[0].pubkey,
+            [0x55; 48]
+        );
     }
 
     fn rlp_header(number: u64) -> Bytes {

--- a/crates/witness-generator-spec-cli/src/catalog.rs
+++ b/crates/witness-generator-spec-cli/src/catalog.rs
@@ -550,7 +550,7 @@ mod tests {
 
     fn write_generated_artifact(config: &CollectorConfig, block_number: u64, block_hash: B256) {
         let generated = GeneratedInput {
-            bytes: vec![0x00, 0x01, block_number as u8],
+            bytes: vec![0x15, 0x01, block_number as u8],
             block_hash,
             block_number,
             slot_number: block_number + 100,

--- a/crates/witness-generator-spec-cli/src/chain_config.rs
+++ b/crates/witness-generator-spec-cli/src/chain_config.rs
@@ -1,21 +1,11 @@
 //! Amsterdam chain configuration used by generated stateless inputs.
 
-use stateless_validator_common::guest::input::{
-    BlobSchedule, ChainConfig, ForkActivation, ForkConfig, ProtocolFork,
-};
+use stateless_validator_common::guest::input::{ChainConfig, ForkActivation, ForkConfig};
 
 pub(crate) fn amsterdam(chain_id: u64) -> ChainConfig {
     ChainConfig {
         chain_id,
-        active_fork: ForkConfig::new(
-            ProtocolFork::Amsterdam,
-            ForkActivation::new(None, Some(0)),
-            Some(BlobSchedule {
-                target: 14,
-                max: 21,
-                base_fee_update_fraction: 11_684_671,
-            }),
-        ),
+        active_fork: ForkConfig::new(ForkActivation::new(None, Some(0))),
     }
 }
 
@@ -28,12 +18,7 @@ mod tests {
         let cfg = amsterdam(1);
 
         assert_eq!(cfg.chain_id, 1);
-        assert_eq!(cfg.active_fork.fork, ProtocolFork::Amsterdam);
         assert_eq!(cfg.active_fork.activation.block_number(), None);
         assert_eq!(cfg.active_fork.activation.timestamp(), Some(0));
-        let schedule = cfg.active_fork.blob_schedule().unwrap();
-        assert_eq!(schedule.target, 14);
-        assert_eq!(schedule.max, 21);
-        assert_eq!(schedule.base_fee_update_fraction, 11_684_671);
     }
 }

--- a/crates/witness-generator-spec-cli/src/collector.rs
+++ b/crates/witness-generator-spec-cli/src/collector.rs
@@ -177,7 +177,7 @@ mod tests {
 
     fn generated_input(block_number: u64, block_hash: B256) -> GeneratedInput {
         GeneratedInput {
-            bytes: vec![0x00, 0x01, 0x02, 0x03],
+            bytes: vec![0x15, 0x01, 0x02, 0x03],
             block_hash,
             block_number,
             slot_number: 64,

--- a/crates/witness-generator-spec-cli/src/export.rs
+++ b/crates/witness-generator-spec-cli/src/export.rs
@@ -329,7 +329,7 @@ mod tests {
 
     fn write_generated_artifact(config: &CollectorConfig, block_number: u64, block_hash: B256) {
         let generated = GeneratedInput {
-            bytes: vec![0x00, 0x01, block_number as u8],
+            bytes: vec![0x15, 0x01, block_number as u8],
             block_hash,
             block_number,
             slot_number: block_number + 100,

--- a/crates/witness-generator-spec-cli/src/lib.rs
+++ b/crates/witness-generator-spec-cli/src/lib.rs
@@ -167,8 +167,6 @@ fn ensure_matching_hash(
 
 #[cfg(test)]
 mod tests {
-    use stateless_validator_common::guest::input::STATELESS_INPUT_SCHEMA_ID;
-
     use super::*;
 
     #[tokio::test]
@@ -184,11 +182,7 @@ mod tests {
             NetworkWitnessClient::new(NetworkWitnessConfig::new(cl_endpoint, el_endpoint))?;
         let generated = client.stateless_input_bytes(BlockSelector::Head).await?;
 
-        assert!(
-            generated
-                .bytes
-                .starts_with(&STATELESS_INPUT_SCHEMA_ID.to_be_bytes())
-        );
+        assert!(generated.bytes.starts_with(&[0x15, 0x01]));
         assert!(generated.block_number > 0);
         Ok(())
     }

--- a/crates/witness-generator-spec-cli/src/rpc.rs
+++ b/crates/witness-generator-spec-cli/src/rpc.rs
@@ -89,6 +89,10 @@ pub(crate) struct ExecutionRequestsJson {
     pub(crate) withdrawals: Vec<WithdrawalRequestJson>,
     #[serde(default)]
     pub(crate) consolidations: Vec<ConsolidationRequestJson>,
+    #[serde(default)]
+    pub(crate) builder_deposits: Vec<BuilderDepositRequestJson>,
+    #[serde(default)]
+    pub(crate) builder_exits: Vec<BuilderExitRequestJson>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -115,6 +119,21 @@ pub(crate) struct ConsolidationRequestJson {
     pub(crate) source_address: Address,
     pub(crate) source_pubkey: FixedBytes<48>,
     pub(crate) target_pubkey: FixedBytes<48>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BuilderDepositRequestJson {
+    pub(crate) pubkey: FixedBytes<48>,
+    pub(crate) withdrawal_credentials: B256,
+    #[serde(deserialize_with = "de_u64")]
+    pub(crate) amount: u64,
+    pub(crate) signature: FixedBytes<96>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BuilderExitRequestJson {
+    pub(crate) source_address: Address,
+    pub(crate) pubkey: FixedBytes<48>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -381,6 +400,16 @@ mod tests {
                 "source_address": format!("0x{}", "66".repeat(20)),
                 "source_pubkey": format!("0x{}", "77".repeat(48)),
                 "target_pubkey": format!("0x{}", "88".repeat(48))
+            }],
+            "builder_deposits": [{
+                "pubkey": format!("0x{}", "99".repeat(48)),
+                "withdrawal_credentials": format!("0x{}", "aa".repeat(32)),
+                "amount": "0x2b",
+                "signature": format!("0x{}", "bb".repeat(96))
+            }],
+            "builder_exits": [{
+                "source_address": format!("0x{}", "cc".repeat(20)),
+                "pubkey": format!("0x{}", "dd".repeat(48))
             }]
         });
 
@@ -390,6 +419,8 @@ mod tests {
         assert_eq!(parsed.deposits[0].index, 42);
         assert_eq!(parsed.withdrawals[0].amount, 1);
         assert_eq!(parsed.consolidations.len(), 1);
+        assert_eq!(parsed.builder_deposits[0].amount, 43);
+        assert_eq!(parsed.builder_exits.len(), 1);
     }
 
     #[test]

--- a/docs/benchmark-execution-inputs.md
+++ b/docs/benchmark-execution-inputs.md
@@ -39,7 +39,7 @@ The only accepted benchmark fixture format is an EEST `blockchain_tests` JSON ob
     },
     "blocks": [
       {
-        "statelessInputBytes": "0x000102",
+        "statelessInputBytes": "0x150102",
         "statelessOutputBytes": "0xaabb",
         "blockHeader": {
           "number": "0x01",
@@ -77,7 +77,7 @@ Each accepted block becomes one benchmark fixture. Its safe output name is deriv
 
 - Reth receives `statelessInputBytes` unchanged on stdin and uses `statelessOutputBytes` as the expected public values.
 - Ethrex uses the same raw canonical path.
-- Zesu first decodes the canonical stateless input and accepts it only when the active fork is `ProtocolFork::Amsterdam`, then uses the same raw input and expected public values.
+- Zesu routing is retained but temporarily gated before fixture or artifact loading. Once enabled, it decodes the fork-qualified tuple, accepts only `ProtocolFork::Amsterdam` (`0x1501`), and forwards the same raw input and expected public values.
 
 Fixture deserialization is independent of the selected execution client. Client-specific routing occurs only after a canonical EEST case has loaded.
 

--- a/docs/benchmark-execution.md
+++ b/docs/benchmark-execution.md
@@ -36,13 +36,19 @@ cargo run -p ere-hosts --release -- --zkvms openvm \
     --input-folder /path/to/eest-fixtures
 ```
 
-Run Zesu's Amsterdam guest with the default ZisK artifact:
+Zesu remains a valid `--execution-client` value, but every Zesu invocation is
+temporarily rejected before default, local, or URL artifact resolution. Its
+Amsterdam routing and ZisK compatibility logic remain in place for the
+forthcoming `tests-zkevm` v0.6.2-compatible artifact:
 
 ```bash
 cargo run -p ere-hosts --release -- --zkvms zisk \
     stateless-validator --execution-client zesu \
     --input-folder /path/to/amsterdam-fixtures
 ```
+
+Until the artifact is published and the availability gate is enabled, this
+command returns a targeted `temporarily unavailable` error.
 
 Run directly from an EEST fixture checkout:
 
@@ -145,9 +151,13 @@ When `--proofs-url` is used, the archive is downloaded, extracted to a temporary
 
 ## Guest Artifact Resolution
 
-All default Reth, Ethrex, and Zesu guests use the `ere-guests` artifact resolver. Tagged dependencies use release assets for that tag; commit or branch dependencies use GitHub Actions artifacts for the resolved commit and require `GITHUB_TOKEN` or `GH_TOKEN`.
+Default Reth and Ethrex guests use the `ere-guests` artifact resolver. Tagged dependencies use release assets for that tag; commit or branch dependencies use GitHub Actions artifacts for the resolved commit and require `GITHUB_TOKEN` or `GH_TOKEN`.
 
 Use local artifacts with `--bin-path <DIRECTORY>`, or provide a compatible remote directory with `--guest-artifact-base-url <URL>`. Those options remain mutually exclusive.
+
+Zesu is gated before this resolver for every artifact source. Re-enabling it
+requires publishing the compatible guest, updating its version pin, enabling
+the availability gate, and confirming the supported zkVM matrix.
 
 ## Operational Notes
 

--- a/docs/stateless-input-publication.md
+++ b/docs/stateless-input-publication.md
@@ -100,14 +100,14 @@ cd /path/to/parent
 git clone https://github.com/ethereum/execution-specs.git
 cd execution-specs
 git fetch --tags
-git checkout tests-zkevm@v0.4.1
+git checkout tests-zkevm@v0.6.2
 ```
 
 From this repository root, run:
 
 ```bash
-CATALOG_URL="https://pub-5345007fbd06486bbb7cbbe9f3112c45.r2.dev/devnets/glamsterdam-devnet-5"
-EEST_REF="tests-zkevm@v0.4.1"
+CATALOG_URL="https://<public-host>/<new-v0.6.2-prefix>/<network>"
+EEST_REF="tests-zkevm@v0.6.2"
 EEST_DIR="../execution-specs"
 SUMMARY_DIR="target/eest-r2-stateless-inputs"
 


### PR DESCRIPTION
_Note: this PR will be kept as a draft until `ere-guests` tags `v0.14` prob when Zesu is supported. ~For now mainly trying to frontrun trying the R2 bucket setup for `glamsterdam-devnet-7`~ (Edit: done, looks like works correctly)_

Update the benchmark workload to the tentative ERE / `ere-guests` v0.14 stack and the `tests-zkevm` v0.6.2 stateless-input format.

- Pin ERE and `ere-guests` to the revisions carrying the Glamsterdam updates, align the Alloy dependencies, and add the temporary `revm`, `alloy-evm`, and Reth compatibility patches required by those revisions.
- Migrate Amsterdam stateless inputs from the generic `0x0001` schema prefix to the fork-qualified `0x1501` prefix. Artifact metadata now derives the schema ID from the generated bytes instead of hard-coding it.
- Extend Gloas input generation to deserialize and encode builder deposit and builder exit requests.
- Use the fork returned by canonical input decoding for Zesu validation and retain raw input forwarding for Reth and Ethrex.
- Stop applying OpenVM-style 32-byte public-output padding to Airbender; OpenVM and ZisK retain their existing normalization.
- Temporarily gate all Zesu runs until a `tests-zkevm` v0.6.2-compatible guest artifact is published, while preserving its routing and compatibility code for re-enablement.
- Update the benchmark and stateless-input publication documentation for the new schema, EEST version, and Zesu availability.

## Compatibility and follow-ups

- Newly generated Amsterdam inputs begin with `0x1501`; fixture bundles and artifacts using the previous `0x0001` format need to be regenerated with the v0.6.2-compatible tooling.
- The ERE / `ere-guests` revision pins and `[patch.crates-io]` entries are temporary and should be replaced or removed once the corresponding releases are available. Prob we might be able to remove them when Reth publishes ELFs and we can stop having to apply patches that have to be downstreamed