### PR TITLE
feat: load only last block of eest fixture, and add target_opcode

### DIFF
--- a/crates/benchmark-runner/src/stateless_validator/eest.rs
+++ b/crates/benchmark-runner/src/stateless_validator/eest.rs
@@ -18,7 +18,8 @@ pub(crate) struct EestStatelessFixture {
     pub(crate) chain_id: u64,
     pub(crate) block_number: Option<u64>,
     pub(crate) block_used_gas: Option<u64>,
-    pub(crate) opcode_count: BTreeMap<String, u64>,
+    pub(crate) opcode_count: Option<BTreeMap<String, u64>>,
+    pub(crate) target_opcode: Option<String>,
     pub(crate) stateless_input_bytes: Vec<u8>,
     pub(crate) stateless_output_bytes: Vec<u8>,
 }
@@ -48,7 +49,9 @@ struct EestInfo {
 #[derive(Debug, Default, Deserialize)]
 struct EestMetadata {
     #[serde(default)]
-    opcode_count_per_block: Vec<BTreeMap<String, u64>>,
+    opcode_count_per_block: Option<Vec<BTreeMap<String, u64>>>,
+    #[serde(default)]
+    target_opcode: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -90,20 +93,25 @@ pub(crate) fn load_eest_benchmark_fixtures(
     let mut fixtures = Vec::new();
     let mut fixture_names = HashSet::new();
 
-    for (test_name, case) in cases {
+    for (test_name, mut case) in cases {
         let chain_id = parse_json_u64(&case.config.chainid)
             .with_context(|| format!("Failed to parse chainid for EEST test {test_name}"))?;
 
-        let opcode_count_per_block = case.info.metadata.opcode_count_per_block;
-        if !opcode_count_per_block.is_empty() && opcode_count_per_block.len() != case.blocks.len() {
+        let opcode_count_per_block = case.info.metadata.opcode_count_per_block.as_ref();
+        if opcode_count_per_block
+            .is_some_and(|opcode_count_per_block| opcode_count_per_block.len() != case.blocks.len())
+        {
             bail!(
                 "EEST test {test_name} has {} opcode_count_per_block entries but {} blocks",
-                opcode_count_per_block.len(),
+                opcode_count_per_block.unwrap().len(),
                 case.blocks.len()
             );
         }
 
-        for (block_index, block) in case.blocks.into_iter().enumerate() {
+        // For EEST benchmark fixtures, the worst case block is the last block and the others are setup blocks,
+        // so here we only load the last block as benchmark fixture.
+        let block_index = case.blocks.len().saturating_sub(1);
+        if let Some(block) = case.blocks.pop() {
             let Some(input_hex) = block.stateless_input_bytes else {
                 info!(
                     "Skipping EEST test {test_name} block {block_index} from {source_path}: missing statelessInputBytes"
@@ -166,9 +174,8 @@ pub(crate) fn load_eest_benchmark_fixtures(
                 block_number,
                 block_used_gas,
                 opcode_count: opcode_count_per_block
-                    .get(block_index)
-                    .cloned()
-                    .unwrap_or_default(),
+                    .map(|opcode_count_per_block| opcode_count_per_block[block_index].clone()),
+                target_opcode: case.info.metadata.target_opcode,
                 stateless_input_bytes,
                 stateless_output_bytes,
             });
@@ -324,8 +331,8 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "eest__tests_foo_py_test_same_name_a__block0".to_string(),
-                "eest__tests_foo_py_test_same_name_a__block0__2".to_string(),
+                "eest__tests_foo_py_test_same_name_a__block2".to_string(),
+                "eest__tests_foo_py_test_same_name_a__block2__2".to_string(),
             ]
         );
         assert!(names.iter().all(|name| name.starts_with("eest__")));
@@ -343,20 +350,28 @@ mod tests {
             fixture.source_path,
             "blockchain_tests/for_amsterdam/compute/mcopy.json"
         );
-        assert_eq!(fixture.block_index, 0);
+        assert_eq!(fixture.block_index, 2);
         assert_eq!(fixture.chain_id, 1);
         assert_eq!(fixture.block_number, Some(1));
         assert_eq!(fixture.block_used_gas, Some(16));
         assert_eq!(
             fixture.opcode_count,
-            BTreeMap::from([("PUSH1".to_string(), 5), ("SSTORE".to_string(), 2)])
+            Some(BTreeMap::from([
+                ("PUSH1".to_string(), 5),
+                ("SSTORE".to_string(), 2)
+            ]))
         );
+        assert_eq!(fixture.target_opcode, Some("MCOPY".to_string()));
 
         let info_without_per_block = fixtures
             .iter()
             .find(|fixture| fixture.original_test_name == "tests/foo.py::test_same[name?a]")
             .unwrap();
-        assert!(info_without_per_block.opcode_count.is_empty());
+        assert!(info_without_per_block.opcode_count.is_none());
+        assert_eq!(
+            info_without_per_block.target_opcode,
+            Some("ADD".to_string())
+        );
 
         Ok(())
     }
@@ -449,21 +464,31 @@ mod tests {
 
     pub(crate) fn sample_eest_fixture() -> &'static str {
         r#"{
+            "tests/foo.py::test_same[empty_input]": {
+                "network": "Amsterdam",
+                "config": {"chainid": "0x01"},
+                "blocks": [
+                    {
+                        "statelessInputBytes": "0x",
+                        "statelessOutputBytes": "0xcc"
+                    }
+                ]
+            },
             "tests/foo.py::test_same[name/a]": {
                 "network": "Amsterdam",
                 "config": {"chainid": "0x01"},
                 "blocks": [
                     {
                         "statelessInputBytes": "0x150102",
-                        "statelessOutputBytes": "0xaabb",
-                        "blockHeader": {"number": "0x01", "gasUsed": "0x10"}
+                        "statelessOutputBytes": "0xcc"
                     },
                     {
                         "blockHeader": {"number": "0x02", "gasUsed": "0x20"}
                     },
                     {
-                        "statelessInputBytes": "0x",
-                        "statelessOutputBytes": "0xcc"
+                        "statelessInputBytes": "0x150102",
+                        "statelessOutputBytes": "0xaabb",
+                        "blockHeader": {"number": "0x01", "gasUsed": "0x10"}
                     }
                 ],
                 "_info": {
@@ -471,9 +496,9 @@ mod tests {
                         "opcode_count": {"PUSH1": 8, "SSTORE": 2, "MCOPY": 7},
                         "target_opcode": "MCOPY",
                         "opcode_count_per_block": [
-                            {"PUSH1": 5, "SSTORE": 2},
+                            {"MCOPY": 7},
                             {"PUSH1": 3},
-                            {"MCOPY": 7}
+                            {"PUSH1": 5, "SSTORE": 2}
                         ]
                     }
                 }
@@ -482,6 +507,8 @@ mod tests {
                 "network": "Amsterdam",
                 "config": {"chainid": "0x01"},
                 "blocks": [
+                    {},
+                    {},
                     {
                         "statelessInputBytes": "0x0f",
                         "statelessOutputBytes": "0xdead",

--- a/crates/benchmark-runner/src/stateless_validator/fixtures.rs
+++ b/crates/benchmark-runner/src/stateless_validator/fixtures.rs
@@ -287,6 +287,7 @@ mod tests {
         assert_eq!(metadata["block_used_gas"].as_u64(), Some(16));
         assert_eq!(metadata["opcode_count"]["PUSH1"].as_u64(), Some(5));
         assert_eq!(metadata["opcode_count"]["SSTORE"].as_u64(), Some(2));
+        assert_eq!(metadata["target_opcode"], "MCOPY");
 
         Ok(())
     }
@@ -395,7 +396,8 @@ mod tests {
                 ],
                 "_info": {
                     "metadata": {
-                        "opcode_count_per_block": [{"PUSH1": 5, "SSTORE": 2}]
+                        "opcode_count_per_block": [{"PUSH1": 5, "SSTORE": 2}],
+                        "target_opcode": "MCOPY"
                     }
                 }
             },

--- a/crates/benchmark-runner/src/stateless_validator/inputs.rs
+++ b/crates/benchmark-runner/src/stateless_validator/inputs.rs
@@ -18,7 +18,10 @@ struct EestBlockMetadata {
     chain_id: u64,
     block_number: Option<u64>,
     block_used_gas: Option<u64>,
-    opcode_count: BTreeMap<String, u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opcode_count: Option<BTreeMap<String, u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_opcode: Option<String>,
 }
 
 pub(crate) fn stateless_validator_input_from_fixture(
@@ -67,6 +70,7 @@ fn raw_eest_input_from_fixture(fixture: EestStatelessFixture) -> Result<Box<dyn 
         block_number: fixture.block_number,
         block_used_gas: fixture.block_used_gas,
         opcode_count: fixture.opcode_count,
+        target_opcode: fixture.target_opcode,
     };
     let fixture = GenericGuestFixture::<EestBlockMetadata> {
         name: fixture.name,

--- a/docs/benchmark-execution-inputs.md
+++ b/docs/benchmark-execution-inputs.md
@@ -58,7 +58,8 @@ The only accepted benchmark fixture format is an EEST `blockchain_tests` JSON ob
             "PUSH1": 5,
             "SSTORE": 2
           }
-        ]
+        ],
+        "target_opcode": "MCOPY"
       }
     }
   }
@@ -70,10 +71,12 @@ Rules:
 - The file is a JSON object keyed by the original EEST test name.
 - Each test case includes `network`, `config.chainid`, and `blocks`; unrelated EEST fields are ignored.
 - `config.chainid`, `blockHeader.number`, `blocknumber`, and `blockHeader.gasUsed` may be decimal strings or `0x`-prefixed hexadecimal strings.
+- Only the last block of a test case is loaded, because EEST benchmark tests place the worst case block last and use any preceding blocks for setup.
 - A block without `statelessInputBytes`, or with empty `statelessInputBytes`, is skipped.
 - A block with non-empty `statelessInputBytes` must also contain `statelessOutputBytes`.
 - Both byte fields are hexadecimal strings with an optional `0x` prefix and an even number of hexadecimal digits after that prefix.
-- `_info.metadata.opcode_count_per_block` holds one opcode-count map per block in block order, so entry N describes `blocks[N]`. A present array whose length differs from the block count is rejected, and an absent array leaves each block's opcode count empty.
+- `_info.metadata.opcode_count_per_block` holds one opcode-count map per block in block order, so entry N describes `blocks[N]` and the last entry describes the loaded block. A present array whose length differs from the block count is rejected.
+- `_info.metadata.target_opcode` names the opcode a benchmark stresses. Benchmarks that stress no single opcode omit it.
 
 Each accepted block becomes one benchmark fixture. Its safe output name is derived from the original EEST test name, block index, and source context; collisions are disambiguated. The original test name remains available for fixture-prefix selection.
 
@@ -101,7 +104,7 @@ A prefix may match either the sanitized fixture name or the original EEST test n
 
 ## Metadata, Existing Outputs, And Public Values
 
-Benchmark metadata preserves the fixture format, original test name, source path, block index, network, chain ID, block number, gas used, and the block's opcode count. See [Benchmark Execution Output](benchmark-execution-output.md#metadata-by-workload) for the serialized shape.
+Benchmark metadata preserves the fixture format, original test name, source path, block index, network, chain ID, block number, gas used, the block's opcode count, and the target opcode. See [Benchmark Execution Output](benchmark-execution-output.md#metadata-by-workload) for the serialized shape.
 
 Unless `--force-rerun` is set, fixture preparation skips cases whose metrics output already exists. Execution and proving both compare the guest's public values with the fixture's raw `statelessOutputBytes`; proof verification retains the existing stored-proof verification behavior.
 

--- a/docs/benchmark-execution-output.md
+++ b/docs/benchmark-execution-output.md
@@ -70,7 +70,8 @@ A successful execution metrics file has this shape:
     "opcode_count": {
       "PUSH1": 5,
       "SSTORE": 2
-    }
+    },
+    "target_opcode": "MCOPY"
   },
   "execution": {
     "success": {
@@ -170,11 +171,12 @@ Canonical EEST metadata has this shape:
   "opcode_count": {
     "PUSH1": 5,
     "SSTORE": 2
-  }
+  },
+  "target_opcode": "MCOPY"
 }
 ```
 
-`block_number` and `block_used_gas` are `null` when the source fixture does not provide those values. `opcode_count` is the per-block opcode tally taken from `_info.metadata.opcode_count_per_block`, and it is `{}` when the source fixture predates that field.
+`block_number` and `block_used_gas` are `null` when the source fixture does not provide those values. `opcode_count` is the opcode tally of the benchmarked block taken from `_info.metadata.opcode_count_per_block`, and `target_opcode` is the opcode the benchmark stresses taken from `_info.metadata.target_opcode`. Either key is omitted when the source fixture supplies no value.
 
 ## Proofs And Verification
 


### PR DESCRIPTION
- In `load_eest_benchmark_fixtures` load only last block, to avoid loading 256 setup blocks from each of 5 `tests/benchmark/compute/instruction/test_block_context.py::test_blockhash[...]` fixtures, that creates unuseful workload to benchmark runner.
- Add `target_opcode` to `metadata` of zkevm-metrics if present in EEST fixture, that should've added in #300 (for `evm-gasfit` integration)
