### PR TITLE
Use EEST fixtures as the unified witness-generator output format

### DIFF
--- a/.github/workflows/eest-r2-stateless-inputs.yml
+++ b/.github/workflows/eest-r2-stateless-inputs.yml
@@ -1,4 +1,4 @@
-name: EEST R2 Stateless Inputs
+name: EEST R2 Stateless Fixtures
 
 on:
   workflow_dispatch:
@@ -62,7 +62,7 @@ jobs:
         id: eest
         run: echo "commit=$(git -C execution-specs rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Validate R2 stateless inputs with EEST
+      - name: Validate R2 stateless fixtures with EEST
         run: |
           mkdir -p "$SUMMARY_DIR"
           uv run --project execution-specs --with zstandard \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6755,6 +6755,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "anyhow",
+ "benchmark-runner",
  "clap",
  "humantime",
  "reqwest",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository benchmarks Ethereum stateless-validator guests across multiple z
 - **`crates/ere-hosts`**: benchmark CLI for execution, proving, and verification jobs.
 - **`crates/benchmark-runner`**: shared orchestration for canonical fixture loading, guest resolution, execution, proof flow, and verification.
 - **`crates/metrics`**: serializable result types such as `BenchmarkRun`.
-- **`crates/witness-generator-spec-cli`**: separate CLI and library for producing and publishing canonical stateless inputs from CL/EL RPC endpoints.
+- **`crates/witness-generator-spec-cli`**: separate CLI and library for producing and publishing benchmark-ready EEST stateless fixtures from CL/EL RPC endpoints.
 
 Reth and Ethrex are enabled across the supported zkVMs. Zesu remains a valid CLI execution-client value and its routing is retained, but it is temporarily gated until `ere-guests` publishes a `tests-zkevm` v0.6.2-compatible artifact. Enabled guest programs are maintained in [eth-act/ere-guests](https://github.com/eth-act/ere-guests) and are downloaded automatically from the resolved release or commit artifacts unless `--bin-path` or `--guest-artifact-base-url` is provided.
 
@@ -32,6 +32,11 @@ Inspect both maintained CLIs:
 cargo run -p ere-hosts -- --help
 cargo run -p witness-generator-spec-cli -- --help
 ```
+
+The witness generator produces benchmark-ready EEST fixtures from live CL/EL
+networks. Use `generate` for one block or `collect` for continuous per-block
+collection. Exported live batches contain a `blockchain_tests/` tree and can be
+passed to `ere-hosts` immediately after extraction.
 
 Obtain an EEST fixture bundle from [ethereum/execution-specs](https://github.com/ethereum/execution-specs) whose `blockchain_tests` cases contain canonical stateless bytes. Then benchmark either the checkout's fixture root, a directory of EEST JSON files, or one EEST JSON file:
 

--- a/crates/witness-generator-spec-cli/Cargo.toml
+++ b/crates/witness-generator-spec-cli/Cargo.toml
@@ -36,3 +36,6 @@ alloy-rlp.workspace = true
 
 # local
 stateless-validator-common.workspace = true
+
+[dev-dependencies]
+benchmark-runner.workspace = true

--- a/crates/witness-generator-spec-cli/src/artifact.rs
+++ b/crates/witness-generator-spec-cli/src/artifact.rs
@@ -1,37 +1,104 @@
 use std::{
+    collections::BTreeMap,
     fs::{self, OpenOptions},
     io::{BufReader, Read, Write},
     path::{Path, PathBuf},
 };
 
-use alloy_primitives::hex;
-use anyhow::Context;
+use alloy_primitives::{B256, hex};
+use anyhow::{Context, ensure};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use stateless_validator_common::{
+    HashTreeRoot as _, Sha2Hasher, SszDecode as _,
+    guest::{StatelessInput, StatelessValidationResult, input::ProtocolFork},
+};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use witness_generator_spec_cli::GeneratedInput;
 
-const ARTIFACT_SCHEMA_VERSION: u64 = 1;
+pub(crate) const ARTIFACT_SCHEMA_VERSION: u64 = 2;
+pub(crate) const BATCH_MANIFEST_PATH: &str = ".meta/manifest.json";
+const EEST_NETWORK: &str = "Amsterdam";
 const ZSTD_LEVEL: i32 = 3;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct EestFixture {
+    tests: BTreeMap<String, EestBlockchainTest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct EestBlockchainTest {
+    network: String,
+    config: EestConfig,
+    blocks: Vec<EestBlock>,
+    #[serde(rename = "_info")]
+    info: EestInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct EestConfig {
+    chainid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EestBlock {
+    stateless_input_bytes: String,
+    stateless_output_bytes: String,
+    block_header: EestBlockHeader,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EestBlockHeader {
+    number: String,
+    gas_used: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct EestInfo {
+    metadata: EestMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct EestMetadata {
+    witness_generator: WitnessGeneratorMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WitnessGeneratorMetadata {
+    schema_version: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    network: Option<String>,
+    block_hash: String,
+    slot_number: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    collection_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    collected_at: Option<String>,
+    generator_package: String,
+    generator_version: String,
+    generator_git_commit: String,
+    stateless_input_schema_id: String,
+    stateless_input_byte_length: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct StatelessInputArtifact {
+    fixture: EestFixture,
     pub(crate) schema_version: u64,
     pub(crate) network: String,
     pub(crate) chain_id: u64,
     pub(crate) block_number: u64,
     pub(crate) block_hash: String,
+    pub(crate) gas_used: u64,
     pub(crate) slot_number: u64,
     pub(crate) collection_mode: String,
     pub(crate) collected_at: String,
-    pub(crate) generator_package: String,
-    pub(crate) generator_version: String,
-    pub(crate) generator_git_commit: String,
-    pub(crate) stateless_input_schema_id: String,
     pub(crate) stateless_input_byte_length: usize,
-    pub(crate) stateless_input_sha256: String,
-    pub(crate) stateless_input_bytes: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -42,11 +109,11 @@ pub(crate) struct ArtifactIndexEntry {
     pub(crate) chain_id: u64,
     pub(crate) block_number: u64,
     pub(crate) block_hash: String,
+    pub(crate) gas_used: u64,
     pub(crate) slot_number: u64,
     pub(crate) collection_mode: String,
     pub(crate) collected_at: String,
     pub(crate) stateless_input_byte_length: usize,
-    pub(crate) stateless_input_sha256: String,
     pub(crate) path: String,
 }
 
@@ -55,6 +122,76 @@ pub(crate) struct ArtifactWriteResult {
     pub(crate) path: PathBuf,
     pub(crate) relative_path: PathBuf,
     pub(crate) created: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct FixtureProvenance {
+    network: Option<String>,
+    collection_mode: Option<String>,
+    collected_at: Option<String>,
+    generator_git_commit: String,
+}
+
+impl EestFixture {
+    fn from_generated(
+        generated: &GeneratedInput,
+        provenance: FixtureProvenance,
+    ) -> anyhow::Result<Self> {
+        let schema_id = generated
+            .stateless_input_bytes
+            .get(..2)
+            .context("generated stateless input is missing its two-byte schema id")?;
+        ensure!(
+            !generated.stateless_output_bytes.is_empty(),
+            "generated stateless output is empty"
+        );
+
+        let block_hash = generated.block_hash.to_string();
+        let test_name = fixture_test_name(generated.block_number, &block_hash);
+        let metadata = WitnessGeneratorMetadata {
+            schema_version: ARTIFACT_SCHEMA_VERSION,
+            network: provenance.network,
+            block_hash,
+            slot_number: generated.slot_number,
+            collection_mode: provenance.collection_mode,
+            collected_at: provenance.collected_at,
+            generator_package: env!("CARGO_PKG_NAME").to_owned(),
+            generator_version: env!("CARGO_PKG_VERSION").to_owned(),
+            generator_git_commit: provenance.generator_git_commit,
+            stateless_input_schema_id: format!("0x{}", hex::encode(schema_id)),
+            stateless_input_byte_length: generated.stateless_input_bytes.len(),
+        };
+        let test = EestBlockchainTest {
+            network: EEST_NETWORK.to_owned(),
+            config: EestConfig {
+                chainid: hex_quantity(generated.chain_id),
+            },
+            blocks: vec![EestBlock {
+                stateless_input_bytes: hex_bytes(&generated.stateless_input_bytes),
+                stateless_output_bytes: hex_bytes(&generated.stateless_output_bytes),
+                block_header: EestBlockHeader {
+                    number: hex_quantity(generated.block_number),
+                    gas_used: hex_quantity(generated.gas_used),
+                },
+            }],
+            info: EestInfo {
+                metadata: EestMetadata {
+                    witness_generator: metadata,
+                },
+            },
+        };
+
+        Ok(Self {
+            tests: BTreeMap::from([(test_name, test)]),
+        })
+    }
+
+    pub(crate) fn to_pretty_json(&self) -> anyhow::Result<Vec<u8>> {
+        let mut bytes =
+            serde_json::to_vec_pretty(self).context("failed to serialize EEST fixture JSON")?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    }
 }
 
 impl StatelessInputArtifact {
@@ -79,28 +216,134 @@ impl StatelessInputArtifact {
         collected_at: &str,
         generator_git_commit: String,
     ) -> anyhow::Result<Self> {
-        let schema_id = generated
-            .bytes
+        let fixture = EestFixture::from_generated(
+            generated,
+            FixtureProvenance {
+                network: Some(network.to_owned()),
+                collection_mode: Some(collection_mode.to_owned()),
+                collected_at: Some(collected_at.to_owned()),
+                generator_git_commit,
+            },
+        )?;
+        Self::from_fixture(fixture)
+    }
+
+    fn from_fixture(fixture: EestFixture) -> anyhow::Result<Self> {
+        ensure!(
+            fixture.tests.len() == 1,
+            "schema-v2 collected fixture must contain exactly one EEST test"
+        );
+        let (test_name, test) = fixture.tests.first_key_value().unwrap();
+        ensure!(
+            test.network == EEST_NETWORK,
+            "schema-v2 collected fixture network must be {EEST_NETWORK}"
+        );
+        ensure!(
+            test.blocks.len() == 1,
+            "schema-v2 collected fixture must contain exactly one block"
+        );
+        let block = &test.blocks[0];
+        let metadata = &test.info.metadata.witness_generator;
+        ensure!(
+            metadata.schema_version == ARTIFACT_SCHEMA_VERSION,
+            "unsupported collected artifact schema version {}; expected {}",
+            metadata.schema_version,
+            ARTIFACT_SCHEMA_VERSION
+        );
+
+        let network = required_metadata("network", metadata.network.as_deref())?.to_owned();
+        let collection_mode =
+            required_metadata("collectionMode", metadata.collection_mode.as_deref())?.to_owned();
+        let collected_at =
+            required_metadata("collectedAt", metadata.collected_at.as_deref())?.to_owned();
+        let chain_id = parse_hex_quantity("config.chainid", &test.config.chainid)?;
+        let block_number = parse_hex_quantity("blockHeader.number", &block.block_header.number)?;
+        let gas_used = parse_hex_quantity("blockHeader.gasUsed", &block.block_header.gas_used)?;
+        let block_hash = metadata
+            .block_hash
+            .parse::<B256>()
+            .context("witness_generator.blockHash is not a valid B256")?;
+        let expected_test_name = fixture_test_name(block_number, &metadata.block_hash);
+        ensure!(
+            test_name == &expected_test_name,
+            "schema-v2 EEST test name does not match its block number and hash"
+        );
+
+        let input_bytes = decode_hex_bytes("statelessInputBytes", &block.stateless_input_bytes)?;
+        let output_bytes = decode_hex_bytes("statelessOutputBytes", &block.stateless_output_bytes)?;
+        ensure!(!input_bytes.is_empty(), "statelessInputBytes is empty");
+        ensure!(!output_bytes.is_empty(), "statelessOutputBytes is empty");
+        let schema_id = input_bytes
             .get(..2)
-            .context("generated stateless input is missing its two-byte schema id")?;
+            .context("statelessInputBytes is missing its two-byte schema id")?;
+        ensure!(
+            metadata.stateless_input_schema_id == format!("0x{}", hex::encode(schema_id)),
+            "stateless input schema id metadata does not match statelessInputBytes"
+        );
+        ensure!(
+            metadata.stateless_input_byte_length == input_bytes.len(),
+            "stateless input byte length metadata does not match statelessInputBytes"
+        );
+        let (fork, input) = StatelessInput::from_schema_prefixed_ssz(&input_bytes)
+            .context("failed to decode statelessInputBytes")?;
+        ensure!(
+            fork == ProtocolFork::Amsterdam,
+            "schema-v2 collected fixture must contain Amsterdam stateless input bytes"
+        );
+        let output = StatelessValidationResult::from_ssz_bytes(&output_bytes)
+            .map_err(|err| anyhow::anyhow!("failed to decode statelessOutputBytes: {err:?}"))?;
+        ensure!(
+            output.successful_validation,
+            "schema-v2 statelessOutputBytes must expect successful validation"
+        );
+        ensure!(
+            output.chain_config == input.chain_config,
+            "stateless output chain configuration does not match stateless input"
+        );
+        ensure!(
+            output.chain_config.chain_id == chain_id,
+            "config.chainid does not match the stateless input chain configuration"
+        );
+        ensure!(
+            output.new_payload_request_root
+                == input.new_payload_request.hash_tree_root(&Sha2Hasher),
+            "stateless output request root does not match stateless input"
+        );
+        ensure!(
+            input.new_payload_request.block_number() == block_number,
+            "blockHeader.number does not match the stateless input payload"
+        );
+        ensure!(
+            input.new_payload_request.gas_used() == gas_used,
+            "blockHeader.gasUsed does not match the stateless input payload"
+        );
+        ensure!(
+            input.new_payload_request.block_hash() == block_hash.0,
+            "witness_generator.blockHash does not match the stateless input payload"
+        );
+
+        let schema_version = metadata.schema_version;
+        let block_hash = metadata.block_hash.clone();
+        let slot_number = metadata.slot_number;
+        let stateless_input_byte_length = metadata.stateless_input_byte_length;
 
         Ok(Self {
-            schema_version: ARTIFACT_SCHEMA_VERSION,
-            network: network.to_owned(),
-            chain_id: generated.chain_id,
-            block_number: generated.block_number,
-            block_hash: generated.block_hash.to_string(),
-            slot_number: generated.slot_number,
-            collection_mode: collection_mode.to_owned(),
-            collected_at: collected_at.to_owned(),
-            generator_package: env!("CARGO_PKG_NAME").to_owned(),
-            generator_version: env!("CARGO_PKG_VERSION").to_owned(),
-            generator_git_commit,
-            stateless_input_schema_id: format!("0x{}", hex::encode(schema_id)),
-            stateless_input_byte_length: generated.bytes.len(),
-            stateless_input_sha256: sha256_hex(&generated.bytes),
-            stateless_input_bytes: format!("0x{}", hex::encode(&generated.bytes)),
+            schema_version,
+            network,
+            chain_id,
+            block_number,
+            block_hash,
+            gas_used,
+            slot_number,
+            collection_mode,
+            collected_at,
+            stateless_input_byte_length,
+            fixture,
         })
+    }
+
+    pub(crate) fn fixture_json(&self) -> anyhow::Result<Vec<u8>> {
+        self.fixture.to_pretty_json()
     }
 
     pub(crate) fn index_entry(&self, path: &Path) -> ArtifactIndexEntry {
@@ -110,14 +353,25 @@ impl StatelessInputArtifact {
             chain_id: self.chain_id,
             block_number: self.block_number,
             block_hash: self.block_hash.clone(),
+            gas_used: self.gas_used,
             slot_number: self.slot_number,
             collection_mode: self.collection_mode.clone(),
             collected_at: self.collected_at.clone(),
             stateless_input_byte_length: self.stateless_input_byte_length,
-            stateless_input_sha256: self.stateless_input_sha256.clone(),
             path: path_to_slash_string(path),
         }
     }
+}
+
+pub(crate) fn one_shot_fixture_json(generated: &GeneratedInput) -> anyhow::Result<Vec<u8>> {
+    EestFixture::from_generated(
+        generated,
+        FixtureProvenance {
+            generator_git_commit: generator_git_commit(),
+            ..Default::default()
+        },
+    )?
+    .to_pretty_json()
 }
 
 pub(crate) fn write_artifact_atomic(
@@ -127,6 +381,7 @@ pub(crate) fn write_artifact_atomic(
     let relative_path = relative_artifact_path(artifact);
     let path = blocks_root.join(&relative_path);
     if path.exists() {
+        read_artifact_with_json(&path)?;
         return Ok(ArtifactWriteResult {
             path,
             relative_path,
@@ -134,7 +389,7 @@ pub(crate) fn write_artifact_atomic(
         });
     }
 
-    let json = serde_json::to_vec_pretty(artifact).context("failed to serialize artifact JSON")?;
+    let json = artifact.fixture_json()?;
     let compressed =
         zstd::bulk::compress(&json, ZSTD_LEVEL).context("failed to compress artifact")?;
     write_bytes_atomic(&path, &compressed)?;
@@ -146,13 +401,27 @@ pub(crate) fn write_artifact_atomic(
     })
 }
 
+#[cfg(test)]
 pub(crate) fn read_artifact(path: &Path) -> anyhow::Result<StatelessInputArtifact> {
+    Ok(read_artifact_with_json(path)?.0)
+}
+
+pub(crate) fn read_artifact_with_json(
+    path: &Path,
+) -> anyhow::Result<(StatelessInputArtifact, Vec<u8>)> {
     let file = fs::File::open(path)
         .with_context(|| format!("failed to open artifact {}", path.display()))?;
     let json = zstd::stream::decode_all(file)
         .with_context(|| format!("failed to decompress artifact {}", path.display()))?;
-    serde_json::from_slice(&json)
-        .with_context(|| format!("failed to decode artifact JSON {}", path.display()))
+    let fixture: EestFixture = serde_json::from_slice(&json).with_context(|| {
+        format!(
+            "failed to decode schema-v2 EEST artifact JSON {}",
+            path.display()
+        )
+    })?;
+    let artifact = StatelessInputArtifact::from_fixture(fixture)
+        .with_context(|| format!("invalid schema-v2 EEST artifact {}", path.display()))?;
+    Ok((artifact, json))
 }
 
 pub(crate) fn append_index_entry(
@@ -209,6 +478,17 @@ pub(crate) fn relative_artifact_path(artifact: &StatelessInputArtifact) -> PathB
     ))
 }
 
+pub(crate) fn fixture_archive_path(artifact: &StatelessInputArtifact) -> PathBuf {
+    let chunk = artifact.block_number / 1_000;
+    PathBuf::from("blockchain_tests")
+        .join(format!("{chunk:06}"))
+        .join(format!(
+            "{}-{}.json",
+            artifact.block_number,
+            filename_hash(&artifact.block_hash)
+        ))
+}
+
 pub(crate) fn path_to_slash_string(path: &Path) -> String {
     path.components()
         .map(|component| component.as_os_str().to_string_lossy())
@@ -246,6 +526,47 @@ pub(crate) fn utc_now_rfc3339() -> anyhow::Result<String> {
         .context("failed to format current timestamp")
 }
 
+fn decode_hex_bytes(label: &str, value: &str) -> anyhow::Result<Vec<u8>> {
+    let value = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .unwrap_or(value);
+    ensure!(
+        value.len().is_multiple_of(2),
+        "{label} must have an even hex length"
+    );
+    hex::decode(value).with_context(|| format!("{label} is not valid hex"))
+}
+
+fn parse_hex_quantity(label: &str, value: &str) -> anyhow::Result<u64> {
+    let value = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .context("schema-v2 EEST quantities must be 0x-prefixed")?;
+    u64::from_str_radix(value, 16).with_context(|| format!("{label} is not a valid hex quantity"))
+}
+
+fn required_metadata<'a>(label: &str, value: Option<&'a str>) -> anyhow::Result<&'a str> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .with_context(|| format!("schema-v2 collected fixture is missing {label} metadata"))
+}
+
+fn fixture_test_name(block_number: u64, block_hash: &str) -> String {
+    format!(
+        "witness-generator-spec-cli::block_{block_number}_{}",
+        filename_hash(block_hash)
+    )
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    format!("0x{}", hex::encode(bytes))
+}
+
+fn hex_quantity(value: u64) -> String {
+    format!("0x{value:x}")
+}
+
 fn part_path(path: &Path) -> PathBuf {
     path.with_extension(
         match path.extension().and_then(|extension| extension.to_str()) {
@@ -268,15 +589,80 @@ fn generator_git_commit() -> String {
 }
 
 #[cfg(test)]
+pub(crate) fn test_generated_input(block_number: u64, block_hash: B256) -> GeneratedInput {
+    use stateless_validator_common::{
+        SszEncode as _,
+        guest::input::{
+            ChainConfig, ExecutionWitness, ForkActivation, ForkConfig, StatelessInput,
+            new_payload_request::{
+                ExecutionPayloadV4, ExecutionRequestsGloas, NewPayloadRequest,
+                NewPayloadRequestGloas,
+            },
+        },
+    };
+
+    let chain_config = ChainConfig {
+        chain_id: 1,
+        active_fork: ForkConfig::new(ForkActivation::new(None, Some(0))),
+    };
+    let new_payload_request = NewPayloadRequest::Gloas(NewPayloadRequestGloas {
+        execution_payload: ExecutionPayloadV4 {
+            parent_hash: [0; 32],
+            fee_recipient: [0; 20],
+            state_root: [0; 32],
+            receipts_root: [0; 32],
+            logs_bloom: [0; 256],
+            prev_randao: [0; 32],
+            block_number,
+            gas_limit: 30_000_000,
+            gas_used: 21_000,
+            timestamp: 1,
+            extra_data: Default::default(),
+            base_fee_per_gas: [0; 32],
+            block_hash: block_hash.0,
+            transactions: Default::default(),
+            withdrawals: Default::default(),
+            blob_gas_used: 0,
+            excess_blob_gas: 0,
+            block_access_list: Default::default(),
+            slot_number: 64,
+        },
+        versioned_hashes: Default::default(),
+        parent_beacon_block_root: [0; 32],
+        execution_requests: ExecutionRequestsGloas::default(),
+    });
+    let input = StatelessInput {
+        new_payload_request: new_payload_request.clone(),
+        witness: ExecutionWitness::default(),
+        chain_config: chain_config.clone(),
+        public_keys: Default::default(),
+    };
+    let output = StatelessValidationResult::new(
+        new_payload_request.hash_tree_root(&Sha2Hasher),
+        true,
+        chain_config,
+    );
+    GeneratedInput {
+        stateless_input_bytes: input.to_schema_prefixed_ssz(ProtocolFork::Amsterdam),
+        stateless_output_bytes: output.to_ssz(),
+        block_hash,
+        block_number,
+        slot_number: 64,
+        chain_id: 1,
+        gas_used: 21_000,
+    }
+}
+
+#[cfg(test)]
 mod tests {
-    use alloy_primitives::B256;
+    use benchmark_runner::stateless_validator::{ExecutionClient, stateless_validator_input_iter};
 
     use super::*;
 
     #[test]
-    fn artifact_serializes_and_roundtrips_through_zstd() {
+    fn artifact_serializes_as_eest_and_roundtrips_through_zstd() {
         let dir = temp_dir("artifact_roundtrip");
-        let generated = generated_input(42, B256::repeat_byte(0xaa));
+        let generated = test_generated_input(42, B256::repeat_byte(0xaa));
         let artifact = StatelessInputArtifact::from_generated_at(
             "glamsterdam-devnet-5",
             "head",
@@ -291,74 +677,170 @@ mod tests {
 
         assert!(result.created);
         assert_eq!(decoded, artifact);
-        assert_eq!(decoded.stateless_input_byte_length, generated.bytes.len());
-        assert_eq!(decoded.stateless_input_sha256, sha256_hex(&generated.bytes));
-        assert_eq!(decoded.stateless_input_schema_id, "0x1501");
-        assert_eq!(decoded.stateless_input_bytes, "0x15010203");
+        assert_eq!(decoded.schema_version, 2);
+        assert_eq!(
+            decoded.stateless_input_byte_length,
+            generated.stateless_input_bytes.len()
+        );
         assert_eq!(decoded.collection_mode, "head");
 
         let file = fs::File::open(&result.path).unwrap();
         let json = zstd::stream::decode_all(file).unwrap();
         let value: serde_json::Value = serde_json::from_slice(&json).unwrap();
-        assert_eq!(value["collectionMode"], "head");
-        assert!(value.get("selector").is_none());
-        assert!(value.get("canonicality").is_none());
+        let test = value.as_object().unwrap().values().next().unwrap();
+        assert_eq!(test["network"], "Amsterdam");
+        assert_eq!(
+            test["blocks"][0]["statelessInputBytes"],
+            hex_bytes(&generated.stateless_input_bytes)
+        );
+        assert_eq!(
+            test["blocks"][0]["statelessOutputBytes"],
+            hex_bytes(&generated.stateless_output_bytes)
+        );
+        assert_eq!(
+            test["_info"]["metadata"]["witness_generator"]["schemaVersion"],
+            2
+        );
+        assert!(
+            test["_info"]["metadata"]["witness_generator"]
+                .get("statelessOutputByteLength")
+                .is_none()
+        );
+        assert!(
+            test["_info"]["metadata"]["witness_generator"]
+                .get("statelessOutputSha256")
+                .is_none()
+        );
+        assert!(
+            test["_info"]["metadata"]["witness_generator"]
+                .get("statelessInputSha256")
+                .is_none()
+        );
     }
 
     #[test]
     fn artifact_paths_include_block_number_and_hash() {
-        let first = StatelessInputArtifact::from_generated_at(
-            "glamsterdam-devnet-5",
-            "head",
-            &generated_input(2_381, B256::repeat_byte(0xaa)),
-            "2026-06-11T00:00:00Z",
-            "test-commit".to_owned(),
-        )
-        .unwrap();
-        let second = StatelessInputArtifact::from_generated_at(
-            "glamsterdam-devnet-5",
-            "head",
-            &generated_input(2_381, B256::repeat_byte(0xbb)),
-            "2026-06-11T00:00:00Z",
-            "test-commit".to_owned(),
-        )
-        .unwrap();
+        let first = artifact_for(2_381, B256::repeat_byte(0xaa));
+        let second = artifact_for(2_381, B256::repeat_byte(0xbb));
 
         assert_ne!(
             relative_artifact_path(&first),
             relative_artifact_path(&second)
         );
         assert_eq!(
-            relative_artifact_path(&first),
-            PathBuf::from("000002").join(format!("2381-{}.json.zst", "aa".repeat(32)))
+            fixture_archive_path(&first),
+            PathBuf::from("blockchain_tests/000002").join(format!("2381-{}.json", "aa".repeat(32)))
         );
     }
 
     #[test]
-    fn artifact_rejects_generated_input_without_schema_id() {
-        let mut generated = generated_input(42, B256::repeat_byte(0xaa));
-        generated.bytes = vec![0x15];
+    fn one_shot_fixture_uses_eest_shape_without_collection_metadata() {
+        let generated = test_generated_input(42, B256::repeat_byte(0xaa));
+        let json = one_shot_fixture_json(&generated).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&json).unwrap();
+        let test = value.as_object().unwrap().values().next().unwrap();
+        let metadata = &test["_info"]["metadata"]["witness_generator"];
 
-        let error = StatelessInputArtifact::from_generated_at(
-            "glamsterdam-devnet-7",
+        assert_eq!(test["config"]["chainid"], "0x1");
+        assert_eq!(test["blocks"][0]["blockHeader"]["number"], "0x2a");
+        assert_eq!(test["blocks"][0]["blockHeader"]["gasUsed"], "0x5208");
+        assert!(metadata.get("network").is_none());
+        assert!(metadata.get("collectionMode").is_none());
+        assert!(metadata.get("collectedAt").is_none());
+    }
+
+    #[test]
+    fn one_shot_fixture_loads_through_benchmark_runner() {
+        let dir = temp_dir("one_shot_benchmark_loader");
+        let fixture_dir = dir.join("blockchain_tests");
+        fs::create_dir_all(&fixture_dir).unwrap();
+        let generated = test_generated_input(42, B256::repeat_byte(0xaa));
+        fs::write(
+            fixture_dir.join("one-shot.json"),
+            one_shot_fixture_json(&generated).unwrap(),
+        )
+        .unwrap();
+
+        let fixtures = stateless_validator_input_iter(&dir, None, ExecutionClient::Reth, None)
+            .unwrap()
+            .collect::<anyhow::Result<Vec<_>>>()
+            .unwrap();
+
+        assert_eq!(fixtures.len(), 1);
+        assert_eq!(
+            fixtures[0].input().unwrap().stdin(),
+            generated.stateless_input_bytes
+        );
+        assert_eq!(
+            fixtures[0].expected_public_values().unwrap(),
+            generated.stateless_output_bytes
+        );
+        assert_eq!(fixtures[0].metadata()["chain_id"], generated.chain_id);
+        assert_eq!(
+            fixtures[0].metadata()["block_number"],
+            generated.block_number
+        );
+        assert_eq!(fixtures[0].metadata()["block_used_gas"], generated.gas_used);
+    }
+
+    #[test]
+    fn rejects_legacy_artifact_shape() {
+        let dir = temp_dir("legacy_rejection");
+        let path = dir.join("legacy.json.zst");
+        let legacy = serde_json::json!({
+            "schemaVersion": 1,
+            "statelessInputBytes": "0x1501"
+        });
+        let compressed = zstd::bulk::compress(&serde_json::to_vec(&legacy).unwrap(), 3).unwrap();
+        fs::write(&path, compressed).unwrap();
+
+        let error = read_artifact(&path).unwrap_err();
+
+        assert!(error.to_string().contains("schema-v2 EEST artifact"));
+    }
+
+    #[test]
+    fn rejects_schema_v2_fixture_without_output_bytes() {
+        let dir = temp_dir("missing_output");
+        let path = dir.join("missing-output.json.zst");
+        let artifact = artifact_for(42, B256::repeat_byte(0xaa));
+        let mut value = serde_json::to_value(&artifact.fixture).unwrap();
+        let test = value.as_object_mut().unwrap().values_mut().next().unwrap();
+        test["blocks"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("statelessOutputBytes");
+        write_compressed_json(&path, &value);
+
+        let error = read_artifact(&path).unwrap_err();
+
+        assert!(error.to_string().contains("schema-v2 EEST artifact"));
+    }
+
+    #[test]
+    fn rejects_unsupported_schema_version() {
+        let dir = temp_dir("unsupported_schema");
+        let path = dir.join("unsupported.json.zst");
+        let artifact = artifact_for(42, B256::repeat_byte(0xaa));
+        let mut value = serde_json::to_value(&artifact.fixture).unwrap();
+        let test = value.as_object_mut().unwrap().values_mut().next().unwrap();
+        test["_info"]["metadata"]["witness_generator"]["schemaVersion"] = serde_json::json!(1);
+        write_compressed_json(&path, &value);
+
+        let error = read_artifact(&path).unwrap_err();
+
+        assert!(format!("{error:#}").contains("unsupported collected artifact"));
+    }
+
+    fn artifact_for(block_number: u64, block_hash: B256) -> StatelessInputArtifact {
+        StatelessInputArtifact::from_generated_at(
+            "glamsterdam-devnet-5",
             "head",
-            &generated,
+            &test_generated_input(block_number, block_hash),
             "2026-06-11T00:00:00Z",
             "test-commit".to_owned(),
         )
-        .unwrap_err();
-
-        assert!(error.to_string().contains("two-byte schema id"));
-    }
-
-    fn generated_input(block_number: u64, block_hash: B256) -> GeneratedInput {
-        GeneratedInput {
-            bytes: vec![0x15, 0x01, 0x02, 0x03],
-            block_hash,
-            block_number,
-            slot_number: 64,
-            chain_id: 1,
-        }
+        .unwrap()
     }
 
     fn temp_dir(name: &str) -> PathBuf {
@@ -369,5 +851,10 @@ mod tests {
         let _ = fs::remove_dir_all(&path);
         fs::create_dir_all(&path).unwrap();
         path
+    }
+
+    fn write_compressed_json(path: &Path, value: &serde_json::Value) {
+        let compressed = zstd::bulk::compress(&serde_json::to_vec(value).unwrap(), 3).unwrap();
+        fs::write(path, compressed).unwrap();
     }
 }

--- a/crates/witness-generator-spec-cli/src/builder.rs
+++ b/crates/witness-generator-spec-cli/src/builder.rs
@@ -6,18 +6,21 @@ use alloy_primitives::{B256, Bytes};
 use alloy_rlp::Decodable;
 use anyhow::{Context, ensure};
 use stateless_validator_common::{
-    SszList,
-    guest::input::{
-        ExecutionWitness, MAX_BYTES_PER_CODE, MAX_BYTES_PER_HEADER, MAX_BYTES_PER_WITNESS_NODE,
-        MAX_PUBLIC_KEYS, MAX_WITNESS_CODES, MAX_WITNESS_HEADERS, MAX_WITNESS_NODES,
-        PUBLIC_KEY_BYTES, ProtocolFork, StatelessInput,
-        new_payload_request::{
-            BlockAccessList, BuilderDepositRequest, BuilderDepositRequests, BuilderExitRequest,
-            BuilderExitRequests, ConsolidationRequest, ConsolidationRequests, DepositRequest,
-            DepositRequests, ExecutionPayloadV4, ExecutionRequestsGloas, ExtraData,
-            NewPayloadRequest, NewPayloadRequestGloas, Transaction as PayloadTransaction,
-            Transactions, VersionedHashes, Withdrawal, WithdrawalRequest, WithdrawalRequests,
-            Withdrawals,
+    HashTreeRoot as _, Sha2Hasher, SszEncode as _, SszList,
+    guest::{
+        StatelessValidationResult,
+        input::{
+            ExecutionWitness, MAX_BYTES_PER_CODE, MAX_BYTES_PER_HEADER, MAX_BYTES_PER_WITNESS_NODE,
+            MAX_PUBLIC_KEYS, MAX_WITNESS_CODES, MAX_WITNESS_HEADERS, MAX_WITNESS_NODES,
+            PUBLIC_KEY_BYTES, ProtocolFork, StatelessInput,
+            new_payload_request::{
+                BlockAccessList, BuilderDepositRequest, BuilderDepositRequests, BuilderExitRequest,
+                BuilderExitRequests, ConsolidationRequest, ConsolidationRequests, DepositRequest,
+                DepositRequests, ExecutionPayloadV4, ExecutionRequestsGloas, ExtraData,
+                NewPayloadRequest, NewPayloadRequestGloas, Transaction as PayloadTransaction,
+                Transactions, VersionedHashes, Withdrawal, WithdrawalRequest, WithdrawalRequests,
+                Withdrawals,
+            },
         },
     },
 };
@@ -35,7 +38,9 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GeneratedInput {
     /// Bytes encoded as `0x1501 || SSZ(StatelessInput)`.
-    pub bytes: Vec<u8>,
+    pub stateless_input_bytes: Vec<u8>,
+    /// Expected plain-SSZ [`StatelessValidationResult`] bytes.
+    pub stateless_output_bytes: Vec<u8>,
     /// Execution block hash.
     pub block_hash: B256,
     /// Execution block number.
@@ -44,6 +49,8 @@ pub struct GeneratedInput {
     pub slot_number: u64,
     /// Execution chain id.
     pub chain_id: u64,
+    /// Gas used by the execution payload.
+    pub gas_used: u64,
 }
 
 pub(crate) fn build_generated_input(
@@ -55,6 +62,7 @@ pub(crate) fn build_generated_input(
     let slot_number = payload.slot_number;
     let block_hash = payload.block_hash;
     let block_number = payload.block_number;
+    let gas_used = payload.gas_used;
     let transaction_artifacts = decode_transaction_artifacts(&payload.transactions)?;
 
     let new_payload_request = NewPayloadRequest::Gloas(NewPayloadRequestGloas {
@@ -71,6 +79,14 @@ pub(crate) fn build_generated_input(
     )
     .map_err(|err| anyhow::anyhow!("public_keys exceed SSZ bound: {err:?}"))?;
 
+    chain_config
+        .validate(&new_payload_request)
+        .context("generated chain configuration is not active for the payload")?;
+    let new_payload_request_root = new_payload_request.hash_tree_root(&Sha2Hasher);
+    let stateless_output_bytes =
+        StatelessValidationResult::new(new_payload_request_root, true, chain_config.clone())
+            .to_ssz();
+
     let stateless_input = StatelessInput {
         new_payload_request,
         witness,
@@ -78,14 +94,16 @@ pub(crate) fn build_generated_input(
         public_keys,
     };
 
-    let bytes = stateless_input.to_schema_prefixed_ssz(ProtocolFork::Amsterdam);
+    let stateless_input_bytes = stateless_input.to_schema_prefixed_ssz(ProtocolFork::Amsterdam);
 
     Ok(GeneratedInput {
-        bytes,
+        stateless_input_bytes,
+        stateless_output_bytes,
         block_hash,
         block_number,
         slot_number,
         chain_id,
+        gas_used,
     })
 }
 
@@ -360,6 +378,7 @@ fn decode_header_number(bytes: &[u8]) -> anyhow::Result<u64> {
 mod tests {
     use alloy_primitives::{b256, hex};
     use alloy_rlp::Encodable;
+    use stateless_validator_common::SszDecode as _;
 
     use super::*;
 
@@ -498,16 +517,27 @@ mod tests {
         let first = build_generated_input(envelope.clone(), witness.clone(), 1).unwrap();
         let second = build_generated_input(envelope, witness, 1).unwrap();
 
-        assert_eq!(first.bytes, second.bytes);
-        assert_eq!(&first.bytes[..2], &[0x15, 0x01]);
+        assert_eq!(first.stateless_input_bytes, second.stateless_input_bytes);
+        assert_eq!(&first.stateless_input_bytes[..2], &[0x15, 0x01]);
         assert_eq!(first.block_number, 10);
         assert_eq!(first.slot_number, 64);
         assert_eq!(first.chain_id, 1);
+        assert_eq!(first.gas_used, 21_000);
 
-        let (fork, decoded) = StatelessInput::from_schema_prefixed_ssz(&first.bytes).unwrap();
+        let (fork, decoded) =
+            StatelessInput::from_schema_prefixed_ssz(&first.stateless_input_bytes).unwrap();
         assert_eq!(fork, ProtocolFork::Amsterdam);
         assert_eq!(decoded.witness.state.len(), 1);
         assert_eq!(decoded.public_keys.len(), 0);
+        let output =
+            StatelessValidationResult::from_ssz_bytes(&first.stateless_output_bytes).unwrap();
+        assert!(!first.stateless_output_bytes.starts_with(&[0x15, 0x01]));
+        assert!(output.successful_validation);
+        assert_eq!(output.chain_config, decoded.chain_config);
+        assert_eq!(
+            output.new_payload_request_root,
+            decoded.new_payload_request.hash_tree_root(&Sha2Hasher)
+        );
         let NewPayloadRequest::Gloas(request) = decoded.new_payload_request else {
             panic!("Amsterdam input must decode as a Gloas payload request");
         };

--- a/crates/witness-generator-spec-cli/src/catalog.rs
+++ b/crates/witness-generator-spec-cli/src/catalog.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use tar::Archive;
 
 use crate::{
-    artifact::{self, path_to_slash_string, write_bytes_atomic},
+    artifact::{self, BATCH_MANIFEST_PATH, path_to_slash_string, write_bytes_atomic},
     config::CollectorConfig,
 };
 
@@ -82,6 +82,7 @@ struct PublicBatchEntry {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct BatchArchiveManifest {
+    schema_version: u64,
     network: String,
     batch_start_block: u64,
     batch_end_block: u64,
@@ -154,6 +155,12 @@ fn read_batch_entries(config: &CollectorConfig) -> anyhow::Result<Vec<PublicBatc
     for archive_path in archive_paths {
         let manifest = read_batch_manifest(&archive_path)?;
         ensure!(
+            manifest.schema_version == 2,
+            "batch archive {} uses unsupported manifest schema version {}; expected 2",
+            archive_path.display(),
+            manifest.schema_version
+        );
+        ensure!(
             manifest.network == config.network,
             "batch archive {} is for network {}, expected {}",
             archive_path.display(),
@@ -221,7 +228,8 @@ fn public_manifest(
             total_byte_length,
         },
         notes: vec![
-            "Public downloads are batch archives; individual block artifacts are inside those archives and are not published as standalone R2 objects.".to_owned(),
+            "Public downloads are batch archives containing benchmark-ready EEST fixtures under blockchain_tests/; individual fixtures are not published as standalone R2 objects.".to_owned(),
+            "After extraction, pass the archive root directly to ere-hosts --input-folder.".to_owned(),
             "Cloudflare R2 public buckets do not provide directory listing; use this page or the JSON indexes instead.".to_owned(),
         ],
     })
@@ -256,20 +264,26 @@ fn read_batch_manifest(path: &Path) -> anyhow::Result<BatchArchiveManifest> {
             .path()
             .with_context(|| format!("failed to read tar entry path from {}", path.display()))?
             .as_ref()
-            == Path::new("manifest.json")
+            == Path::new(BATCH_MANIFEST_PATH)
         {
             let mut bytes = Vec::new();
-            entry
-                .read_to_end(&mut bytes)
-                .with_context(|| format!("failed to read manifest.json from {}", path.display()))?;
+            entry.read_to_end(&mut bytes).with_context(|| {
+                format!(
+                    "failed to read {BATCH_MANIFEST_PATH} from {}",
+                    path.display()
+                )
+            })?;
             let manifest = serde_json::from_slice(&bytes).with_context(|| {
-                format!("failed to decode manifest.json from {}", path.display())
+                format!(
+                    "failed to decode {BATCH_MANIFEST_PATH} from {}",
+                    path.display()
+                )
             })?;
             return Ok(manifest);
         }
     }
     anyhow::bail!(
-        "batch archive {} does not contain manifest.json",
+        "batch archive {} does not contain {BATCH_MANIFEST_PATH}",
         path.display()
     )
 }
@@ -337,7 +351,7 @@ fn render_html(manifest: &PublicManifest, batches: &[PublicBatchEntry]) -> Strin
     html.push_str("</section>\n");
 
     html.push_str("<section class=\"panel\">\n<h2>How to download</h2>\n");
-    html.push_str("<p>Use the batch archive links below. Each archive contains block artifacts plus a <code>manifest.json</code>.</p>\n");
+    html.push_str("<p>Each archive contains benchmark-ready EEST fixtures under <code>blockchain_tests/</code> and metadata at <code>.meta/manifest.json</code>.</p>\n");
     if let Some(first_batch) = batches.first() {
         html.push_str("<pre>curl -LO ");
         push_escaped(&mut html, &first_batch.path);
@@ -351,6 +365,7 @@ fn render_html(manifest: &PublicManifest, batches: &[PublicBatchEntry]) -> Strin
                 .unwrap_or(&first_batch.path),
         );
         html.push_str("</pre>\n");
+        html.push_str("<p>Pass the extracted directory directly to <code>ere-hosts --input-folder</code>.</p>\n");
     } else {
         html.push_str("<p>No complete batch archives are available yet.</p>\n");
     }
@@ -454,10 +469,11 @@ mod tests {
 
     use alloy_primitives::B256;
     use serde_json::Value;
-    use witness_generator_spec_cli::GeneratedInput;
 
     use crate::{
-        artifact::{StatelessInputArtifact, append_index_entry, write_artifact_atomic},
+        artifact::{
+            StatelessInputArtifact, append_index_entry, test_generated_input, write_artifact_atomic,
+        },
         export,
     };
 
@@ -511,6 +527,8 @@ mod tests {
         let html = fs::read_to_string(config.network_root().join("index.html")).unwrap();
         assert!(html.contains("glamsterdam-devnet-5 stateless inputs"));
         assert!(html.contains("exports/batches/0-1.tar.zst"));
+        assert!(html.contains("blockchain_tests/"));
+        assert!(html.contains(".meta/manifest.json"));
         assert!(!html.contains("blocks.jsonl"));
         assert!(!html.contains("index.jsonl"));
     }
@@ -549,13 +567,7 @@ mod tests {
     }
 
     fn write_generated_artifact(config: &CollectorConfig, block_number: u64, block_hash: B256) {
-        let generated = GeneratedInput {
-            bytes: vec![0x15, 0x01, block_number as u8],
-            block_hash,
-            block_number,
-            slot_number: block_number + 100,
-            chain_id: 1,
-        };
+        let generated = test_generated_input(block_number, block_hash);
         let artifact = StatelessInputArtifact::from_generated_at(
             &config.network,
             "head",

--- a/crates/witness-generator-spec-cli/src/collector.rs
+++ b/crates/witness-generator-spec-cli/src/collector.rs
@@ -49,12 +49,12 @@ pub(crate) async fn collect(config: CollectorConfig, once: bool) -> anyhow::Resu
                     block_number = persisted.artifact.block_number,
                     block_hash = persisted.artifact.block_hash,
                     path = %persisted.write.path.display(),
-                    "collected stateless input artifact",
+                    "collected stateless EEST fixture",
                 );
             }
             Ok(None) => {}
             Err(error) => {
-                warn!(?error, "failed to collect stateless input artifact");
+                warn!(?error, "failed to collect stateless EEST fixture");
             }
         }
         time::sleep(config.poll_interval).await;
@@ -122,6 +122,8 @@ fn write_state(config: &CollectorConfig, artifact: &StatelessInputArtifact) -> a
 mod tests {
     use alloy_primitives::B256;
 
+    use crate::artifact::test_generated_input;
+
     use super::*;
 
     #[test]
@@ -176,12 +178,6 @@ mod tests {
     }
 
     fn generated_input(block_number: u64, block_hash: B256) -> GeneratedInput {
-        GeneratedInput {
-            bytes: vec![0x15, 0x01, 0x02, 0x03],
-            block_hash,
-            block_number,
-            slot_number: 64,
-            chain_id: 1,
-        }
+        test_generated_input(block_number, block_hash)
     }
 }

--- a/crates/witness-generator-spec-cli/src/export.rs
+++ b/crates/witness-generator-spec-cli/src/export.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
+    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -10,7 +11,8 @@ use tar::{Builder, Header};
 
 use crate::{
     artifact::{
-        self, StatelessInputArtifact, file_sha256_hex, path_to_slash_string, read_artifact,
+        self, BATCH_MANIFEST_PATH, StatelessInputArtifact, fixture_archive_path,
+        path_to_slash_string, read_artifact_with_json, sha256_hex,
     },
     config::CollectorConfig,
 };
@@ -20,8 +22,8 @@ const ZSTD_LEVEL: i32 = 3;
 #[derive(Debug, Clone)]
 struct ArtifactFile {
     path: PathBuf,
-    relative_path: PathBuf,
     artifact: StatelessInputArtifact,
+    fixture_json: Vec<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -43,12 +45,12 @@ struct BatchManifestArtifact {
     archive_path: String,
     block_number: u64,
     block_hash: String,
+    gas_used: u64,
     slot_number: u64,
     chain_id: u64,
-    stateless_input_sha256: String,
     stateless_input_byte_length: usize,
-    compressed_file_sha256: String,
-    compressed_file_byte_length: u64,
+    fixture_sha256: String,
+    fixture_byte_length: usize,
 }
 
 pub(crate) fn export_batches(
@@ -90,29 +92,19 @@ fn artifacts_by_block(
 
     let mut by_block: BTreeMap<u64, Vec<ArtifactFile>> = BTreeMap::new();
     for path in files {
-        let artifact = read_artifact(&path)?;
-        let relative_path = path
-            .strip_prefix(config.blocks_root())
-            .with_context(|| {
-                format!(
-                    "artifact {} is not under {}",
-                    path.display(),
-                    config.blocks_root().display()
-                )
-            })?
-            .to_path_buf();
+        let (artifact, fixture_json) = read_artifact_with_json(&path)?;
         by_block
             .entry(artifact.block_number)
             .or_default()
             .push(ArtifactFile {
                 path,
-                relative_path,
                 artifact,
+                fixture_json,
             });
     }
 
     for files in by_block.values_mut() {
-        files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        files.sort_by(|left, right| left.path.cmp(&right.path));
     }
 
     Ok(by_block)
@@ -166,24 +158,19 @@ fn write_batch_archive(
     let mut tar = Builder::new(encoder);
 
     for artifact in artifacts {
-        let archive_path = PathBuf::from("blocks").join(&artifact.relative_path);
-        tar.append_path_with_name(&artifact.path, &archive_path)
-            .with_context(|| {
-                format!(
-                    "failed to append {} as {}",
-                    artifact.path.display(),
-                    archive_path.display()
-                )
-            })?;
+        let archive_path = fixture_archive_path(&artifact.artifact);
+        append_bytes(&mut tar, &archive_path, &artifact.fixture_json).with_context(|| {
+            format!(
+                "failed to append {} as {}",
+                artifact.path.display(),
+                archive_path.display()
+            )
+        })?;
     }
 
     let manifest_bytes =
         serde_json::to_vec_pretty(&manifest).context("failed to serialize batch manifest")?;
-    let mut header = Header::new_gnu();
-    header.set_size(manifest_bytes.len() as u64);
-    header.set_mode(0o644);
-    header.set_cksum();
-    tar.append_data(&mut header, "manifest.json", manifest_bytes.as_slice())
+    append_bytes(&mut tar, Path::new(BATCH_MANIFEST_PATH), &manifest_bytes)
         .context("failed to append batch manifest")?;
 
     let encoder = tar.into_inner().context("failed to finish tar archive")?;
@@ -213,25 +200,23 @@ fn build_manifest(
     let artifacts = artifacts
         .iter()
         .map(|file| {
-            let archive_path = PathBuf::from("blocks").join(&file.relative_path);
+            let archive_path = fixture_archive_path(&file.artifact);
             Ok(BatchManifestArtifact {
                 archive_path: path_to_slash_string(&archive_path),
                 block_number: file.artifact.block_number,
                 block_hash: file.artifact.block_hash.clone(),
+                gas_used: file.artifact.gas_used,
                 slot_number: file.artifact.slot_number,
                 chain_id: file.artifact.chain_id,
-                stateless_input_sha256: file.artifact.stateless_input_sha256.clone(),
                 stateless_input_byte_length: file.artifact.stateless_input_byte_length,
-                compressed_file_sha256: file_sha256_hex(&file.path)?,
-                compressed_file_byte_length: fs::metadata(&file.path)
-                    .with_context(|| format!("failed to stat {}", file.path.display()))?
-                    .len(),
+                fixture_sha256: sha256_hex(&file.fixture_json),
+                fixture_byte_length: file.fixture_json.len(),
             })
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
     Ok(BatchManifest {
-        schema_version: 1,
+        schema_version: 2,
         network: config.network.clone(),
         batch_start_block: start,
         batch_end_block: end,
@@ -240,6 +225,15 @@ fn build_manifest(
         created_at: artifact::utc_now_rfc3339()?,
         artifacts,
     })
+}
+
+fn append_bytes<W: Write>(tar: &mut Builder<W>, path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    let mut header = Header::new_gnu();
+    header.set_size(bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    tar.append_data(&mut header, path, bytes)
+        .context("failed to append tar entry")
 }
 
 fn collect_artifact_files(dir: &Path, files: &mut Vec<PathBuf>) -> anyhow::Result<()> {
@@ -283,10 +277,12 @@ mod tests {
     use std::io::Read;
 
     use alloy_primitives::B256;
+    use benchmark_runner::stateless_validator::{
+        ExecutionClient, benchmark_fixture_paths, stateless_validator_input_iter,
+    };
     use tar::Archive;
-    use witness_generator_spec_cli::GeneratedInput;
 
-    use crate::artifact::{StatelessInputArtifact, write_artifact_atomic};
+    use crate::artifact::{StatelessInputArtifact, test_generated_input, write_artifact_atomic};
 
     use super::*;
 
@@ -308,11 +304,19 @@ mod tests {
         assert_eq!(manifest.batch_start_block, 0);
         assert_eq!(manifest.batch_end_block, 1);
         assert_eq!(manifest.artifact_count, 2);
-        assert!(
-            manifest
-                .artifacts
+        assert_eq!(manifest.schema_version, 2);
+        assert!(manifest.artifacts.iter().all(|artifact| {
+            artifact.archive_path.starts_with("blockchain_tests/")
+                && artifact.archive_path.ends_with(".json")
+        }));
+        let entries = archive_entries(&exported[0]);
+        assert!(entries.contains(&BATCH_MANIFEST_PATH.to_owned()));
+        assert_eq!(
+            entries
                 .iter()
-                .all(|artifact| artifact.archive_path.starts_with("blocks/"))
+                .filter(|path| path.starts_with("blockchain_tests/"))
+                .count(),
+            2
         );
     }
 
@@ -327,14 +331,40 @@ mod tests {
         assert_eq!(export_batches(&config, true).unwrap().len(), 1);
     }
 
+    #[test]
+    fn extracted_batch_is_directly_loadable_by_benchmark_runner() {
+        let config = test_config("benchmark_ready", 2);
+        write_generated_artifact(&config, 0, B256::repeat_byte(0xaa));
+        write_generated_artifact(&config, 1, B256::repeat_byte(0xbb));
+        let archive = export_batches(&config, false).unwrap().remove(0);
+        let extracted = config.out_root.join("extracted");
+
+        let file = fs::File::open(archive).unwrap();
+        let decoder = zstd::stream::read::Decoder::new(file).unwrap();
+        Archive::new(decoder).unpack(&extracted).unwrap();
+
+        let paths = benchmark_fixture_paths(&extracted).unwrap();
+        assert_eq!(paths.len(), 2);
+        assert!(
+            paths
+                .iter()
+                .all(|path| path.starts_with(extracted.join("blockchain_tests")))
+        );
+        let fixtures =
+            stateless_validator_input_iter(&extracted, None, ExecutionClient::Reth, None)
+                .unwrap()
+                .collect::<anyhow::Result<Vec<_>>>()
+                .unwrap();
+        assert_eq!(fixtures.len(), 2);
+        assert_eq!(
+            fixtures[0].expected_public_values().unwrap(),
+            test_generated_input(0, B256::repeat_byte(0xaa)).stateless_output_bytes
+        );
+        assert_eq!(fixtures[0].metadata()["block_used_gas"], 21_000);
+    }
+
     fn write_generated_artifact(config: &CollectorConfig, block_number: u64, block_hash: B256) {
-        let generated = GeneratedInput {
-            bytes: vec![0x15, 0x01, block_number as u8],
-            block_hash,
-            block_number,
-            slot_number: block_number + 100,
-            chain_id: 1,
-        };
+        let generated = test_generated_input(block_number, block_hash);
         let artifact = StatelessInputArtifact::from_generated_at(
             &config.network,
             "head",
@@ -352,13 +382,30 @@ mod tests {
         let mut archive = Archive::new(decoder);
         for entry in archive.entries().unwrap() {
             let mut entry = entry.unwrap();
-            if entry.path().unwrap().as_ref() == Path::new("manifest.json") {
+            if entry.path().unwrap().as_ref() == Path::new(BATCH_MANIFEST_PATH) {
                 let mut bytes = Vec::new();
                 entry.read_to_end(&mut bytes).unwrap();
                 return serde_json::from_slice(&bytes).unwrap();
             }
         }
         panic!("manifest not found");
+    }
+
+    fn archive_entries(path: &Path) -> Vec<String> {
+        let file = fs::File::open(path).unwrap();
+        let decoder = zstd::stream::read::Decoder::new(file).unwrap();
+        Archive::new(decoder)
+            .entries()
+            .unwrap()
+            .map(|entry| {
+                entry
+                    .unwrap()
+                    .path()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect()
     }
 
     fn test_config(name: &str, batch_size: u64) -> CollectorConfig {

--- a/crates/witness-generator-spec-cli/src/lib.rs
+++ b/crates/witness-generator-spec-cli/src/lib.rs
@@ -1,4 +1,4 @@
-//! Build canonical Amsterdam stateless guest input bytes from live network RPC data.
+//! Build canonical Amsterdam stateless guest input and expected output bytes from live RPC data.
 
 mod builder;
 mod chain_config;
@@ -13,6 +13,8 @@ pub use builder::GeneratedInput;
 use reqwest::Client;
 
 // These dependencies are used by this package's CLI target.
+#[cfg(test)]
+use benchmark_runner as _;
 use clap as _;
 use humantime as _;
 use sha2 as _;
@@ -83,7 +85,7 @@ impl NetworkWitnessClient {
         })
     }
 
-    /// Fetches network data for `selector` and returns canonical spec guest input bytes.
+    /// Fetches network data and returns canonical spec guest input and expected output bytes.
     pub async fn stateless_input_bytes(
         &self,
         selector: BlockSelector,
@@ -182,7 +184,7 @@ mod tests {
             NetworkWitnessClient::new(NetworkWitnessConfig::new(cl_endpoint, el_endpoint))?;
         let generated = client.stateless_input_bytes(BlockSelector::Head).await?;
 
-        assert!(generated.bytes.starts_with(&[0x15, 0x01]));
+        assert!(generated.stateless_input_bytes.starts_with(&[0x15, 0x01]));
         assert!(generated.block_number > 0);
         Ok(())
     }

--- a/crates/witness-generator-spec-cli/src/main.rs
+++ b/crates/witness-generator-spec-cli/src/main.rs
@@ -1,4 +1,4 @@
-//! CLI entry point for generating and collecting canonical stateless input bytes.
+//! CLI entry point for generating and collecting canonical stateless fixtures.
 
 #![allow(
     unused_crate_dependencies,
@@ -18,9 +18,8 @@ use std::{
     path::PathBuf,
 };
 
-use alloy_primitives::hex;
 use anyhow::Context;
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand};
 use config::CollectorConfig;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -29,7 +28,7 @@ use witness_generator_spec_cli::{BlockSelector, NetworkWitnessClient, NetworkWit
 #[derive(Debug, Parser)]
 #[command(
     name = "witness-generator-spec-cli",
-    about = "Generate and collect canonical Amsterdam stateless guest input bytes from CL/EL RPC endpoints.",
+    about = "Generate and collect canonical Amsterdam stateless guest fixtures from CL/EL RPC endpoints.",
     long_about = None
 )]
 struct Cli {
@@ -48,9 +47,6 @@ struct Cli {
     /// Execution block number to resolve to a CL slot via block timestamp.
     #[arg(long, conflicts_with = "block_id")]
     execution_block_number: Option<u64>,
-    /// Output encoding.
-    #[arg(long, value_enum, default_value_t = OutputFormat::Hex)]
-    format: OutputFormat,
     /// Output file. Stdout is used when omitted.
     #[arg(long)]
     out: Option<PathBuf>,
@@ -58,7 +54,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// Generate canonical stateless input bytes once.
+    /// Generate one benchmark-ready EEST fixture.
     Generate(GenerateArgs),
     /// Poll the live network head and store one artifact per observed block.
     Collect(CollectArgs),
@@ -82,9 +78,6 @@ struct GenerateArgs {
     /// Execution block number to resolve to a CL slot via block timestamp.
     #[arg(long, conflicts_with = "block_id")]
     execution_block_number: Option<u64>,
-    /// Output encoding.
-    #[arg(long, value_enum, default_value_t = OutputFormat::Hex)]
-    format: OutputFormat,
     /// Output file. Stdout is used when omitted.
     #[arg(long)]
     out: Option<PathBuf>,
@@ -115,12 +108,6 @@ struct PublishR2Args {
     /// TOML config path.
     #[arg(long)]
     config: PathBuf,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-enum OutputFormat {
-    Hex,
-    Raw,
 }
 
 #[tokio::main]
@@ -168,7 +155,6 @@ impl Cli {
                 .context("--el-url is required when no subcommand is used")?,
             block_id: self.block_id,
             execution_block_number: self.execution_block_number,
-            format: self.format,
             out: self.out,
         })
     }
@@ -178,10 +164,7 @@ async fn run_generate(args: GenerateArgs) -> anyhow::Result<()> {
     let selector = block_selector(args.block_id.as_deref(), args.execution_block_number);
     let client = NetworkWitnessClient::new(NetworkWitnessConfig::new(args.cl_url, args.el_url))?;
     let generated = client.stateless_input_bytes(selector).await?;
-    let output = match args.format {
-        OutputFormat::Hex => format!("0x{}\n", hex::encode(&generated.bytes)).into_bytes(),
-        OutputFormat::Raw => generated.bytes,
-    };
+    let output = artifact::one_shot_fixture_json(&generated)?;
 
     if let Some(path) = args.out {
         fs::write(path, output)?;
@@ -234,15 +217,14 @@ mod tests {
             "http://cl",
             "--el-url",
             "http://el",
-            "--format",
-            "raw",
         ])
         .unwrap();
 
         let Some(Command::Generate(args)) = cli.command else {
             panic!("expected generate subcommand");
         };
-        assert_eq!(args.format, OutputFormat::Raw);
+        assert_eq!(args.cl_url, "http://cl");
+        assert_eq!(args.el_url, "http://el");
     }
 
     #[test]

--- a/docs/benchmark-execution-inputs.md
+++ b/docs/benchmark-execution-inputs.md
@@ -26,6 +26,10 @@ When the input path contains a `blockchain_tests/` subdirectory, only that subtr
 
 An empty directory retains the existing discovery behavior: it produces no fixture paths.
 
+Batch archives exported by `witness-generator-spec-cli` use this layout. After
+extracting one, pass the extraction root as `--input-folder`; discovery selects
+its `blockchain_tests/` subtree and ignores `.meta/manifest.json`.
+
 ## Canonical EEST Schema
 
 The only accepted benchmark fixture format is an EEST `blockchain_tests` JSON object whose executable blocks contain `statelessInputBytes` and `statelessOutputBytes`:

--- a/docs/stateless-input-publication.md
+++ b/docs/stateless-input-publication.md
@@ -1,6 +1,6 @@
-# Stateless Input Publication
+# Stateless Fixture Publication
 
-This guide describes how to publish canonical stateless input batches as a public R2 dataset.
+This guide describes how to publish benchmark-ready stateless fixture batches as a public R2 dataset.
 
 ## Public Dataset Shape
 
@@ -16,7 +16,9 @@ The public dataset is batch-first. Users should download complete `.tar.zst` bat
 exports/batches/<start>-<end>.tar.zst
 ```
 
-Individual block artifacts remain described inside each batch archive's `manifest.json`, but they are not published as standalone public objects.
+Each archive contains directly executable EEST fixtures under `blockchain_tests/`
+and describes them in `.meta/manifest.json`. Individual fixtures are not
+published as standalone public objects.
 
 ## Generated Catalog Files
 
@@ -31,7 +33,19 @@ The generated links are relative, so the same catalog works with an `r2.dev` dev
 
 ## Operator Flow
 
-Collect live stateless inputs:
+Schema v2 is a clean cut and does not read input-only v1 artifacts. Configure a
+fresh local output root and publish to a fresh R2 prefix when deploying it.
+
+Generate one benchmark-ready fixture without starting the collector:
+
+```bash
+cargo run -p witness-generator-spec-cli --release -- generate \
+    --cl-url http://127.0.0.1:3500 \
+    --el-url http://127.0.0.1:8545 \
+    --out block.json
+```
+
+Collect live stateless fixtures:
 
 ```bash
 cargo run -p witness-generator-spec-cli --release -- collect \
@@ -80,14 +94,24 @@ curl -fsSL https://<public-host>/devnets/<network>/manifest.json | jq
 curl -fsSL https://<public-host>/devnets/<network>/batches.jsonl | head
 ```
 
+Run an extracted batch directly with the benchmark runner:
+
+```bash
+cargo run -p ere-hosts --release -- --zkvms sp1 \
+  stateless-validator --execution-client reth \
+  --input-folder /path/to/extracted-batch
+```
+
+The runner detects the extracted `blockchain_tests/` directory automatically.
+
 ## Local EEST Validation
 
 Use [`scripts/validate-r2-stateless-inputs-with-eest.py`](../scripts/validate-r2-stateless-inputs-with-eest.py)
 to validate published R2 batch archives against the EEST Amsterdam stateless
 guest. The script downloads the selected batch archives, verifies the catalog
-metadata, decompresses each `blocks/*.json.zst` artifact, checks the recorded
-stateless input byte length and SHA-256 digest, and runs each stateless input
-through EEST.
+metadata, reads each `blockchain_tests/**/*.json` fixture, checks its recorded
+stateless input byte length, runs each input through EEST, and requires EEST's
+complete output bytes to match the stored `statelessOutputBytes` exactly.
 
 Prerequisites:
 

--- a/scripts/validate-r2-stateless-inputs-with-eest.py
+++ b/scripts/validate-r2-stateless-inputs-with-eest.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-"""Validate public R2 stateless input batches with the EEST spec guest."""
+"""Validate public R2 stateless fixture batches with the EEST spec guest."""
 
 from __future__ import annotations
 
 import argparse
 import hashlib
-import io
 import json
 import sys
 import tarfile
@@ -29,6 +28,8 @@ DEFAULT_CATALOG_URL = (
 REQUEST_TIMEOUT_SECONDS = 60
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 FAILURE_MARKDOWN_LIMIT = 20
+BATCH_MANIFEST_PATH = ".meta/manifest.json"
+ARTIFACT_SCHEMA_VERSION = 2
 
 
 class ValidationError(Exception):
@@ -101,7 +102,7 @@ def main() -> int:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Validate R2 stateless input batches with EEST",
+        description="Validate R2 stateless fixture batches with EEST",
     )
     parser.add_argument(
         "--catalog-url",
@@ -390,6 +391,7 @@ def validate_batch(
     artifact_count = 0
     successful_artifacts = 0
     batch_manifest: dict[str, Any] | None = None
+    observed_artifacts: dict[str, dict[str, Any]] = {}
     stopped_early = False
     full_batch_validation = block_number is None and max_artifacts is None
 
@@ -403,7 +405,7 @@ def validate_batch(
                 extracted = archive.extractfile(member)
                 if extracted is None:
                     continue
-                if member_name == "manifest.json":
+                if member_name == BATCH_MANIFEST_PATH:
                     batch_manifest = read_json_member(extracted, member_name)
                 elif is_artifact_member(member_name):
                     if block_number is not None:
@@ -419,14 +421,23 @@ def validate_batch(
                     artifact_count += 1
                     artifact = None
                     try:
-                        artifact = read_artifact_member(extracted, member_name)
+                        artifact, fixture_bytes = read_artifact_member(
+                            extracted,
+                            member_name,
+                        )
                         if (
                             block_number is not None
-                            and artifact.get("blockNumber") != block_number
+                            and fixture_block_number(artifact) != block_number
                         ):
                             artifact_count -= 1
                             continue
                         validate_artifact(batch, member_name, artifact, guest)
+                        observed_artifacts[member_name] = {
+                            "archivePath": member_name,
+                            "fixtureByteLength": len(fixture_bytes),
+                            "fixtureSha256": "0x"
+                            + hashlib.sha256(fixture_bytes).hexdigest(),
+                        }
                         successful_artifacts += 1
                     except Exception as error:
                         failures.append(
@@ -447,7 +458,12 @@ def validate_batch(
         )
     if full_batch_validation:
         failures.extend(
-            validate_batch_manifest(batch, batch_manifest, artifact_count)
+            validate_batch_manifest(
+                batch,
+                batch_manifest,
+                artifact_count,
+                observed_artifacts,
+            )
         )
 
     return (
@@ -486,7 +502,10 @@ def download_file(url: str, path: Path) -> tuple[str, int]:
 
 
 def is_artifact_member(member_name: str) -> bool:
-    return member_name.startswith("blocks/") and member_name.endswith(".json.zst")
+    return (
+        member_name.startswith("blockchain_tests/")
+        and member_name.endswith(".json")
+    )
 
 
 def block_number_from_member_name(member_name: str) -> int | None:
@@ -510,24 +529,18 @@ def read_json_member(member_file: Any, member_name: str) -> dict[str, Any]:
     return value
 
 
-def read_artifact_member(member_file: Any, member_name: str) -> dict[str, Any]:
-    compressed = member_file.read()
-    try:
-        reader = zstandard.ZstdDecompressor().stream_reader(
-            io.BytesIO(compressed)
-        )
-        with reader:
-            data = reader.read()
-    except zstandard.ZstdError as error:
-        raise ValidationError(f"failed to decompress {member_name}") from error
-
+def read_artifact_member(
+    member_file: Any,
+    member_name: str,
+) -> tuple[dict[str, Any], bytes]:
+    data = member_file.read()
     try:
         value = json.loads(data)
     except json.JSONDecodeError as error:
         raise ValidationError(f"failed to decode {member_name} JSON") from error
     if not isinstance(value, dict):
         raise ValidationError(f"{member_name} must contain a JSON object")
-    return value
+    return value, data
 
 
 def validate_artifact(
@@ -536,13 +549,30 @@ def validate_artifact(
     artifact: dict[str, Any],
     guest: EestGuest,
 ) -> None:
+    _, test, block, metadata = fixture_parts(artifact)
+    if test.get("network") != "Amsterdam":
+        raise ValidationError("EEST fixture network must be Amsterdam")
+    if metadata.get("schemaVersion") != ARTIFACT_SCHEMA_VERSION:
+        raise ValidationError(
+            "unsupported witness_generator schemaVersion: "
+            f"expected {ARTIFACT_SCHEMA_VERSION}, "
+            f"got {metadata.get('schemaVersion')}"
+        )
+    if metadata.get("network") != batch.network:
+        raise ValidationError(
+            "witness_generator.network mismatch: "
+            f"expected {batch.network}, got {metadata.get('network')}"
+        )
+
     input_bytes = decode_hex_bytes(
         "statelessInputBytes",
-        artifact.get("statelessInputBytes"),
+        block.get("statelessInputBytes"),
     )
+    if not input_bytes:
+        raise ValidationError("statelessInputBytes must not be empty")
     expected_length = int_required(
         "statelessInputByteLength",
-        artifact.get("statelessInputByteLength"),
+        metadata.get("statelessInputByteLength"),
     )
     if len(input_bytes) != expected_length:
         raise ValidationError(
@@ -550,20 +580,18 @@ def validate_artifact(
             f"expected {expected_length}, got {len(input_bytes)}"
         )
 
-    expected_sha256 = normalize_sha256(
-        str_required(
-            "statelessInputSha256",
-            artifact.get("statelessInputSha256"),
-        )
-    )
-    actual_sha256 = hashlib.sha256(input_bytes).hexdigest()
-    if actual_sha256 != expected_sha256:
+    schema_id = str_required(
+        "statelessInputSchemaId",
+        metadata.get("statelessInputSchemaId"),
+    ).lower()
+    actual_schema_id = "0x" + input_bytes[:2].hex()
+    if len(input_bytes) < 2 or schema_id != actual_schema_id:
         raise ValidationError(
-            "statelessInputSha256 mismatch: "
-            f"expected {expected_sha256}, got {actual_sha256}"
+            "statelessInputSchemaId mismatch: "
+            f"expected {schema_id}, got {actual_schema_id}"
         )
 
-    block_number = int_required("blockNumber", artifact.get("blockNumber"))
+    block_number = fixture_block_number(artifact)
     if block_number < batch.batch_start_block or block_number > batch.batch_end_block:
         raise ValidationError(
             "blockNumber outside selected batch range: "
@@ -571,15 +599,92 @@ def validate_artifact(
             f"{batch.batch_start_block}-{batch.batch_end_block}"
         )
 
-    output_bytes = guest.run_stateless_guest(guest.bytes_type(input_bytes))
-    output = guest.deserialize_stateless_output(output_bytes)
-    if not bool(output.successful_validation):
-        output_root = bytes(output.new_payload_request_root).hex()
+    expected_output_bytes = decode_hex_bytes(
+        "statelessOutputBytes",
+        block.get("statelessOutputBytes"),
+    )
+    if not expected_output_bytes:
+        raise ValidationError("statelessOutputBytes must not be empty")
+    expected_output = guest.deserialize_stateless_output(
+        guest.bytes_type(expected_output_bytes)
+    )
+    if not bool(expected_output.successful_validation):
+        raise ValidationError(
+            "stored statelessOutputBytes does not expect successful validation "
+            f"({stateless_output_diagnostics(expected_output)})"
+        )
+
+    actual_output_bytes = bytes(
+        guest.run_stateless_guest(guest.bytes_type(input_bytes))
+    )
+    actual_output = guest.deserialize_stateless_output(
+        guest.bytes_type(actual_output_bytes)
+    )
+    if actual_output_bytes != expected_output_bytes:
+        raise ValidationError(
+            "statelessOutputBytes mismatch: "
+            f"expected {stateless_output_diagnostics(expected_output)}, "
+            f"got {stateless_output_diagnostics(actual_output)}; "
+            f"{stateless_input_diagnostics(input_bytes, guest)}"
+        )
+    if not bool(actual_output.successful_validation):
         raise ValidationError(
             "EEST stateless guest returned unsuccessful_validation "
-            f"(newPayloadRequestRoot=0x{output_root}; "
+            f"({stateless_output_diagnostics(actual_output)}; "
             f"{stateless_input_diagnostics(input_bytes, guest)})"
         )
+
+
+def fixture_parts(
+    artifact: dict[str, Any],
+) -> tuple[str, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    if len(artifact) != 1:
+        raise ValidationError("schema-v2 EEST fixture must contain exactly one test")
+    test_name, test = next(iter(artifact.items()))
+    if not isinstance(test, dict):
+        raise ValidationError(f"EEST test {test_name} must be an object")
+    blocks = test.get("blocks")
+    if not isinstance(blocks, list) or len(blocks) != 1:
+        raise ValidationError(
+            f"EEST test {test_name} must contain exactly one block"
+        )
+    block = blocks[0]
+    if not isinstance(block, dict):
+        raise ValidationError(f"EEST test {test_name} block must be an object")
+    info = test.get("_info")
+    if not isinstance(info, dict):
+        raise ValidationError(f"EEST test {test_name} is missing _info")
+    metadata_container = info.get("metadata")
+    if not isinstance(metadata_container, dict):
+        raise ValidationError(
+            f"EEST test {test_name} is missing _info.metadata"
+        )
+    metadata = metadata_container.get("witness_generator")
+    if not isinstance(metadata, dict):
+        raise ValidationError(
+            f"EEST test {test_name} is missing witness_generator metadata"
+        )
+    return test_name, test, block, metadata
+
+
+def fixture_block_number(artifact: dict[str, Any]) -> int:
+    _, _, block, _ = fixture_parts(artifact)
+    block_header = block.get("blockHeader")
+    if not isinstance(block_header, dict):
+        raise ValidationError("EEST fixture block is missing blockHeader")
+    return parse_json_u64(
+        "blockHeader.number",
+        block_header.get("number"),
+    )
+
+
+def stateless_output_diagnostics(output: Any) -> str:
+    output_root = bytes(output.new_payload_request_root).hex()
+    return (
+        f"newPayloadRequestRoot=0x{output_root}, "
+        f"successfulValidation={bool(output.successful_validation)}, "
+        f"chainId={int(output.chain_config.chain_id)}"
+    )
 
 
 def stateless_input_diagnostics(input_bytes: bytes, guest: EestGuest) -> str:
@@ -607,12 +712,20 @@ def validate_batch_manifest(
     batch: BatchEntry,
     manifest: dict[str, Any] | None,
     artifact_count: int,
+    observed_artifacts: dict[str, dict[str, Any]],
 ) -> list[dict[str, Any]]:
     failures = []
     if manifest is None:
-        return [batch_failure(batch, "manifest.json", "missing batch manifest")]
+        return [
+            batch_failure(
+                batch,
+                BATCH_MANIFEST_PATH,
+                "missing batch manifest",
+            )
+        ]
 
     checks = [
+        ("schemaVersion", ARTIFACT_SCHEMA_VERSION),
         ("network", batch.network),
         ("batchStartBlock", batch.batch_start_block),
         ("batchEndBlock", batch.batch_end_block),
@@ -625,7 +738,7 @@ def validate_batch_manifest(
             failures.append(
                 batch_failure(
                     batch,
-                    "manifest.json",
+                    BATCH_MANIFEST_PATH,
                     f"{field_name} mismatch: expected {expected}, got {actual}",
                 )
             )
@@ -633,14 +746,61 @@ def validate_batch_manifest(
         failures.append(
             batch_failure(
                 batch,
-                "manifest.json",
+                BATCH_MANIFEST_PATH,
                 (
                     "artifact count mismatch: "
                     f"expected {batch.artifact_count}, got {artifact_count}"
                 ),
             )
         )
+    manifest_artifacts = manifest.get("artifacts")
+    if not isinstance(manifest_artifacts, list):
+        failures.append(
+            batch_failure(
+                batch,
+                BATCH_MANIFEST_PATH,
+                "artifacts must be an array",
+            )
+        )
+        return failures
+    by_path = {
+        entry.get("archivePath"): entry
+        for entry in manifest_artifacts
+        if isinstance(entry, dict) and isinstance(entry.get("archivePath"), str)
+    }
+    for archive_path, observed in observed_artifacts.items():
+        expected = by_path.get(archive_path)
+        if expected is None:
+            failures.append(
+                batch_failure(
+                    batch,
+                    BATCH_MANIFEST_PATH,
+                    f"missing manifest artifact entry for {archive_path}",
+                )
+            )
+            continue
+        for field_name in ("fixtureByteLength", "fixtureSha256"):
+            if expected.get(field_name) != observed[field_name]:
+                failures.append(
+                    batch_failure(
+                        batch,
+                        BATCH_MANIFEST_PATH,
+                        (
+                            f"{archive_path} {field_name} mismatch: "
+                            f"expected {expected.get(field_name)}, "
+                            f"got {observed[field_name]}"
+                        ),
+                    )
+                )
     return failures
+
+
+def parse_json_u64(field_name: str, value: Any) -> int:
+    raw = str_required(field_name, value).strip()
+    try:
+        return int(raw, 16 if raw.lower().startswith("0x") else 10)
+    except ValueError as error:
+        raise ValidationError(f"{field_name} is not a valid integer") from error
 
 
 def decode_hex_bytes(field_name: str, value: Any) -> bytes:
@@ -690,8 +850,12 @@ def artifact_failure(
         f"{type(error).__name__}: {error}",
     )
     if artifact is not None:
-        failure["blockNumber"] = artifact.get("blockNumber")
-        failure["blockHash"] = artifact.get("blockHash")
+        try:
+            _, _, _, metadata = fixture_parts(artifact)
+            failure["blockNumber"] = fixture_block_number(artifact)
+            failure["blockHash"] = metadata.get("blockHash")
+        except Exception:
+            pass
     return failure
 
 
@@ -775,7 +939,7 @@ def render_markdown_summary(summary: dict[str, Any]) -> str:
     totals = summary["totals"]
     eest = summary["eest"]
     lines = [
-        "# EEST R2 Stateless Input Validation",
+        "# EEST R2 Stateless Fixture Validation",
         "",
         f"- Catalog: `{summary['catalogUrl']}`",
         f"- EEST ref: `{eest['ref']}`",


### PR DESCRIPTION
_Note: this is targeting https://github.com/eth-act/zkevm-benchmark-workload/pull/301 branch, just to keep things clean from a merging perspective. ~Still pending to try it out in `glamsterdam-devnet-7` and R2 bucket with new format.~_

This PR makes EEST blockchain-test fixtures the unified output format of `witness-generator-spec-cli`.

The main goal is consistency across the stateless-validation toolchain:

- EL implementations already use EEST fixtures as the common interoperability format.
- `ere-hosts` already discovers and consumes EEST fixtures directly.
- The witness generator can now produce the same format from live CL/EL networks, avoiding a separate generator-specific artifact schema and conversion step.

This means the complete workflow is now:

```text
collect live blocks → EEST fixtures → export batch → extract → ere-hosts
```

## Expected stateless output

The generator now produces both `statelessInputBytes` and the expected `statelessOutputBytes`.

The expected output does not require executing the block. After constructing the `StatelessInput`, the generator:

1. validates the generated chain configuration against the payload;
2. calculates the SSZ hash-tree-root of `new_payload_request` using SHA-256;
3. constructs a successful `StatelessValidationResult` containing that root and the input chain configuration;
4. serializes the result as plain SSZ, without an input schema prefix.

This provides the complete expected public output required by `ere-hosts` while leaving full execution validation to the stateless guest.

## Unified EEST fixture format

Both one-shot generation and live collection use the same fixture serializer.

Each fixture contains:

- `network: "Amsterdam"`;
- hexadecimal `config.chainid`;
- one block with `statelessInputBytes` and `statelessOutputBytes`;
- block number and gas used;
- block hash, slot, generator provenance, schema version, and collection metadata where applicable.

`generate` now always outputs a benchmark-ready EEST JSON fixture. The old input-only `hex` and `raw` output modes and the `--format` option were removed.

Live collection stores each fixture as an individually compressed `.json.zst` file. The decompressed content is a complete EEST fixture rather than a custom artifact object.

## Benchmark-ready exports

Exported `.tar.zst` batches now use this layout:

```text
blockchain_tests/<chunk>/<block-hash>.json
.meta/manifest.json
```

Fixtures inside the archive are uncompressed JSON; compression is provided by the outer archive.

After extraction, the archive root can be passed directly to:

```bash
ere-hosts ... stateless-validator --input-folder <extracted-root>
```

No conversion or fixture preparation step is required.

The batch manifest records fixture paths, fixture checksums and lengths, block metadata, and input length. It lives under `.meta/` so `ere-hosts` fixture discovery does not interpret it as a blockchain test.