### PR TITLE
feat: remove zesu fork check since valid fixtures test byte-invalid inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,7 +631,6 @@ dependencies = [
  "serde",
  "serde_json",
  "stateless-validator-catalog",
- "stateless-validator-common",
  "stateless-validator-downloader",
  "strum 0.26.3",
  "tar",

--- a/crates/benchmark-runner/Cargo.toml
+++ b/crates/benchmark-runner/Cargo.toml
@@ -24,7 +24,6 @@ anyhow.workspace = true
 auto_impl.workspace = true
 stateless-validator-downloader.workspace = true
 stateless-validator-catalog.workspace = true
-stateless-validator-common.workspace = true
 tempfile.workspace = true
 hex.workspace = true
 

--- a/crates/benchmark-runner/src/stateless_validator/inputs.rs
+++ b/crates/benchmark-runner/src/stateless_validator/inputs.rs
@@ -2,10 +2,9 @@ use crate::{
     guest_programs::{GenericGuestFixture, GuestFixture},
     stateless_validator::{eest::EestStatelessFixture, ExecutionClient},
 };
-use anyhow::{bail, Context, Result};
+use anyhow::Result;
 use ere_dockerized::Input;
 use serde::Serialize;
-use stateless_validator_common::guest::input::{ProtocolFork, StatelessInput};
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Serialize)]
@@ -29,34 +28,10 @@ pub(crate) fn stateless_validator_input_from_fixture(
     el: ExecutionClient,
 ) -> Result<Box<dyn GuestFixture>> {
     match el {
-        ExecutionClient::Reth | ExecutionClient::Ethrex => raw_eest_input_from_fixture(fixture),
-        ExecutionClient::Zesu => zesu_input_from_fixture(fixture),
+        ExecutionClient::Reth | ExecutionClient::Ethrex | ExecutionClient::Zesu => {
+            raw_eest_input_from_fixture(fixture)
+        }
     }
-}
-
-fn zesu_input_from_fixture(fixture: EestStatelessFixture) -> Result<Box<dyn GuestFixture>> {
-    let (fork, _input) = StatelessInput::from_schema_prefixed_ssz(&fixture.stateless_input_bytes)
-        .with_context(|| {
-        format!(
-            "failed to decode canonical stateless input for Zesu fixture {}",
-            fixture.name
-        )
-    })?;
-    validate_zesu_fork(fork, &fixture.name)?;
-
-    raw_eest_input_from_fixture(fixture)
-}
-
-fn validate_zesu_fork(fork: ProtocolFork, fixture_name: &str) -> Result<()> {
-    if fork != ProtocolFork::Amsterdam {
-        bail!(
-            "Zesu {} supports only Glamsterdam inputs (ProtocolFork::Amsterdam), but fixture {} targets {fork:?}",
-            ExecutionClient::Zesu.version(),
-            fixture_name
-        );
-    }
-
-    Ok(())
 }
 
 fn raw_eest_input_from_fixture(fixture: EestStatelessFixture) -> Result<Box<dyn GuestFixture>> {


### PR DESCRIPTION
This PR removes the (paranoid) fork check we added a while ago for Zesu.

This gets in the way of running all `tests-zkevm@v0.6.2` since I recentely added fixtures with invalid raw bytes inputs, so trying to decode them to do this check fails thus the test can't even run.

I considered maybe for those failure cases still run it and keep the fork check, but feels to me it might be just better to don't have Zesu be an exception at all and handle the same as Ethrex and Reth. If Zesu doesn't support a fork, then the guest program should fail.