### PR TITLE
Warn on mismatched EEST opcode count metadata

### DIFF
--- a/crates/benchmark-runner/src/stateless_validator/eest.rs
+++ b/crates/benchmark-runner/src/stateless_validator/eest.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{BTreeMap, HashSet},
     path::Path,
 };
-use tracing::info;
+use tracing::{info, warn};
 
 const EEST_SAFE_FILE_STEM_MAX_LEN: usize = 220;
 
@@ -97,16 +97,18 @@ pub(crate) fn load_eest_benchmark_fixtures(
         let chain_id = parse_json_u64(&case.config.chainid)
             .with_context(|| format!("Failed to parse chainid for EEST test {test_name}"))?;
 
-        let opcode_count_per_block = case.info.metadata.opcode_count_per_block.as_ref();
-        if opcode_count_per_block
-            .is_some_and(|opcode_count_per_block| opcode_count_per_block.len() != case.blocks.len())
-        {
-            bail!(
-                "EEST test {test_name} has {} opcode_count_per_block entries but {} blocks",
-                opcode_count_per_block.unwrap().len(),
-                case.blocks.len()
-            );
-        }
+        let opcode_count_per_block = match case.info.metadata.opcode_count_per_block.as_ref() {
+            Some(counts) if counts.len() != case.blocks.len() => {
+                // Mismatched counts cannot be assigned to blocks reliably, but guest I/O is still usable.
+                warn!(
+                    "Ignoring opcode_count_per_block for EEST test {test_name} from {source_path}: {} entries but {} blocks",
+                    counts.len(),
+                    case.blocks.len()
+                );
+                None
+            }
+            counts => counts,
+        };
 
         // For EEST benchmark fixtures, the worst case block is the last block and the others are setup blocks,
         // so here we only load the last block as benchmark fixture.
@@ -430,34 +432,43 @@ mod tests {
     }
 
     #[test]
-    fn eest_opcode_count_per_block_length_must_match_blocks() -> Result<()> {
-        let dir = tempfile::tempdir()?;
-        let fixture_path = dir.path().join("mismatched-opcode-count.json");
-        fs::write(
-            &fixture_path,
-            r#"{
-                "tests/foo.py::test_mismatch": {
+    fn eest_opcode_counts_are_used_only_when_aligned_with_blocks() -> Result<()> {
+        let input_root = Path::new("fixtures");
+        let fixture_path = input_root.join("opcode-count.json");
+        for (count_len, expected_count) in [(0, None), (4, None), (5, Some(5)), (6, None)] {
+            let counts: Vec<_> = (1..=count_len)
+                .map(|count| serde_json::json!({"PUSH1": count}))
+                .collect();
+            let value = serde_json::json!({
+                "tests/foo.py::test_opcode_counts": {
                     "network": "Amsterdam",
                     "config": {"chainid": "0x01"},
-                    "blocks": [
-                        {"statelessInputBytes": "0x0102", "statelessOutputBytes": "0xaa"}
-                    ],
+                    "blocks": [{}, {}, {}, {}, {
+                        "statelessInputBytes": "0x0102",
+                        "statelessOutputBytes": "0xaa"
+                    }],
                     "_info": {
                         "metadata": {
-                            "opcode_count_per_block": [{"PUSH1": 1}, {"PUSH1": 2}]
+                            "opcode_count_per_block": counts,
+                            "target_opcode": "PUSH1"
                         }
                     }
                 }
-            }"#,
-        )?;
+            });
 
-        let err = load_eest_benchmark_fixtures(
-            serde_json::from_str(&fs::read_to_string(&fixture_path)?)?,
-            &fixture_path,
-            dir.path(),
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("opcode_count_per_block"));
+            let fixtures = load_eest_benchmark_fixtures(value, &fixture_path, input_root)?;
+            assert_eq!(fixtures.len(), 1);
+            let fixture = &fixtures[0];
+            assert_eq!(fixture.block_index, 4);
+            assert_eq!(fixture.stateless_input_bytes, [0x01, 0x02]);
+            assert_eq!(fixture.stateless_output_bytes, [0xaa]);
+            assert_eq!(fixture.target_opcode.as_deref(), Some("PUSH1"));
+            assert_eq!(
+                fixture.opcode_count,
+                expected_count.map(|count| BTreeMap::from([("PUSH1".to_string(), count)])),
+                "unexpected opcode counts with {count_len} entries for 5 blocks"
+            );
+        }
 
         Ok(())
     }

--- a/docs/benchmark-execution-inputs.md
+++ b/docs/benchmark-execution-inputs.md
@@ -75,7 +75,7 @@ Rules:
 - A block without `statelessInputBytes`, or with empty `statelessInputBytes`, is skipped.
 - A block with non-empty `statelessInputBytes` must also contain `statelessOutputBytes`.
 - Both byte fields are hexadecimal strings with an optional `0x` prefix and an even number of hexadecimal digits after that prefix.
-- `_info.metadata.opcode_count_per_block` holds one opcode-count map per block in block order, so entry N describes `blocks[N]` and the last entry describes the loaded block. A present array whose length differs from the block count is rejected.
+- `_info.metadata.opcode_count_per_block` holds one opcode-count map per block in block order, so entry N describes `blocks[N]` and the last entry describes the loaded block. If the array length differs from the block count, the loader logs a warning and omits opcode counts for that test case. The fixture is still loaded, and guest input/output validation still applies.
 - `_info.metadata.target_opcode` names the opcode a benchmark stresses. Benchmarks that stress no single opcode omit it.
 
 Each accepted block becomes one benchmark fixture. Its safe output name is derived from the original EEST test name, block index, and source context; collisions are disambiguated. The original test name remains available for fixture-prefix selection.

--- a/docs/benchmark-execution-output.md
+++ b/docs/benchmark-execution-output.md
@@ -235,7 +235,7 @@ Canonical EEST metadata has this shape:
 }
 ```
 
-`block_number` and `block_used_gas` are `null` when the source fixture does not provide those values. `opcode_count` is the opcode tally of the benchmarked block taken from `_info.metadata.opcode_count_per_block`, and `target_opcode` is the opcode the benchmark stresses taken from `_info.metadata.target_opcode`. Either key is omitted when the source fixture supplies no value.
+`block_number` and `block_used_gas` are `null` when the source fixture does not provide those values. `opcode_count` is the opcode tally of the benchmarked block taken from `_info.metadata.opcode_count_per_block`, and `target_opcode` is the opcode the benchmark stresses taken from `_info.metadata.target_opcode`. Either key is omitted when the source fixture supplies no value. `opcode_count` is also omitted when the per-block array length differs from the block count; the loader logs a warning and continues loading the fixture.
 
 ## Proofs And Verification
 


### PR DESCRIPTION
The EEST loader previously failed when `opcode_count_per_block` had a different number of entries than `blocks`, even when the guest input and output were valid. This change logs a warning, omits opcode counts for the affected test case and continues loading the fixture.

Updates the input and output documentation and adds test coverage for empty, shorter, matching and longer opcode count arrays.

I discovered this while running a [new Hive UI dashboard](https://github.com/eth-act/eest-execution-witness-dashboard/actions/runs/34525355957/job/103032838399#step:10:40507). Quite honestly, I'm not sure this makes sense from the EEST perspective so for now not making this situation a blocker, but I'll dig into EEST why this happen and if makes sense.